### PR TITLE
Fix auth callback flow and family tab layout

### DIFF
--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,0 +1,34 @@
+import { createServerClient } from '@supabase/ssr'
+import { cookies } from 'next/headers'
+import { NextResponse, type NextRequest } from 'next/server'
+
+export async function GET(request: NextRequest) {
+  const { searchParams, origin } = new URL(request.url)
+  const code = searchParams.get('code')
+  const next = searchParams.get('next') ?? '/'
+
+  if (code) {
+    const cookieStore = await cookies()
+    const supabase = createServerClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL ?? 'https://placeholder.supabase.co',
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? 'placeholder-anon-key',
+      {
+        cookies: {
+          getAll() { return cookieStore.getAll() },
+          setAll(cookiesToSet) {
+            cookiesToSet.forEach(({ name, value, options }) =>
+              cookieStore.set(name, value, options)
+            )
+          },
+        },
+      }
+    )
+
+    const { error } = await supabase.auth.exchangeCodeForSession(code)
+    if (!error) {
+      return NextResponse.redirect(`${origin}${next}`)
+    }
+  }
+
+  return NextResponse.redirect(`${origin}/login`)
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -25,7 +25,7 @@ export default function LoginPage() {
       const { error } = await supabase.auth.signUp({
         email,
         password,
-        options: { emailRedirectTo: 'https://chorequest.dresponda.com' },
+        options: { emailRedirectTo: 'https://chorequest.dresponda.com/auth/callback?next=/parent' },
       })
       if (error) {
         toast.error(error.message)

--- a/src/app/parent/page.tsx
+++ b/src/app/parent/page.tsx
@@ -446,7 +446,11 @@ export default function ParentDashboard() {
                     onChange={setFamilyName}
                     className="flex-1"
                   />
-                  <ActionButton onClick={handleSaveFamilyName} label={savingFamily ? '...' : 'Save'} />
+                  <ActionButton
+                    onClick={handleSaveFamilyName}
+                    label={savingFamily ? '...' : 'Save'}
+                    className="flex-shrink-0 px-5"
+                  />
                 </div>
               </Section>
 
@@ -670,17 +674,18 @@ function FormInput({
 }
 
 function ActionButton({
-  onClick, label, disabled = false
+  onClick, label, disabled = false, className = 'w-full'
 }: {
   onClick: () => void
   label: string
   disabled?: boolean
+  className?: string
 }) {
   return (
     <motion.button
       onClick={onClick}
       disabled={disabled}
-      className="w-full py-2.5 rounded-xl text-sm font-bold transition-all disabled:opacity-40"
+      className={`${className} py-2.5 rounded-xl text-sm font-bold transition-all disabled:opacity-40`}
       style={{
         background: 'rgba(251, 191, 36, 0.15)',
         border: '1px solid rgba(251, 191, 36, 0.35)',


### PR DESCRIPTION
## Summary

- **Auth callback**: Added `/auth/callback` route that exchanges the Supabase confirmation code for a session. Without this, clicking the confirmation email link redirected users to the site with no session established — the middleware saw no user and bounced them to `/login`. Now confirmation links point to `/auth/callback?next=/parent` so new users land on setup after confirming.
- **Supabase redirect allowlist** updated to include the callback URL.
- **Realm Name row**: `ActionButton` was hardcoded `w-full`, making the Save button dominate the flex row and squishing the input. Added `className` prop (default `w-full` preserved everywhere else), Save button now uses `flex-shrink-0 px-5`.

## Test plan

- [ ] Sign up with a new email → confirm → lands on `/parent` (not `/login`)
- [ ] Existing login flow still works
- [ ] Family tab: Realm Name input and Save button sit side-by-side at sensible proportions
- [ ] All 3 CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)