### PR TITLE
feat: Quest tiers, QR login, family invite links (#7, #17)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "next-themes": "^0.4.6",
         "react": "19.2.4",
         "react-dom": "19.2.4",
+        "react-qr-code": "^2.0.21",
         "shadcn": "^4.6.0",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
@@ -9084,7 +9085,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -10232,7 +10232,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -10268,6 +10267,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/qr.js": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/qr.js/-/qr.js-0.0.0.tgz",
+      "integrity": "sha512-c4iYnWb+k2E+vYpRimHqSu575b1/wKl4XFeJGpFmrJQz5I88v9aY2czh7s0w36srfCM1sXgC/xpoJz5dJfq+OQ==",
+      "license": "MIT"
     },
     "node_modules/qs": {
       "version": "6.15.1",
@@ -10353,8 +10358,20 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-qr-code": {
+      "version": "2.0.21",
+      "resolved": "https://registry.npmjs.org/react-qr-code/-/react-qr-code-2.0.21.tgz",
+      "integrity": "sha512-xaywjo0eaF4S3LOz6ns5eoPbM2E+q9HYl4VATYpxK4bBniOhQ9noY2RJ9G4SnZFhUwzx63FUT6KdHzfKgUwyuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.8.1",
+        "qr.js": "0.0.0"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
     },
     "node_modules/recast": {
       "version": "0.23.11",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "next-themes": "^0.4.6",
     "react": "19.2.4",
     "react-dom": "19.2.4",
+    "react-qr-code": "^2.0.21",
     "shadcn": "^4.6.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -5,7 +5,9 @@ import { NextResponse, type NextRequest } from 'next/server'
 export async function GET(request: NextRequest) {
   const { searchParams, origin } = new URL(request.url)
   const code = searchParams.get('code')
-  const next = searchParams.get('next') ?? '/'
+  const rawNext = searchParams.get('next') ?? '/'
+  // Prevent open redirect: only allow same-origin relative paths
+  const next = rawNext.startsWith('/') && !rawNext.startsWith('//') ? rawNext : '/'
 
   if (code) {
     const cookieStore = await cookies()

--- a/src/app/join/[token]/page.tsx
+++ b/src/app/join/[token]/page.tsx
@@ -1,0 +1,128 @@
+'use client'
+
+export const dynamic = 'force-dynamic'
+
+import { use, useState, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { motion } from 'framer-motion'
+import Link from 'next/link'
+import { createClient } from '@/lib/supabase/client'
+import { StarField } from '@/components/star-field'
+import { KID_COLORS } from '@/lib/constants'
+import type { KidColor } from '@/lib/types'
+
+interface FamilyData {
+  id: string
+  name: string
+  kids: { id: string; name: string; avatar: string; color: KidColor }[]
+}
+
+export default function JoinPage({ params }: { params: Promise<{ token: string }> }) {
+  const { token } = use(params)
+  const router = useRouter()
+  const [family, setFamily] = useState<FamilyData | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [notFound, setNotFound] = useState(false)
+  const [supabase] = useState(createClient)
+
+  useEffect(() => {
+    supabase.rpc('get_family_by_invite_token', { token }).then(({ data }) => {
+      if (data) {
+        setFamily(data as FamilyData)
+      } else {
+        setNotFound(true)
+      }
+      setLoading(false)
+    })
+  }, [token, supabase])
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-quest-void flex items-center justify-center">
+        <StarField />
+        <motion.p
+          className="relative z-10 font-heading text-2xl text-white/40"
+          animate={{ opacity: [0.3, 0.8, 0.3] }}
+          transition={{ duration: 2, repeat: Infinity }}
+        >
+          ✦ Loading ✦
+        </motion.p>
+      </div>
+    )
+  }
+
+  if (notFound || !family) {
+    return (
+      <div className="min-h-screen bg-quest-void flex items-center justify-center px-4">
+        <StarField />
+        <div className="relative z-10 text-center">
+          <p className="text-5xl mb-4">🔮</p>
+          <h1 className="font-heading text-2xl font-bold text-white mb-2">Realm Not Found</h1>
+          <p className="text-white/40 text-sm mb-6">This invite link may have expired or been reset.</p>
+          <Link href="/" className="text-white/40 hover:text-white/70 transition-all text-sm">
+            ← Back to Realm
+          </Link>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-quest-void flex flex-col items-center justify-center px-4">
+      <StarField />
+      <motion.div
+        className="relative z-10 w-full max-w-xs"
+        initial={{ opacity: 0, y: 16 }}
+        animate={{ opacity: 1, y: 0 }}
+      >
+        <div className="text-center mb-8">
+          <motion.p
+            className="text-5xl mb-3"
+            animate={{ y: [0, -6, 0] }}
+            transition={{ duration: 3, repeat: Infinity, ease: 'easeInOut' }}
+          >
+            🏰
+          </motion.p>
+          <h1 className="font-heading text-3xl font-bold text-white">{family.name}</h1>
+          <p className="text-white/40 text-sm mt-1">Who are you?</p>
+        </div>
+
+        <div className="flex flex-col gap-3">
+          {family.kids.length === 0 ? (
+            <p className="text-center text-white/30 text-sm py-8">No adventurers in this realm yet.</p>
+          ) : (
+            family.kids.map((kid, i) => {
+              const colors = KID_COLORS[kid.color]
+              return (
+                <motion.button
+                  key={kid.id}
+                  onClick={() => router.push(`/kid/${kid.id}`)}
+                  className="flex items-center gap-4 p-4 rounded-2xl w-full text-left transition-all"
+                  style={{ background: colors.bg, border: `1px solid ${colors.border}` }}
+                  initial={{ opacity: 0, y: 12 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ delay: i * 0.07 }}
+                  whileHover={{ scale: 1.02 }}
+                  whileTap={{ scale: 0.98 }}
+                >
+                  <span className="text-3xl">{kid.avatar}</span>
+                  <span className="font-heading font-bold text-lg" style={{ color: colors.primary }}>
+                    {kid.name}
+                  </span>
+                  <span className="ml-auto text-white/30 text-sm">→</span>
+                </motion.button>
+              )
+            })
+          )}
+        </div>
+
+        <Link
+          href="/"
+          className="mt-8 block text-center text-white/25 text-sm hover:text-white/50 transition-all"
+        >
+          ← Back to Realm
+        </Link>
+      </motion.div>
+    </div>
+  )
+}

--- a/src/app/parent/page.tsx
+++ b/src/app/parent/page.tsx
@@ -10,7 +10,9 @@ import { createClient } from '@/lib/supabase/client'
 import { StarField } from '@/components/star-field'
 import { QuestCard } from '@/components/quest-card'
 import type { Kid, Quest, Completion, Reward, Family } from '@/lib/types'
-import { KID_COLORS, KID_AVATARS, QUEST_ICONS, DEFAULT_QUESTS } from '@/lib/constants'
+import { KID_COLORS, KID_AVATARS, QUEST_ICONS, DEFAULT_QUESTS, TIER_CONFIG } from '@/lib/constants'
+import type { QuestTier } from '@/lib/types'
+import QRCode from 'react-qr-code'
 import { toast } from 'sonner'
 
 const PARENT_PIN_SESSION_KEY = 'cq_parent_unlocked'
@@ -37,6 +39,8 @@ export default function ParentDashboard() {
   const [newQuestCoins, setNewQuestCoins] = useState(10)
   const [newQuestFor, setNewQuestFor] = useState<string>('all')
   const [newQuestFrequency, setNewQuestFrequency] = useState<'daily' | 'once'>('daily')
+  const [newQuestTier, setNewQuestTier] = useState<QuestTier>('normal')
+  const [qrKidId, setQrKidId] = useState<string | null>(null)
   const [newRewardTitle, setNewRewardTitle] = useState('')
   const [newRewardDesc, setNewRewardDesc] = useState('')
   const [newRewardIcon, setNewRewardIcon] = useState('🎁')
@@ -50,6 +54,7 @@ export default function ParentDashboard() {
   const [savingParentPin, setSavingParentPin] = useState(false)
   const [editingCoinsKidId, setEditingCoinsKidId] = useState<string | null>(null)
   const [editCoinsValue, setEditCoinsValue] = useState('')
+  const [revealPinKidId, setRevealPinKidId] = useState<string | null>(null)
 
   const [supabase] = useState(createClient)
   const router = useRouter()
@@ -175,6 +180,7 @@ export default function ParentDashboard() {
       coins: newQuestCoins,
       assigned_to: newQuestFor === 'all' ? null : newQuestFor,
       frequency: newQuestFrequency,
+      tier: newQuestTier,
       active: true,
     })
     if (!error) {
@@ -182,6 +188,7 @@ export default function ParentDashboard() {
       setNewQuestTitle('')
       setNewQuestDesc('')
       setNewQuestFrequency('daily')
+      setNewQuestTier('normal')
       await fetchData()
     } else {
       toast.error('Failed to add quest')
@@ -327,6 +334,13 @@ export default function ParentDashboard() {
     await supabase.from('families').update({ parent_pin: null }).eq('id', family.id)
     sessionStorage.removeItem(PARENT_PIN_SESSION_KEY)
     toast.success('Parent lock removed')
+    await fetchData()
+  }
+
+  const handleRegenerateToken = async () => {
+    if (!family) return
+    await supabase.from('families').update({ invite_token: crypto.randomUUID() }).eq('id', family.id)
+    toast.success('Invite link regenerated')
     await fetchData()
   }
 
@@ -629,6 +643,30 @@ export default function ParentDashboard() {
                       ))}
                     </div>
                   </div>
+                  <div>
+                    <label className="text-xs text-white/40 mb-1.5 block">Tier</label>
+                    <div className="grid grid-cols-4 gap-1.5">
+                      {(['normal', 'heroic', 'legendary', 'epic'] as const).map((t) => {
+                        const tc = TIER_CONFIG[t]
+                        const selected = newQuestTier === t
+                        return (
+                          <button
+                            key={t}
+                            onClick={() => setNewQuestTier(t)}
+                            className="py-2 rounded-xl text-xs font-semibold transition-all"
+                            style={{
+                              background: selected ? tc.bg : 'rgba(255,255,255,0.04)',
+                              border: `1px solid ${selected ? tc.border : 'rgba(255,255,255,0.08)'}`,
+                              color: selected ? tc.color : 'rgba(255,255,255,0.4)',
+                              boxShadow: selected && tc.glow ? tc.glow : 'none',
+                            }}
+                          >
+                            {tc.label}
+                          </button>
+                        )
+                      })}
+                    </div>
+                  </div>
                   <ActionButton onClick={handleAddQuest} label="+ Add Quest" />
                 </div>
               </Section>
@@ -875,13 +913,66 @@ export default function ParentDashboard() {
                               </button>
                             )}
                           </div>
-                          <span className="text-xs text-white/30 font-mono">PIN: {kid.pin}</span>
+                          <div className="flex items-center gap-2 flex-shrink-0">
+                            <button
+                              onClick={() => setRevealPinKidId(revealPinKidId === kid.id ? null : kid.id)}
+                              className="text-xs text-white/30 font-mono hover:text-white/60 transition-all"
+                              title={revealPinKidId === kid.id ? 'Hide PIN' : 'Show PIN'}
+                            >
+                              {revealPinKidId === kid.id ? `PIN: ${kid.pin}` : 'PIN: ····'}
+                            </button>
+                            <button
+                              onClick={() => setQrKidId(kid.id)}
+                              className="text-lg hover:scale-110 transition-all"
+                              title="Show QR code"
+                            >
+                              📱
+                            </button>
+                          </div>
                         </div>
                       )
                     })}
                   </div>
                 )}
               </Section>
