### PR TITLE
feat: configurable daily quest reset time

### DIFF
--- a/src/app/kid/[id]/page.tsx
+++ b/src/app/kid/[id]/page.tsx
@@ -12,6 +12,7 @@ import { CoinCounter } from '@/components/coin-counter'
 import { StreakBadge } from '@/components/streak-badge'
 import type { Kid, Quest, Completion, Reward } from '@/lib/types'
 import { KID_COLORS, getLockDurationMs } from '@/lib/constants'
+import { questDateString } from '@/lib/utils'
 import { toast } from 'sonner'
 
 const PIN_SESSION_KEY = 'cq_kid_pin_'
@@ -36,7 +37,7 @@ export default function KidPage({ params }: { params: Promise<{ id: string }> })
   const [loading, setLoading] = useState(true)
   const [tab, setTab] = useState<'quests' | 'rewards'>('quests')
   const [supabase] = useState(createClient)
-  const today = new Date().toISOString().split('T')[0]
+  const [resetHour, setResetHour] = useState(0)
 
   const fetchData = useCallback(async () => {
     const [kidRes, questsRes, completionsRes, rewardsRes] = await Promise.all([
@@ -45,6 +46,11 @@ export default function KidPage({ params }: { params: Promise<{ id: string }> })
       supabase.from('completions').select('*').eq('kid_id', id),
       supabase.from('rewards').select('*').eq('available', true),
     ])
+
+    if (kidRes.data?.family_id) {
+      const { data: fam } = await supabase.from('families').select('daily_reset_hour').eq('id', kidRes.data.family_id).single()
+      if (fam) setResetHour(fam.daily_reset_hour ?? 0)
+    }
 
     if (kidRes.data) setKid(kidRes.data)
     if (questsRes.data) {
@@ -126,7 +132,7 @@ export default function KidPage({ params }: { params: Promise<{ id: string }> })
         quest_id: questId,
         kid_id: id,
         status: 'pending',
-        date: new Date().toISOString().split('T')[0],
+        date: questDateString(resetHour),
       })
 
       if (error) {
@@ -137,7 +143,7 @@ export default function KidPage({ params }: { params: Promise<{ id: string }> })
       toast.success(`Quest submitted! ✨`, { description: `+${quest.coins} coins once approved` })
       await fetchData()
     },
-    [quests, id, supabase, fetchData]
+    [quests, id, supabase, fetchData, resetHour]
   )
 
   const handleRedeem = useCallback(
@@ -181,6 +187,7 @@ export default function KidPage({ params }: { params: Promise<{ id: string }> })
     )
   }
 
+  const today = questDateString(resetHour)
   const colors = KID_COLORS[kid.color]
 
   // PIN screen

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,6 +9,7 @@ import { createClient } from '@/lib/supabase/client'
 import { StarField } from '@/components/star-field'
 import { KidColumn } from '@/components/kid-column'
 import type { Kid, Quest, Completion, Family } from '@/lib/types'
