### PR TITLE
fix: redemptions, PIN security, once-quest cleanup, edge case tests

### DIFF
--- a/src/app/api/kid/[id]/verify-pin/route.ts
+++ b/src/app/api/kid/[id]/verify-pin/route.ts
@@ -1,11 +1,12 @@
 import { createServiceClient } from '@/lib/supabase/service'
+import { isValidPin } from '@/lib/utils'
 import { NextRequest } from 'next/server'
 
 export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
 
   const body = await req.json().catch(() => null)
-  if (!body?.pin || typeof body.pin !== 'string' || !/^\d{4}$/.test(body.pin)) {
+  if (!isValidPin(body?.pin)) {
     return Response.json({ error: 'Invalid request' }, { status: 400 })
   }
 

--- a/src/app/api/parent/verify-pin/route.ts
+++ b/src/app/api/parent/verify-pin/route.ts
@@ -2,6 +2,7 @@ import { createServerClient } from '@supabase/ssr'
 import { cookies } from 'next/headers'
 import { NextRequest } from 'next/server'
 import { createServiceClient } from '@/lib/supabase/service'
+import { isValidPin } from '@/lib/utils'
 
 export async function POST(req: NextRequest) {
   // Require an active Supabase session (parent must be logged in)
@@ -27,7 +28,7 @@ export async function POST(req: NextRequest) {
   }
 
   const body = await req.json().catch(() => null)
-  if (!body?.pin || typeof body.pin !== 'string' || !/^\d{4}$/.test(body.pin)) {
+  if (!isValidPin(body?.pin)) {
     return Response.json({ error: 'Invalid request' }, { status: 400 })
   }
 

--- a/src/app/kid/[id]/page.tsx
+++ b/src/app/kid/[id]/page.tsx
@@ -11,7 +11,7 @@ import { QuestCard } from '@/components/quest-card'
 import { CoinCounter } from '@/components/coin-counter'
 import { StreakBadge } from '@/components/streak-badge'
 import type { Kid, Quest, Completion, Reward } from '@/lib/types'
-import { KID_COLORS } from '@/lib/constants'
+import { KID_COLORS, getLockDurationMs } from '@/lib/constants'
 import { toast } from 'sonner'
 
 const PIN_SESSION_KEY = 'cq_kid_pin_'
@@ -106,8 +106,7 @@ export default function KidPage({ params }: { params: Promise<{ id: string }> })
         const attempts = pinAttempts + 1
         setPinAttempts(attempts)
         if (attempts >= 5) {
-          const lockMs = attempts >= 8 ? 5 * 60_000 : 30_000
-          setLockedUntil(now + lockMs)
+          setLockedUntil(now + getLockDurationMs(attempts))
         }
         setPinError(true)
         setTimeout(() => {

--- a/src/app/parent/page.tsx
+++ b/src/app/parent/page.tsx
@@ -9,8 +9,8 @@ import { useRouter } from 'next/navigation'
 import { createClient } from '@/lib/supabase/client'
 import { StarField } from '@/components/star-field'
 import { QuestCard } from '@/components/quest-card'
-import type { Kid, Quest, Completion, Reward, Family } from '@/lib/types'
-import { KID_COLORS, KID_AVATARS, QUEST_ICONS, DEFAULT_QUESTS, TIER_CONFIG } from '@/lib/constants'
+import type { Kid, Quest, Completion, Reward, Redemption, Family } from '@/lib/types'
+import { KID_COLORS, KID_AVATARS, QUEST_ICONS, DEFAULT_QUESTS, TIER_CONFIG, getLockDurationMs } from '@/lib/constants'
 import type { QuestTier } from '@/lib/types'
 import QRCode from 'react-qr-code'
 import { toast } from 'sonner'
@@ -26,6 +26,7 @@ export default function ParentDashboard() {
   const [quests, setQuests] = useState<Quest[]>([])
   const [completions, setCompletions] = useState<Completion[]>([])
   const [rewards, setRewards] = useState<Reward[]>([])
+  const [redemptions, setRedemptions] = useState<Redemption[]>([])
   const [loading, setLoading] = useState(true)
 
   // Forms
@@ -69,23 +70,27 @@ export default function ParentDashboard() {
 
     const today = new Date().toISOString().split('T')[0]
 
-    const [familyRes, kidsRes, questsRes, completionsRes, rewardsRes] = await Promise.all([
-      supabase.from('families').select('id, name, invite_token, created_at, parent_pin').eq('id', profile.family_id).single(),
-      supabase.from('kids').select('*').eq('family_id', profile.family_id).order('created_at'),
+    const kidCols = 'id, name, avatar, color, coins, streak, last_completed_date, family_id, created_at'
+
+    const [familyRes, kidsRes, questsRes, completionsRes, rewardsRes, redemptionsRes] = await Promise.all([
+      supabase.from('families').select('id, name, invite_token, api_key, created_at, parent_pin').eq('id', profile.family_id).single(),
+      supabase.from('kids').select(kidCols).eq('family_id', profile.family_id).order('created_at'),
       supabase.from('quests').select('*').eq('family_id', profile.family_id).order('created_at'),
-      supabase.from('completions').select('*, quest:quests(*), kid:kids(*)').eq('date', today).order('completed_at', { ascending: false }),
+      supabase.from('completions').select(`*, quest:quests(*), kid:kids(${kidCols})`).eq('date', today).order('completed_at', { ascending: false }),
       supabase.from('rewards').select('*').eq('family_id', profile.family_id).order('created_at'),
+      supabase.from('redemptions').select(`*, reward:rewards(*), kid:kids(${kidCols})`).eq('status', 'pending').order('redeemed_at', { ascending: false }),
     ])
 
     if (familyRes.data) {
       const { parent_pin, ...rest } = familyRes.data
-      setFamily({ ...rest, has_parent_pin: parent_pin !== null })
+      setFamily({ ...rest, has_parent_pin: parent_pin !== null, api_key: rest.api_key ?? undefined })
       setFamilyName(familyRes.data.name)
     }
     if (kidsRes.data) setKids(kidsRes.data)
     if (questsRes.data) setQuests(questsRes.data)
     if (completionsRes.data) setCompletions(completionsRes.data)
     if (rewardsRes.data) setRewards(rewardsRes.data)
+    if (redemptionsRes.data) setRedemptions(redemptionsRes.data)
     setLoading(false)
   }, [supabase])
 
@@ -116,6 +121,7 @@ export default function ParentDashboard() {
     const channel = supabase
       .channel('parent-realtime')
       .on('postgres_changes', { event: '*', schema: 'public', table: 'completions' }, fetchData)
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'redemptions' }, fetchData)
       .subscribe()
     return () => { supabase.removeChannel(channel) }
   }, [fetchData, supabase])
@@ -147,6 +153,10 @@ export default function ParentDashboard() {
         .update({ streak: newStreak, last_completed_date: today })
         .eq('id', completion.kid_id)
 
+      if (completion.quest?.frequency === 'once') {
+        await supabase.from('quests').update({ active: false }).eq('id', completion.quest.id)
+      }
+
       toast.success(`Quest approved! +${coinsAwarded} coins awarded ✨`)
       await fetchData()
     }
@@ -158,6 +168,34 @@ export default function ParentDashboard() {
       .update({ status: 'rejected' })
       .eq('id', completionId)
     toast.success('Quest rejected')
+    await fetchData()
+  }
+
+  const handleFulfillRedemption = async (redemptionId: string) => {
+    const redemption = redemptions.find((r) => r.id === redemptionId)
+    if (!redemption) return
+    const kid = redemption.kid as Kid | undefined
+    const reward = redemption.reward as Reward | undefined
+    if (!kid || !reward) return
+
+    const { error } = await supabase
+      .from('redemptions')
+      .update({ status: 'approved' })
+      .eq('id', redemptionId)
+
+    if (!error) {
+      await supabase
+        .from('kids')
+        .update({ coins: Math.max(0, kid.coins - reward.cost) })
+        .eq('id', kid.id)
+      toast.success(`${kid.name} got ${reward.title}! 🎁 -${reward.cost} coins`)
+      await fetchData()
+    }
+  }
+
+  const handleDenyRedemption = async (redemptionId: string) => {
+    await supabase.from('redemptions').delete().eq('id', redemptionId)
+    toast.success('Reward request denied')
     await fetchData()
   }
 
@@ -319,7 +357,7 @@ export default function ParentDashboard() {
         const attempts = parentPinAttempts + 1
         setParentPinAttempts(attempts)
         if (attempts >= 5) {
-          const lockMs = attempts >= 8 ? 5 * 60_000 : 30_000
+          const lockMs = getLockDurationMs(attempts)
           setParentLockedUntil(now + lockMs)
           toast.error(`Too many attempts — locked for ${attempts >= 8 ? '5 minutes' : '30 seconds'}`)
         }
@@ -363,6 +401,13 @@ export default function ParentDashboard() {
     await fetchData()
   }
 
+  const handleRegenerateApiKey = async () => {
+    if (!family) return
+    await supabase.from('families').update({ api_key: crypto.randomUUID() }).eq('id', family.id)
+    toast.success('API key regenerated')
+    await fetchData()
+  }
+
   const handleRegenerateToken = async () => {
     if (!family) return
     await supabase.from('families').update({ invite_token: crypto.randomUUID() }).eq('id', family.id)
@@ -371,6 +416,7 @@ export default function ParentDashboard() {
   }
 
   const pendingCompletions = completions.filter((c) => c.status === 'pending')
+  const pendingRedemptions = redemptions.filter((r) => r.status === 'pending')
 
   if (loading) {
     return (
@@ -466,7 +512,7 @@ export default function ParentDashboard() {
   }
 
   const tabs: { id: Tab; label: string; badge?: number }[] = [
-    { id: 'approvals', label: '✓ Approvals', badge: pendingCompletions.length },
+    { id: 'approvals', label: '✓ Approvals', badge: pendingCompletions.length + pendingRedemptions.length },
     { id: 'quests', label: '⚔️ Quests' },
     { id: 'family', label: '👨‍👩‍👧 Family' },
     { id: 'rewards', label: '🎁 Rewards' },
@@ -540,8 +586,52 @@ export default function ParentDashboard() {
         <AnimatePresence mode="wait">
           {tab === 'approvals' && (
             <motion.div key="approvals" {...fadeSlide} className="flex flex-col gap-4">
+              {pendingRedemptions.length > 0 && (
+                <div>
+                  <p className="text-white/30 text-xs uppercase tracking-widest mb-3">Reward requests</p>
+                  <div className="flex flex-col gap-2">
+                    {pendingRedemptions.map((r) => {
+                      const kid = r.kid as Kid | undefined
+                      const reward = r.reward as Reward | undefined
+                      if (!kid || !reward) return null
+                      return (
+                        <div
+                          key={r.id}
+                          className="flex items-center gap-3 p-3 rounded-2xl"
+                          style={{ background: 'rgba(251,191,36,0.06)', border: '1px solid rgba(251,191,36,0.18)' }}
+                        >
+                          <span className="text-2xl">{reward.icon}</span>
+                          <div className="flex-1 min-w-0">
+                            <p className="text-white/90 text-sm font-semibold truncate">{reward.title}</p>
+                            <p className="text-white/45 text-xs">
+                              {kid.avatar} {kid.name} · 🪙 {reward.cost} coins
+                            </p>
+                          </div>
+                          <div className="flex gap-2 flex-shrink-0">
+                            <button
+                              onClick={() => handleFulfillRedemption(r.id)}
+                              className="px-3 py-1.5 rounded-xl text-xs font-bold transition-all"
+                              style={{ background: 'rgba(74,222,128,0.15)', border: '1px solid rgba(74,222,128,0.35)', color: '#4ade80' }}
+                            >
+                              ✓ Give
+                            </button>
+                            <button
+                              onClick={() => handleDenyRedemption(r.id)}
+                              className="px-3 py-1.5 rounded-xl text-xs font-bold transition-all"
+                              style={{ background: 'rgba(248,113,113,0.1)', border: '1px solid rgba(248,113,113,0.25)', color: '#f87171' }}
+                            >
+                              ✕
+                            </button>
+                          </div>
+                        </div>
+                      )
+                    })}
+                  </div>
+                </div>
+              )}
+
               {pendingCompletions.length === 0 ? (
-                <Empty icon="✅" message="All clear — no pending quests!" />
+                <Empty icon="✅" message={pendingRedemptions.length === 0 ? "All clear — nothing pending!" : "No pending quests"} />
               ) : (
                 pendingCompletions.map((c) => {
                   const kid = c.kid as Kid | undefined
@@ -1003,6 +1093,37 @@ export default function ParentDashboard() {
                         ↻
                       </button>
                     </div>
+                  </div>
+                </Section>
+              )}
+
+              {/* API Key */}
+              {family?.api_key && (
+                <Section title="API Key">
+                  <div className="flex flex-col gap-3">
+                    <p className="text-white/45 text-xs">
+                      Use this key to access your family data via the REST API. Keep it secret.
+                    </p>
+                    <div
+                      className="flex items-center gap-2 px-3 py-2.5 rounded-xl"
+                      style={{ background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.08)' }}
+                    >
+                      <code className="flex-1 text-xs text-white/60 font-mono truncate">
+                        {family.api_key}
+                      </code>
+                      <button
+                        onClick={() => { navigator.clipboard.writeText(family.api_key!); toast.success('API key copied!') }}
+                        className="text-xs text-white/40 hover:text-cq-azure transition-all flex-shrink-0"
+                      >
+                        Copy
+                      </button>
+                    </div>
+                    <button
+                      onClick={handleRegenerateApiKey}
+                      className="text-xs text-white/25 hover:text-red-400 transition-all text-center"
+                    >
+                      Regenerate key (invalidates current key)
+                    </button>
                   </div>
                 </Section>
               )}

--- a/src/lib/__tests__/api-auth.test.ts
+++ b/src/lib/__tests__/api-auth.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { isAuthError, cors } from '../api-auth'
 
 describe('isAuthError', () => {
@@ -16,25 +16,26 @@ describe('isAuthError', () => {
   })
 
   it('returns false for non-Response values', () => {
-    expect(isAuthError(null)).toBe(false)
-    expect(isAuthError(undefined)).toBe(false)
-    expect(isAuthError('error')).toBe(false)
-    expect(isAuthError(401)).toBe(false)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const check = (v: any) => isAuthError(v)
+    expect(check(null)).toBe(false)
+    expect(check(undefined)).toBe(false)
+    expect(check('error')).toBe(false)
+    expect(check(401)).toBe(false)
   })
 })
 
 describe('cors', () => {
-  let originalCorsOrigin: string | undefined
-  let originalNodeEnv: string | undefined
+  let savedCorsOrigin: string | undefined
 
   beforeEach(() => {
-    originalCorsOrigin = process.env.CORS_ORIGIN
-    originalNodeEnv = process.env.NODE_ENV
+    savedCorsOrigin = process.env.CORS_ORIGIN
+    vi.unstubAllEnvs()
   })
 
   afterEach(() => {
-    process.env.CORS_ORIGIN = originalCorsOrigin
-    process.env.NODE_ENV = originalNodeEnv
+    process.env.CORS_ORIGIN = savedCorsOrigin
+    vi.unstubAllEnvs()
   })
 
   it('returns required CORS headers', () => {
@@ -54,13 +55,13 @@ describe('cors', () => {
 
   it('returns * in non-production when CORS_ORIGIN is unset', () => {
     delete process.env.CORS_ORIGIN
-    process.env.NODE_ENV = 'test'
+    vi.stubEnv('NODE_ENV', 'test')
     expect(cors()['Access-Control-Allow-Origin']).toBe('*')
   })
 
   it('returns production URL in production when CORS_ORIGIN is unset', () => {
     delete process.env.CORS_ORIGIN
-    process.env.NODE_ENV = 'production'
+    vi.stubEnv('NODE_ENV', 'production')
     expect(cors()['Access-Control-Allow-Origin']).toBe('https://chorequest.dresponda.com')
   })
 })

--- a/src/lib/__tests__/api-auth.test.ts
+++ b/src/lib/__tests__/api-auth.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { isAuthError, cors } from '../api-auth'
 
 describe('isAuthError', () => {
@@ -6,24 +6,61 @@ describe('isAuthError', () => {
     expect(isAuthError(new Response(null, { status: 401 }))).toBe(true)
   })
 
+  it('returns true regardless of HTTP status code', () => {
+    expect(isAuthError(new Response(null, { status: 200 }))).toBe(true)
+    expect(isAuthError(new Response(null, { status: 500 }))).toBe(true)
+  })
+
   it('returns false for an auth success object', () => {
     expect(isAuthError({ familyId: 'abc-123' })).toBe(false)
+  })
+
+  it('returns false for non-Response values', () => {
+    expect(isAuthError(null)).toBe(false)
+    expect(isAuthError(undefined)).toBe(false)
+    expect(isAuthError('error')).toBe(false)
+    expect(isAuthError(401)).toBe(false)
   })
 })
 
 describe('cors', () => {
+  let originalCorsOrigin: string | undefined
+  let originalNodeEnv: string | undefined
+
+  beforeEach(() => {
+    originalCorsOrigin = process.env.CORS_ORIGIN
+    originalNodeEnv = process.env.NODE_ENV
+  })
+
+  afterEach(() => {
+    process.env.CORS_ORIGIN = originalCorsOrigin
+    process.env.NODE_ENV = originalNodeEnv
+  })
+
   it('returns required CORS headers', () => {
     const headers = cors()
     expect(headers['Access-Control-Allow-Origin']).toBeTruthy()
     expect(headers['Access-Control-Allow-Methods']).toContain('GET')
     expect(headers['Access-Control-Allow-Methods']).toContain('POST')
+    expect(headers['Access-Control-Allow-Methods']).toContain('DELETE')
     expect(headers['Access-Control-Allow-Headers']).toContain('Authorization')
+    expect(headers['Access-Control-Allow-Headers']).toContain('Content-Type')
   })
 
   it('uses CORS_ORIGIN env var when set', () => {
-    const original = process.env.CORS_ORIGIN
     process.env.CORS_ORIGIN = 'https://example.com'
     expect(cors()['Access-Control-Allow-Origin']).toBe('https://example.com')
-    process.env.CORS_ORIGIN = original
+  })
+
+  it('returns * in non-production when CORS_ORIGIN is unset', () => {
+    delete process.env.CORS_ORIGIN
+    process.env.NODE_ENV = 'test'
+    expect(cors()['Access-Control-Allow-Origin']).toBe('*')
+  })
+
+  it('returns production URL in production when CORS_ORIGIN is unset', () => {
+    delete process.env.CORS_ORIGIN
+    process.env.NODE_ENV = 'production'
+    expect(cors()['Access-Control-Allow-Origin']).toBe('https://chorequest.dresponda.com')
   })
 })

--- a/src/lib/__tests__/constants.test.ts
+++ b/src/lib/__tests__/constants.test.ts
@@ -1,11 +1,16 @@
 import { describe, it, expect } from 'vitest'
-import { getStreakBonus, getStreakLabel, TIER_CONFIG, KID_COLORS } from '../constants'
+import { getStreakBonus, getStreakLabel, getLockDurationMs, TIER_CONFIG, KID_COLORS } from '../constants'
 
 describe('getStreakBonus', () => {
   it('returns 1.0 for streaks below 3', () => {
     expect(getStreakBonus(0)).toBe(1.0)
     expect(getStreakBonus(1)).toBe(1.0)
     expect(getStreakBonus(2)).toBe(1.0)
+  })
+
+  it('returns 1.0 for negative streaks', () => {
+    expect(getStreakBonus(-1)).toBe(1.0)
+    expect(getStreakBonus(-100)).toBe(1.0)
   })
 
   it('returns 1.25 for streaks 3–6', () => {
@@ -70,6 +75,26 @@ describe('TIER_CONFIG', () => {
     expect(TIER_CONFIG.heroic.glow).toBeNull()
     expect(TIER_CONFIG.legendary.glow).toBeNull()
     expect(TIER_CONFIG.epic.glow).toBeTruthy()
+  })
+})
+
+describe('getLockDurationMs', () => {
+  it('returns 30 seconds (30_000ms) for attempts 5–7', () => {
+    expect(getLockDurationMs(5)).toBe(30_000)
+    expect(getLockDurationMs(6)).toBe(30_000)
+    expect(getLockDurationMs(7)).toBe(30_000)
+  })
+
+  it('returns 5 minutes (300_000ms) for attempts 8+', () => {
+    expect(getLockDurationMs(8)).toBe(300_000)
+    expect(getLockDurationMs(9)).toBe(300_000)
+    expect(getLockDurationMs(100)).toBe(300_000)
+  })
+
+  it('treats attempt counts below 5 as short lock (edge: called with any value)', () => {
+    // Function is called only when attempts >= 5, but should still be safe
+    expect(getLockDurationMs(1)).toBe(30_000)
+    expect(getLockDurationMs(0)).toBe(30_000)
   })
 })
 

--- a/src/lib/__tests__/redirect.test.ts
+++ b/src/lib/__tests__/redirect.test.ts
@@ -9,6 +9,15 @@ describe('safeRedirectPath', () => {
     expect(safeRedirectPath('/join/some-token')).toBe('/join/some-token')
   })
 
+  it('allows paths with query strings', () => {
+    expect(safeRedirectPath('/parent?tab=quests')).toBe('/parent?tab=quests')
+    expect(safeRedirectPath('/kid/abc?q=1&r=2')).toBe('/kid/abc?q=1&r=2')
+  })
+
+  it('allows paths with fragments', () => {
+    expect(safeRedirectPath('/kid/abc#rewards')).toBe('/kid/abc#rewards')
+  })
+
   it('blocks protocol-relative open redirects', () => {
     expect(safeRedirectPath('//evil.com')).toBe('/')
     expect(safeRedirectPath('//evil.com/path')).toBe('/')
@@ -17,6 +26,16 @@ describe('safeRedirectPath', () => {
   it('blocks absolute URLs', () => {
     expect(safeRedirectPath('https://evil.com')).toBe('/')
     expect(safeRedirectPath('http://evil.com/steal')).toBe('/')
+  })
+
+  it('blocks javascript: and data: URIs', () => {
+    expect(safeRedirectPath('javascript:alert(1)')).toBe('/')
+    expect(safeRedirectPath('data:text/html,<h1>xss</h1>')).toBe('/')
+  })
+
+  it('blocks paths with leading whitespace', () => {
+    expect(safeRedirectPath('  /parent')).toBe('/')
+    expect(safeRedirectPath('\t/parent')).toBe('/')
   })
 
   it('falls back to / for null or undefined', () => {

--- a/src/lib/__tests__/utils.test.ts
+++ b/src/lib/__tests__/utils.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import { isValidPin } from '../utils'
+
+describe('isValidPin', () => {
+  it('accepts exactly 4 numeric digits', () => {
+    expect(isValidPin('0000')).toBe(true)
+    expect(isValidPin('1234')).toBe(true)
+    expect(isValidPin('9999')).toBe(true)
+  })
+
+  it('rejects PINs that are too short', () => {
+    expect(isValidPin('')).toBe(false)
+    expect(isValidPin('1')).toBe(false)
+    expect(isValidPin('123')).toBe(false)
+  })
+
+  it('rejects PINs that are too long', () => {
+    expect(isValidPin('12345')).toBe(false)
+    expect(isValidPin('00000')).toBe(false)
+  })
+
+  it('rejects PINs with non-numeric characters', () => {
+    expect(isValidPin('abcd')).toBe(false)
+    expect(isValidPin('12ab')).toBe(false)
+    expect(isValidPin('12 4')).toBe(false)
+    expect(isValidPin('12.4')).toBe(false)
+    expect(isValidPin('12-4')).toBe(false)
+  })
+
+  it('rejects non-string values', () => {
+    expect(isValidPin(1234)).toBe(false)
+    expect(isValidPin(null)).toBe(false)
+    expect(isValidPin(undefined)).toBe(false)
+    expect(isValidPin([])).toBe(false)
+    expect(isValidPin({ pin: '1234' })).toBe(false)
+  })
+
+  it('rejects PINs with leading/trailing whitespace', () => {
+    expect(isValidPin(' 1234')).toBe(false)
+    expect(isValidPin('1234 ')).toBe(false)
+    expect(isValidPin(' 1234 ')).toBe(false)
+  })
+})

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -98,6 +98,11 @@ export function getStreakLabel(streak: number): string | null {
   return null
 }
 
+/** Returns the lockout duration in ms for a given number of failed PIN attempts. */
+export function getLockDurationMs(attempts: number): number {
+  return attempts >= 8 ? 5 * 60_000 : 30_000
+}
+
 export const DEFAULT_QUESTS = [
   { title: 'Make Your Bed', icon: '🛏️', coins: 10, description: 'Straighten covers and fluff pillows' },
   { title: 'Brush Teeth', icon: '✨', coins: 5, description: 'Morning and evening' },

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -8,6 +8,7 @@ export interface Family {
   name: string
   has_parent_pin: boolean
   invite_token: string
+  api_key?: string
   created_at: string
 }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,8 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+/** Returns true if `pin` is a valid 4-digit numeric string. */
+export function isValidPin(pin: unknown): pin is string {
+  return typeof pin === 'string' && /^\d{4}$/.test(pin)
+}


### PR DESCRIPTION
## Summary
- **Redemption approvals** — reward requests from kids now appear in the parent Approvals tab with Fulfill/Deny buttons; coins deducted on fulfill; realtime updates
- **PIN security** — parent page `kids.select('*')` was sending plaintext PIN to the browser; fixed to enumerate safe columns (kid page was already correct)
- **Once-quest auto-deactivation** — after a parent approves a one-time quest it now sets `active: false`, preventing kids from resubmitting
- **API key in UI** — Family tab now shows the family's API key with copy + regenerate, enabling external automations
- **Extracted testable utilities** — `getLockDurationMs()` and `isValidPin()` moved from inline to `constants.ts` / `utils.ts`
- **39 tests (+15 new)** — edge cases for `getStreakBonus`, `getLockDurationMs`, `isValidPin`, `safeRedirectPath`, `cors()` env handling

## Test plan
- [ ] Kid requests a reward → parent sees it in Approvals tab with kid name, reward name, and coin cost
- [ ] Parent clicks Give → redemption disappears, kid's coins decrease by reward cost, coins can't go below 0
- [ ] Parent clicks ✕ → redemption removed with no coin change
- [ ] Approve a once-quest → quest moves to Archived Quests, doesn't reappear for kid
- [ ] Go to Family tab → API key visible, copy works, regenerate works
- [ ] `npm test` → 39/39 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)