+
+              {/* Invite link */}
+              {family && (
+                <Section title="Family Invite Link">
+                  <div className="flex flex-col gap-3">
+                    <p className="text-white/50 text-sm">
+                      Share this link so anyone in your family can pick their adventurer and jump straight to their PIN screen.
+                    </p>
+                    <div
+                      className="px-3 py-2.5 rounded-xl text-xs text-white/60 font-mono break-all select-all"
+                      style={{ background: 'rgba(255,255,255,0.05)', border: '1px solid rgba(255,255,255,0.1)' }}
+                    >
+                      {typeof window !== 'undefined' ? `${window.location.origin}/join/${family.invite_token}` : `/join/${family.invite_token}`}
+                    </div>
+                    <div className="flex gap-2">
+                      <button
+                        onClick={() => {
+                          const url = `${window.location.origin}/join/${family.invite_token}`
+                          navigator.clipboard.writeText(url)
+                          toast.success('Invite link copied!')
+                        }}
+                        className="flex-1 py-2 rounded-xl text-sm font-semibold transition-all"
+                        style={{ background: 'rgba(56,189,248,0.1)', border: '1px solid rgba(56,189,248,0.25)', color: '#38bdf8' }}
+                      >
+                        Copy Link
+                      </button>
+                      <button
+                        onClick={handleRegenerateToken}
+                        className="px-4 py-2 rounded-xl text-sm font-semibold transition-all"
+                        style={{ background: 'rgba(255,255,255,0.05)', border: '1px solid rgba(255,255,255,0.1)', color: 'rgba(255,255,255,0.4)' }}
+                        title="Regenerate to invalidate old link"
+                      >
+                        ↻
+                      </button>
+                    </div>
+                  </div>
+                </Section>
+              )}
             </motion.div>
           )}
 