+import { questDateString } from '@/lib/utils'
 import { toast } from 'sonner'
 
 export default function WallDisplay() {
@@ -29,18 +30,18 @@ export default function WallDisplay() {
     if (!profile) return
 
     const [familyRes, kidsRes, questsRes] = await Promise.all([
-      supabase.from('families').select('*').eq('id', profile.family_id).single(),
-      supabase.from('kids').select('*').eq('family_id', profile.family_id).order('created_at'),
+      supabase.from('families').select('id, name, invite_token, daily_reset_hour, created_at').eq('id', profile.family_id).single(),
+      supabase.from('kids').select('id, name, avatar, color, coins, streak, last_completed_date, family_id, created_at').eq('family_id', profile.family_id).order('created_at'),
       supabase.from('quests').select('*').eq('family_id', profile.family_id).eq('active', true).order('created_at'),
     ])
 
-    const today = new Date().toISOString().split('T')[0]
+    const today = questDateString(familyRes.data?.daily_reset_hour ?? 0)
     const { data: completionsData } = await supabase
       .from('completions')
       .select('*')
       .eq('date', today)
 
-    if (familyRes.data) setFamily(familyRes.data)
+    if (familyRes.data) setFamily({ ...familyRes.data, has_parent_pin: false })
     if (kidsRes.data) setKids(kidsRes.data)
     if (questsRes.data) setQuests(questsRes.data)
     if (completionsData) {
@@ -72,7 +73,7 @@ export default function WallDisplay() {
         quest_id: questId,
         kid_id: kidId,
         status: 'pending',
-        date: new Date().toISOString().split('T')[0],
+        date: questDateString(family?.daily_reset_hour ?? 0),
       })
 
       if (error) {
@@ -86,7 +87,7 @@ export default function WallDisplay() {
 
       await fetchData()
     },
-    [quests, supabase, fetchData]
+    [quests, supabase, fetchData, family?.daily_reset_hour]
   )
 
   const getKidQuests = (kid: Kid) =>

--- a/src/app/parent/page.tsx
+++ b/src/app/parent/page.tsx
@@ -11,6 +11,7 @@ import { StarField } from '@/components/star-field'
 import { QuestCard } from '@/components/quest-card'
 import type { Kid, Quest, Completion, Reward, Redemption, Family } from '@/lib/types'
 import { KID_COLORS, KID_AVATARS, QUEST_ICONS, DEFAULT_QUESTS, TIER_CONFIG, getLockDurationMs } from '@/lib/constants'
+import { questDateString } from '@/lib/utils'
 import type { QuestTier } from '@/lib/types'
 import QRCode from 'react-qr-code'
 import { toast } from 'sonner'
@@ -68,12 +69,14 @@ export default function ParentDashboard() {
     const { data: profile } = await supabase.from('profiles').select('family_id').single()
     if (!profile) return
 
-    const today = new Date().toISOString().split('T')[0]
+    // Fetch reset hour first so today is always computed against the correct boundary
+    const { data: resetData } = await supabase.from('families').select('daily_reset_hour').eq('id', profile.family_id).single()
+    const today = questDateString(resetData?.daily_reset_hour ?? 0)
 
     const kidCols = 'id, name, avatar, color, coins, streak, last_completed_date, family_id, created_at'
 
     const [familyRes, kidsRes, questsRes, completionsRes, rewardsRes, redemptionsRes] = await Promise.all([
-      supabase.from('families').select('id, name, invite_token, api_key, created_at, parent_pin').eq('id', profile.family_id).single(),
+      supabase.from('families').select('id, name, invite_token, api_key, daily_reset_hour, created_at, parent_pin').eq('id', profile.family_id).single(),
       supabase.from('kids').select(kidCols).eq('family_id', profile.family_id).order('created_at'),
       supabase.from('quests').select('*').eq('family_id', profile.family_id).order('created_at'),
       supabase.from('completions').select(`*, quest:quests(*), kid:kids(${kidCols})`).eq('date', today).order('completed_at', { ascending: false }),
@@ -83,7 +86,7 @@ export default function ParentDashboard() {
 
     if (familyRes.data) {
       const { parent_pin, ...rest } = familyRes.data
-      setFamily({ ...rest, has_parent_pin: parent_pin !== null, api_key: rest.api_key ?? undefined })
+      setFamily({ ...rest, has_parent_pin: parent_pin !== null, api_key: rest.api_key ?? undefined, daily_reset_hour: rest.daily_reset_hour ?? 0 })
       setFamilyName(familyRes.data.name)
     }
     if (kidsRes.data) setKids(kidsRes.data)
@@ -144,7 +147,7 @@ export default function ParentDashboard() {
         .update({ coins: (completion.kid?.coins ?? 0) + coinsAwarded })
         .eq('id', completion.kid_id)
 
-      const today = new Date().toISOString().split('T')[0]
+      const today = questDateString(family?.daily_reset_hour ?? 0)
       const lastDate = completion.kid?.last_completed_date
       const newStreak = lastDate === yesterday() ? (completion.kid?.streak ?? 0) + 1 : 1
 
@@ -269,6 +272,13 @@ export default function ParentDashboard() {
       setNewRewardDesc('')
       await fetchData()
     }
+  }
+
+  const handleSaveResetHour = async (hour: number) => {
+    if (!family) return
+    await supabase.from('families').update({ daily_reset_hour: hour }).eq('id', family.id)
+    toast.success('Daily reset time updated!')
+    await fetchData()
   }
 
   const handleSaveFamilyName = async () => {
@@ -844,6 +854,53 @@ export default function ParentDashboard() {
                 </div>
               </Section>
 
+              {/* Daily reset */}
+              <Section title="Daily Quest Reset">
+                <div className="flex flex-col gap-3">
+                  <p className="text-white/45 text-xs">
+                    Quests reset each day at this time
+                    {typeof window !== 'undefined' && (
+                      <span className="text-white/30"> · {Intl.DateTimeFormat().resolvedOptions().timeZone}</span>
+                    )}
+                  </p>
+                  <div className="grid grid-cols-4 gap-2">
+                    {([0, 3, 5, 6] as const).map((h) => {
+                      const label = h === 0 ? '12 AM' : `${h} AM`
+                      const selected = (family?.daily_reset_hour ?? 0) === h
+                      return (
+                        <button
+                          key={h}
+                          onClick={() => handleSaveResetHour(h)}
+                          className="py-2.5 rounded-xl text-sm font-semibold transition-all"
+                          style={{
+                            background: selected ? 'rgba(251,191,36,0.14)' : 'rgba(255,255,255,0.05)',
+                            border: `1px solid ${selected ? 'rgba(251,191,36,0.35)' : 'rgba(255,255,255,0.08)'}`,
+                            color: selected ? '#fbbf24' : 'rgba(255,255,255,0.5)',
+                          }}
+                        >
+                          {label}
+                        </button>
+                      )
+                    })}
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <label className="text-xs text-white/30 flex-shrink-0">Custom hour (0–23):</label>
+                    <input
+                      type="number"
+                      min={0}
+                      max={23}
+                      value={family?.daily_reset_hour ?? 0}
+                      onChange={(e) => {
+                        const v = Math.max(0, Math.min(23, parseInt(e.target.value, 10) || 0))
+                        handleSaveResetHour(v)
+                      }}
+                      className="w-16 px-2 py-1 rounded-lg text-xs text-white/90 outline-none"
+                      style={{ background: 'rgba(255,255,255,0.06)', border: '1px solid rgba(255,255,255,0.1)' }}
+                    />
+                  </div>
+                </div>
+              </Section>
+
               {/* Parent lock */}
               <Section title="Parent Lock">
                 {family?.has_parent_pin ? (
@@ -1410,7 +1467,7 @@ function getStreakBonus(streak: number): number {
 function yesterday(): string {
   const d = new Date()
   d.setDate(d.getDate() - 1)
-  return d.toISOString().split('T')[0]
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
 }
 
 const fadeSlide = {

--- a/src/lib/__tests__/utils.test.ts
+++ b/src/lib/__tests__/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { isValidPin } from '../utils'
+import { isValidPin, questDateString } from '../utils'
 
 describe('isValidPin', () => {
   it('accepts exactly 4 numeric digits', () => {
@@ -39,5 +39,35 @@ describe('isValidPin', () => {
     expect(isValidPin(' 1234')).toBe(false)
     expect(isValidPin('1234 ')).toBe(false)
     expect(isValidPin(' 1234 ')).toBe(false)
+  })
+})
+
+describe('questDateString', () => {
+  const date = (h: number, min = 0) => {
+    const d = new Date(2025, 5, 15, h, min) // 2025-06-15, local time
+    return d
+  }
+
+  it('returns today when current hour is at or after resetHour', () => {
+    expect(questDateString(0, date(0))).toBe('2025-06-15')   // midnight reset, midnight
+    expect(questDateString(3, date(3))).toBe('2025-06-15')   // 3 AM reset, exactly 3 AM
+    expect(questDateString(3, date(9))).toBe('2025-06-15')   // 3 AM reset, 9 AM
+    expect(questDateString(6, date(23))).toBe('2025-06-15')  // 6 AM reset, 11 PM
+  })
+
+  it('returns yesterday when current hour is before resetHour', () => {
+    expect(questDateString(3, date(2))).toBe('2025-06-14')   // 3 AM reset, 2 AM → still yesterday
+    expect(questDateString(6, date(5))).toBe('2025-06-14')   // 6 AM reset, 5 AM → still yesterday
+    expect(questDateString(3, date(0))).toBe('2025-06-14')   // 3 AM reset, midnight → still yesterday
+  })
+
+  it('defaults to midnight reset (resetHour=0)', () => {
+    expect(questDateString(0, date(0))).toBe('2025-06-15')
+    expect(questDateString(0, date(23, 59))).toBe('2025-06-15')
+  })
+
+  it('handles month boundary correctly', () => {
+    const lastDayOfMonth = new Date(2025, 5, 1, 2) // June 1 at 2 AM, resetHour=3
+    expect(questDateString(3, lastDayOfMonth)).toBe('2025-05-31') // rolls back to May 31
   })
 })

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -9,6 +9,7 @@ export interface Family {
   has_parent_pin: boolean
   invite_token: string
   api_key?: string
+  daily_reset_hour: number
   created_at: string
 }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -9,3 +9,24 @@ export function cn(...inputs: ClassValue[]) {
 export function isValidPin(pin: unknown): pin is string {
   return typeof pin === 'string' && /^\d{4}$/.test(pin)
 }
+
+/** Returns a date as YYYY-MM-DD in the browser's local timezone. */
+export function localDateString(date = new Date()): string {
+  const y = date.getFullYear()
+  const m = String(date.getMonth() + 1).padStart(2, '0')
+  const d = String(date.getDate()).padStart(2, '0')
+  return `${y}-${m}-${d}`
+}
+
+/**
+ * Returns the effective quest-day date string (YYYY-MM-DD).
+ * Before `resetHour` each day, completions still belong to the previous day.
+ * e.g. resetHour=3 means dailies reset at 3 AM — 1 AM is still "yesterday".
+ */
+export function questDateString(resetHour = 0, now = new Date()): string {
+  const effective = new Date(now)
+  if (now.getHours() < resetHour) {
+    effective.setDate(effective.getDate() - 1)
+  }
+  return localDateString(effective)
+}

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -9,6 +9,7 @@ create table families (
   parent_pin text check (parent_pin ~ '^[0-9]{4}$'), -- optional 4-digit lock PIN
   invite_token uuid not null default gen_random_uuid() unique,
   api_key uuid not null default gen_random_uuid() unique,
+  daily_reset_hour integer not null default 0 check (daily_reset_hour >= 0 and daily_reset_hour <= 23),
   created_at timestamptz default now()
 );
 


### PR DESCRIPTION
## Summary
- Dailies no longer reset at UTC midnight — they now reset at **local browser midnight by default**, fixing the ~7-8 PM EDT reset bug
- Parent can configure the exact reset hour in the Family tab (presets: 12 AM, 3 AM, 5 AM, 6 AM + custom 0–23 input)
- Detected timezone is shown next to the setting so it's unambiguous
- All completion queries and inserts use the new `questDateString(resetHour)` utility

## How it works
`questDateString(resetHour)` returns today's local date string — unless the current hour is before `resetHour`, in which case it returns yesterday's date. So with `resetHour=3`, anything submitted between midnight and 3 AM still counts toward the previous day's quests.

## Test plan
- [ ] Dailies now clear at midnight local time (not 7-8 PM EDT)
- [ ] Go to Parent → Family tab → "Daily Quest Reset" section shows timezone and preset buttons
- [ ] Change reset to 3 AM → save → verify completions query uses correct date
- [ ] Custom input accepts 0–23
- [ ] `npm test` → 43/43 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)