@@ -957,6 +1048,65 @@ export default function ParentDashboard() {
         </AnimatePresence>
       </main>
       </div>
+
+      {/* QR code modal */}
+      <AnimatePresence>
+        {qrKidId && (() => {
+          const kid = kids.find((k) => k.id === qrKidId)
+          if (!kid) return null
+          const kidUrl = typeof window !== 'undefined'
+            ? `${window.location.origin}/kid/${kid.id}`
+            : `/kid/${kid.id}`
+          return (
+            <motion.div
+              className="fixed inset-0 z-50 flex items-center justify-center p-4"
+              style={{ background: 'rgba(0,0,0,0.7)', backdropFilter: 'blur(8px)' }}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              onClick={() => setQrKidId(null)}
+            >
+              <motion.div
+                className="relative w-full max-w-xs rounded-3xl p-6 text-center"
+                style={{ background: '#0e0b24', border: '1px solid rgba(255,255,255,0.12)' }}
+                initial={{ scale: 0.9, opacity: 0 }}
+                animate={{ scale: 1, opacity: 1 }}
+                exit={{ scale: 0.9, opacity: 0 }}
+                onClick={(e) => e.stopPropagation()}
+              >
+                <button
+                  onClick={() => setQrKidId(null)}
+                  className="absolute top-4 right-4 text-white/30 hover:text-white/70 transition-all text-lg"
+                >
+                  ✕
+                </button>
+                <span className="text-4xl block mb-2">{kid.avatar}</span>
+                <h3 className="font-heading font-bold text-white text-xl mb-4">{kid.name}</h3>
+                <div className="bg-white p-4 rounded-2xl inline-block mb-4">
+                  <QRCode value={kidUrl} size={160} />
+                </div>
+                <p className="text-white/40 text-xs mb-4">Scan to go straight to {kid.name}&apos;s PIN screen</p>
+                <div className="flex gap-2">
+                  <button
+                    onClick={() => { navigator.clipboard.writeText(kidUrl); toast.success('Link copied!') }}
+                    className="flex-1 py-2 rounded-xl text-sm font-semibold transition-all"
+                    style={{ background: 'rgba(56,189,248,0.1)', border: '1px solid rgba(56,189,248,0.25)', color: '#38bdf8' }}
+                  >
+                    Copy Link
+                  </button>
+                  <button
+                    onClick={() => window.print()}
+                    className="px-4 py-2 rounded-xl text-sm font-semibold transition-all"
+                    style={{ background: 'rgba(255,255,255,0.05)', border: '1px solid rgba(255,255,255,0.1)', color: 'rgba(255,255,255,0.5)' }}
+                  >
+                    Print
+                  </button>
+                </div>
+              </motion.div>
+            </motion.div>
+          )
+        })()}
+      </AnimatePresence>
     </div>
   )
 }
@@ -1041,6 +1191,7 @@ function QuestRow({
   onDelete: (id: string) => void
 }) {
   const assignedKid = kids.find((k) => k.id === quest.assigned_to)
+  const tier = TIER_CONFIG[quest.tier ?? 'normal']
   return (
     <div
       className="flex items-center gap-3 p-3 rounded-xl mb-2"
@@ -1052,6 +1203,14 @@ function QuestRow({
           <p className={`text-sm font-semibold ${quest.active ? 'text-white/90' : 'text-white/40 line-through'}`}>
             {quest.title}
           </p>
+          {(quest.tier ?? 'normal') !== 'normal' && (
+            <span
+              className="text-xs px-1.5 py-0.5 rounded-md flex-shrink-0"
+              style={{ background: tier.bg, color: tier.color, border: `1px solid ${tier.border}` }}
+            >
+              {tier.label}
+            </span>
+          )}
           {quest.frequency === 'once' && (
             <span
               className="text-xs px-1.5 py-0.5 rounded-md flex-shrink-0"

--- a/src/components/quest-card.tsx
+++ b/src/components/quest-card.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import type { Quest, Completion, KidColor } from '@/lib/types'
-import { KID_COLORS } from '@/lib/constants'
+import { KID_COLORS, TIER_CONFIG } from '@/lib/constants'
 import { CoinBurst } from './coin-burst'
 
 interface QuestCardProps {
@@ -35,13 +35,15 @@ export function QuestCard({
   const isApproved = status === 'approved'
   const isRejected = status === 'rejected'
 
+  const tier = TIER_CONFIG[quest.tier ?? 'normal']
+
   const cardBg = isApproved
     ? 'rgba(74, 222, 128, 0.06)'
     : isPending
     ? 'rgba(251, 191, 36, 0.06)'
     : isRejected
     ? 'rgba(239, 68, 68, 0.05)'
-    : colors.bg
+    : tier.bg
 
   const cardBorder = isApproved
     ? 'rgba(74, 222, 128, 0.25)'
@@ -49,13 +51,13 @@ export function QuestCard({
     ? 'rgba(251, 191, 36, 0.35)'
     : isRejected
     ? 'rgba(239, 68, 68, 0.2)'
-    : colors.border
+    : tier.border
 
   const cardShadow = isPending
     ? '0 0 20px rgba(251, 191, 36, 0.12)'
     : isApproved
     ? '0 0 16px rgba(74, 222, 128, 0.1)'
-    : 'none'
+    : tier.glow ?? 'none'
 
   const handleComplete = async () => {
     if (!onComplete || loading || !isTodo) return
@@ -87,13 +89,23 @@ export function QuestCard({
           <span className="text-2xl leading-none mt-0.5 flex-shrink-0">{quest.icon}</span>
 
           <div className="flex-1 min-w-0">
-            <p
-              className={`font-semibold text-sm leading-snug ${
-                isApproved ? 'line-through opacity-40' : 'text-white/90'
-              }`}
-            >
-              {quest.title}
-            </p>
+            <div className="flex items-center gap-1.5 flex-wrap">
+              <p
+                className={`font-semibold text-sm leading-snug ${
+                  isApproved ? 'line-through opacity-40' : 'text-white/90'
+                }`}
+              >
+                {quest.title}
+              </p>
+              {(quest.tier ?? 'normal') !== 'normal' && (
+                <span
+                  className="text-xs px-1.5 py-0.5 rounded-md font-semibold flex-shrink-0"
+                  style={{ background: tier.bg, color: tier.color, border: `1px solid ${tier.border}` }}
+                >
+                  {tier.label}
+                </span>
+              )}
+            </div>
             {quest.description && (
               <p className="text-white/40 text-xs mt-0.5 truncate">{quest.description}</p>
             )}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,4 +1,46 @@
-import type { KidColor } from './types'
+import type { KidColor, QuestTier } from './types'
+
+export const TIER_CONFIG: Record<QuestTier, {
+  label: string
+  icon: string
+  color: string
+  bg: string
+  border: string
+  glow: string | null
+}> = {
+  normal: {
+    label: 'Normal',
+    icon: '⚔️',
+    color: 'rgba(255,255,255,0.55)',
+    bg: 'rgba(255,255,255,0.05)',
+    border: 'rgba(255,255,255,0.12)',
+    glow: null,
+  },
+  heroic: {
+    label: 'Heroic',
+    icon: '🔵',
+    color: '#38bdf8',
+    bg: 'rgba(56,189,248,0.08)',
+    border: 'rgba(56,189,248,0.25)',
+    glow: null,
+  },
+  legendary: {
+    label: 'Legendary',
+    icon: '🌟',
+    color: '#fbbf24',
+    bg: 'rgba(251,191,36,0.08)',
+    border: 'rgba(251,191,36,0.28)',
+    glow: null,
+  },
+  epic: {
+    label: 'Epic',
+    icon: '💜',
+    color: '#a78bfa',
+    bg: 'rgba(167,139,250,0.1)',
+    border: 'rgba(167,139,250,0.3)',
+    glow: '0 0 20px rgba(167,139,250,0.2)',
+  },
+}
 
 export const QUEST_ICONS = [
   '⚔️', '🛡️', '🧹', '🍳', '📚', '🌿', '🐾',

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,11 +1,13 @@
 export type KidColor = 'azure' | 'mystic'
 export type QuestFrequency = 'daily' | 'weekly' | 'once'
+export type QuestTier = 'normal' | 'heroic' | 'legendary' | 'epic'
 export type CompletionStatus = 'pending' | 'approved' | 'rejected'
 
 export interface Family {
   id: string
   name: string
   parent_pin: string | null
+  invite_token: string
   created_at: string
 }
 
@@ -37,6 +39,7 @@ export interface Quest {
   coins: number
   assigned_to: string | null
   frequency: QuestFrequency
+  tier: QuestTier
   active: boolean
   created_at: string
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -29,7 +29,10 @@ export async function proxy(request: NextRequest) {
   const { data: { user } } = await supabase.auth.getUser()
 
   const path = request.nextUrl.pathname
-  const isPublic = path === '/login' || path.startsWith('/api/')
+  const isPublic =
+    path === '/login' ||
+    path.startsWith('/api/') ||
+    path.startsWith('/join/')
 
   if (!user && !isPublic) {
     const url = request.nextUrl.clone()

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -7,6 +7,7 @@ create table families (
   id uuid primary key default gen_random_uuid(),
   name text not null default 'My Family',
   parent_pin text check (parent_pin ~ '^[0-9]{4}$'), -- optional 4-digit lock PIN
+  invite_token uuid not null default gen_random_uuid() unique,
   created_at timestamptz default now()
 );
 
@@ -39,6 +40,7 @@ create table quests (
   coins integer not null default 10,
   assigned_to uuid references kids(id) on delete set null,
   frequency text not null default 'daily',
+  tier text not null default 'normal' check (tier in ('normal', 'heroic', 'legendary', 'epic')),
   active boolean not null default true,
   created_at timestamptz default now()
 );
@@ -141,6 +143,39 @@ create index completions_status_idx on completions(status);
 
 alter publication supabase_realtime add table completions;
 alter publication supabase_realtime add table kids;
+
+-- ─── Public invite token lookup (no auth required) ───────────────────────────
+
+create or replace function get_family_by_invite_token(token uuid)
+returns json
+language plpgsql
+security definer
+stable
+as $$
+declare
+  result json;
+begin
+  select json_build_object(
+    'id', f.id,
+    'name', f.name,
+    'kids', coalesce((
+      select json_agg(json_build_object(
+        'id', k.id,
+        'name', k.name,
+        'avatar', k.avatar,
+        'color', k.color
+      ) order by k.created_at)
+      from kids k where k.family_id = f.id
+    ), '[]'::json)
+  ) into result
+  from families f
+  where f.invite_token = token;
+
+  return result;
+end;
+$$;
+
+grant execute on function get_family_by_invite_token(uuid) to anon;
 
 -- ─── Auto-create profile + family on signup ───────────────────────────────────
 


### PR DESCRIPTION
## Summary
Implements both 🟠 Next priority features plus security fixes from audit.

### #7 Quest tiers
- DB migration: `tier` column on `quests` (normal / heroic / legendary / epic, CHECK constraint)
- `TIER_CONFIG` constant with per-tier colors, borders, glow
- Tier badge on `QuestCard` — hidden for Normal, colored for Heroic/Legendary, purple glow for Epic
- 4-button tier picker in parent quest creation form
- Tier badge in parent quest list (`QuestRow`)

### #17 QR codes + family invite links (Options A + B)
- 📱 QR button on each kid row → modal with QR code, copy link, and print
- Family invite link section with one-click copy and regenerate button
- DB migration: `invite_token uuid` on `families` + `get_family_by_invite_token()` RPC (anon-callable, returns no PINs)
- New `/join/[token]` public page — shows the family's kid picker, redirects to PIN screen
- `/join/*` marked public in `proxy.ts` (no auth redirect)

### Security fixes (from audit run before commit)
- **Reverted** `/kid/*` from public routes — kid pages rely on the parent's auth session for RLS, making them public broke data loading
- **Fixed open redirect** in `/auth/callback`: `next` param now validated to start with `/` and not `//`
- **Masked kid PINs** in parent Family tab — click-to-reveal instead of always plaintext

## Security issues filed for follow-up
- #22 / #23: Server-side PIN verification + brute-force protection, API route data exposures

## Test plan
- [ ] Create a quest with each tier — verify correct badge color/glow on parent and kid views
- [ ] Open Family tab → click 📱 on a kid → QR modal appears with correct URL
- [ ] Scan QR (or open URL) → lands on kid PIN screen as expected
- [ ] Copy invite link → open in browser → kid picker shows all kids → click kid → PIN screen
- [ ] Regenerate invite link → old link returns "Realm Not Found"
- [ ] Kid PINs in Family tab show `····` by default; click reveals the PIN
- [ ] Verify auth callback with a malformed `next` param (e.g. `?next=//evil.com`) redirects to `/` not external URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)