### PR TITLE
feat: tier quest cards, frequency display, recurring quests, curses, and bounty section

### DIFF
--- a/src/app/api/curse-instances/[id]/route.ts
+++ b/src/app/api/curse-instances/[id]/route.ts
@@ -1,0 +1,45 @@
+import { authenticate, isAuthError, cors } from '@/lib/api-auth'
+import { createServiceClient } from '@/lib/supabase/service'
+
+export async function OPTIONS() {
+  return new Response(null, { status: 204, headers: cors() })
+}
+
+export async function PATCH(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const auth = await authenticate(req)
+  if (isAuthError(auth)) return auth
+
+  const { id } = await params
+  const body = await req.json().catch(() => ({}))
+
+  const supabase = createServiceClient()
+
+  const { data: instance, error: fetchErr } = await supabase
+    .from('curse_instances')
+    .select('*, kid:kids(id, coins, family_id)')
+    .eq('id', id)
+    .single()
+
+  if (fetchErr || !instance) {
+    return Response.json({ error: 'Instance not found' }, { status: 404, headers: cors() })
+  }
+
+  const kid = instance.kid as { id: string; coins: number; family_id: string } | null
+  if (!kid || kid.family_id !== auth.familyId) {
+    return Response.json({ error: 'Not authorized' }, { status: 403, headers: cors() })
+  }
+
+  if (body.refund === true) {
+    await supabase.from('kids').update({ coins: kid.coins + instance.coins_deducted }).eq('id', kid.id)
+  }
+
+  const { data, error } = await supabase
+    .from('curse_instances')
+    .update({ status: 'resolved', resolved_at: new Date().toISOString() })
+    .eq('id', id)
+    .select()
+    .single()
+
+  if (error) return Response.json({ error: error.message }, { status: 500, headers: cors() })
+  return Response.json({ instance: data }, { headers: cors() })
+}

--- a/src/app/api/curses/[id]/cast/route.ts
+++ b/src/app/api/curses/[id]/cast/route.ts
@@ -1,0 +1,47 @@
+import { authenticate, isAuthError, cors } from '@/lib/api-auth'
+import { createServiceClient } from '@/lib/supabase/service'
+
+export async function OPTIONS() {
+  return new Response(null, { status: 204, headers: cors() })
+}
+
+export async function POST(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const auth = await authenticate(req)
+  if (isAuthError(auth)) return auth
+
+  const { id } = await params
+  const body = await req.json().catch(() => null)
+  if (!body?.kid_id) {
+    return Response.json({ error: '`kid_id` is required' }, { status: 400, headers: cors() })
+  }
+
+  const supabase = createServiceClient()
+
+  const [curseRes, kidRes] = await Promise.all([
+    supabase.from('curses').select('*').eq('id', id).eq('family_id', auth.familyId).single(),
+    supabase.from('kids').select('id, coins').eq('id', body.kid_id).eq('family_id', auth.familyId).single(),
+  ])
+
+  if (!curseRes.data) return Response.json({ error: 'Curse not found' }, { status: 404, headers: cors() })
+  if (!kidRes.data) return Response.json({ error: 'Kid not found' }, { status: 404, headers: cors() })
+
+  const curse = curseRes.data
+  const kid = kidRes.data
+  const newCoins = Math.max(0, kid.coins - curse.penalty)
+
+  const [instanceRes] = await Promise.all([
+    supabase.from('curse_instances').insert({
+      curse_id: curse.id,
+      kid_id: kid.id,
+      coins_deducted: curse.penalty,
+      status: 'active',
+    }).select().single(),
+    supabase.from('kids').update({ coins: newCoins }).eq('id', kid.id),
+  ])
+
+  if (instanceRes.error) {
+    return Response.json({ error: instanceRes.error.message }, { status: 500, headers: cors() })
+  }
+
+  return Response.json({ instance: instanceRes.data, coins_deducted: curse.penalty }, { status: 201, headers: cors() })
+}

--- a/src/app/api/curses/[id]/route.ts
+++ b/src/app/api/curses/[id]/route.ts
@@ -12,7 +12,7 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
   const { id } = await params
   const body = await req.json().catch(() => ({}))
 
-  const allowed = ['title', 'description', 'icon', 'coins', 'assigned_to', 'frequency', 'tier', 'exclusive', 'active_days', 'weekly_target', 'active']
+  const allowed = ['title', 'icon', 'penalty']
   const updates: Record<string, unknown> = {}
   for (const key of allowed) {
     if (key in body) updates[key] = body[key]
@@ -24,7 +24,7 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
 
   const supabase = createServiceClient()
   const { data, error } = await supabase
-    .from('quests')
+    .from('curses')
     .update(updates)
     .eq('id', id)
     .eq('family_id', auth.familyId)
@@ -32,10 +32,10 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
     .single()
 
   if (error || !data) {
-    return Response.json({ error: error?.message ?? 'Quest not found' }, { status: error ? 500 : 404, headers: cors() })
+    return Response.json({ error: error?.message ?? 'Curse not found' }, { status: error ? 500 : 404, headers: cors() })
   }
 
-  return Response.json({ quest: data }, { headers: cors() })
+  return Response.json({ curse: data }, { headers: cors() })
 }
 
 export async function DELETE(req: Request, { params }: { params: Promise<{ id: string }> }) {
@@ -46,12 +46,11 @@ export async function DELETE(req: Request, { params }: { params: Promise<{ id: s
   const supabase = createServiceClient()
 
   const { error } = await supabase
-    .from('quests')
+    .from('curses')
     .delete()
     .eq('id', id)
     .eq('family_id', auth.familyId)
 
   if (error) return Response.json({ error: error.message }, { status: 500, headers: cors() })
-
   return Response.json({ deleted: true }, { headers: cors() })
 }

--- a/src/app/api/curses/route.ts
+++ b/src/app/api/curses/route.ts
@@ -9,22 +9,15 @@ export async function GET(req: Request) {
   const auth = await authenticate(req)
   if (isAuthError(auth)) return auth
 
-  const { searchParams } = new URL(req.url)
-  const activeOnly = searchParams.get('active') !== 'false'
-
   const supabase = createServiceClient()
-  let query = supabase
-    .from('quests')
+  const { data, error } = await supabase
+    .from('curses')
     .select('*')
     .eq('family_id', auth.familyId)
     .order('created_at')
 
-  if (activeOnly) query = query.eq('active', true)
-
-  const { data, error } = await query
   if (error) return Response.json({ error: error.message }, { status: 500, headers: cors() })
-
-  return Response.json({ quests: data }, { headers: cors() })
+  return Response.json({ curses: data }, { headers: cors() })
 }
 
 export async function POST(req: Request) {
@@ -38,25 +31,16 @@ export async function POST(req: Request) {
 
   const supabase = createServiceClient()
   const { data, error } = await supabase
-    .from('quests')
+    .from('curses')
     .insert({
       family_id: auth.familyId,
       title: body.title,
-      description: body.description ?? null,
-      icon: body.icon ?? '⚔️',
-      coins: Number(body.coins ?? 10),
-      assigned_to: body.assigned_to ?? null,
-      frequency: body.frequency ?? 'daily',
-      tier: body.tier ?? 'normal',
-      exclusive: body.exclusive ?? false,
-      active_days: body.active_days ?? null,
-      weekly_target: body.weekly_target ?? null,
-      active: true,
+      icon: body.icon ?? '☠️',
+      penalty: Number(body.penalty ?? 10),
     })
     .select()
     .single()
 
   if (error) return Response.json({ error: error.message }, { status: 500, headers: cors() })
-
-  return Response.json({ quest: data }, { status: 201, headers: cors() })
+  return Response.json({ curse: data }, { status: 201, headers: cors() })
 }

--- a/src/app/api/kids/route.ts
+++ b/src/app/api/kids/route.ts
@@ -1,5 +1,6 @@
 import { authenticate, isAuthError, cors } from '@/lib/api-auth'
 import { createServiceClient } from '@/lib/supabase/service'
+import { questDateString } from '@/lib/utils'
 
 export async function OPTIONS() {
   return new Response(null, { status: 204, headers: cors() })
@@ -10,7 +11,14 @@ export async function GET(req: Request) {
   if (isAuthError(auth)) return auth
 
   const supabase = createServiceClient()
-  const today = new Date().toISOString().split('T')[0]
+  const { searchParams } = new URL(req.url)
+
+  // Allow caller to supply date explicitly (YYYY-MM-DD) to handle timezone edge cases
+  let today = searchParams.get('date') ?? null
+  if (!today) {
+    const { data: fam } = await supabase.from('families').select('daily_reset_hour').eq('id', auth.familyId).single()
+    today = questDateString(fam?.daily_reset_hour ?? 0)
+  }
 
   const [kidsRes, completionsRes] = await Promise.all([
     supabase.from('kids').select('id, name, avatar, color, coins, streak, last_completed_date, created_at').eq('family_id', auth.familyId).order('created_at'),

--- a/src/app/kid/[id]/page.tsx
+++ b/src/app/kid/[id]/page.tsx
@@ -12,6 +12,7 @@ import { CoinCounter } from '@/components/coin-counter'
 import { StreakBadge } from '@/components/streak-badge'
 import type { Kid, Quest, Completion, Reward } from '@/lib/types'
 import { KID_COLORS, getLockDurationMs } from '@/lib/constants'
+import { questDateString } from '@/lib/utils'
 import { toast } from 'sonner'
 
 const PIN_SESSION_KEY = 'cq_kid_pin_'
@@ -36,7 +37,7 @@ export default function KidPage({ params }: { params: Promise<{ id: string }> })
   const [loading, setLoading] = useState(true)
   const [tab, setTab] = useState<'quests' | 'rewards'>('quests')
   const [supabase] = useState(createClient)
-  const today = new Date().toISOString().split('T')[0]
+  const [resetHour, setResetHour] = useState(0)
 
   const fetchData = useCallback(async () => {
     const [kidRes, questsRes, completionsRes, rewardsRes] = await Promise.all([
@@ -45,6 +46,11 @@ export default function KidPage({ params }: { params: Promise<{ id: string }> })
       supabase.from('completions').select('*').eq('kid_id', id),
       supabase.from('rewards').select('*').eq('available', true),
     ])
+
+    if (kidRes.data?.family_id) {
+      const { data: fam } = await supabase.from('families').select('daily_reset_hour').eq('id', kidRes.data.family_id).single()
+      if (fam) setResetHour(fam.daily_reset_hour ?? 0)
+    }
 
     if (kidRes.data) setKid(kidRes.data)
     if (questsRes.data) {
@@ -126,7 +132,7 @@ export default function KidPage({ params }: { params: Promise<{ id: string }> })
         quest_id: questId,
         kid_id: id,
         status: 'pending',
-        date: new Date().toISOString().split('T')[0],
+        date: questDateString(resetHour),
       })
 
       if (error) {
@@ -137,7 +143,7 @@ export default function KidPage({ params }: { params: Promise<{ id: string }> })
       toast.success(`Quest submitted! ✨`, { description: `+${quest.coins} coins once approved` })
       await fetchData()
     },
-    [quests, id, supabase, fetchData]
+    [quests, id, supabase, fetchData, resetHour]
   )
 
   const handleRedeem = useCallback(
@@ -181,6 +187,7 @@ export default function KidPage({ params }: { params: Promise<{ id: string }> })
     )
   }
 
+  const today = questDateString(resetHour)
   const colors = KID_COLORS[kid.color]
 
   // PIN screen

--- a/src/app/kid/[id]/page.tsx
+++ b/src/app/kid/[id]/page.tsx
@@ -10,9 +10,9 @@ import { StarField } from '@/components/star-field'
 import { QuestCard } from '@/components/quest-card'
 import { CoinCounter } from '@/components/coin-counter'
 import { StreakBadge } from '@/components/streak-badge'
-import type { Kid, Quest, Completion, Reward } from '@/lib/types'
+import type { Kid, Quest, Completion, Reward, CurseInstance } from '@/lib/types'
 import { KID_COLORS, getLockDurationMs } from '@/lib/constants'
-import { questDateString } from '@/lib/utils'
+import { questDateString, questWeekKey } from '@/lib/utils'
 import { toast } from 'sonner'
 
 const PIN_SESSION_KEY = 'cq_kid_pin_'
@@ -24,6 +24,8 @@ export default function KidPage({ params }: { params: Promise<{ id: string }> })
   const [quests, setQuests] = useState<Quest[]>([])
   const [completions, setCompletions] = useState<Completion[]>([])
   const [rewards, setRewards] = useState<Reward[]>([])
+  const [activeCurses, setActiveCurses] = useState<CurseInstance[]>([])
+  const [claimedExclusiveIds, setClaimedExclusiveIds] = useState<Set<string>>(new Set())
   const [pinVerified, setPinVerified] = useState(() =>
     typeof window !== 'undefined'
       ? sessionStorage.getItem(PIN_SESSION_KEY + id) === 'verified'
@@ -40,38 +42,59 @@ export default function KidPage({ params }: { params: Promise<{ id: string }> })
   const [resetHour, setResetHour] = useState(0)
 
   const fetchData = useCallback(async () => {
-    const [kidRes, questsRes, completionsRes, rewardsRes] = await Promise.all([
+    const [kidRes, questsRes, rewardsRes] = await Promise.all([
       supabase.from('kids').select('id, name, avatar, color, coins, streak, last_completed_date, family_id, created_at').eq('id', id).single(),
       supabase.from('quests').select('*').eq('active', true).order('created_at'),
-      supabase.from('completions').select('*').eq('kid_id', id),
       supabase.from('rewards').select('*').eq('available', true),
     ])
 
+    let fetchedResetHour = resetHour
     if (kidRes.data?.family_id) {
       const { data: fam } = await supabase.from('families').select('daily_reset_hour').eq('id', kidRes.data.family_id).single()
-      if (fam) setResetHour(fam.daily_reset_hour ?? 0)
+      if (fam) {
+        fetchedResetHour = fam.daily_reset_hour ?? 0
+        setResetHour(fetchedResetHour)
+      }
     }
 
+    const today = questDateString(fetchedResetHour)
+    const weekStart = questWeekKey(fetchedResetHour)
+
+    const [completionsRes, cursesRes, exclusiveRes] = await Promise.all([
+      supabase.from('completions').select('*').eq('kid_id', id).gte('date', weekStart),
+      supabase.from('curse_instances').select('*, curse:curses(*)').eq('kid_id', id).eq('status', 'active'),
+      // Check exclusive quests claimed by other kids today
+      (async () => {
+        const exclusiveIds = (questsRes.data ?? []).filter(q => q.exclusive).map(q => q.id)
+        if (exclusiveIds.length === 0) return { data: [] }
+        return supabase.from('completions').select('quest_id').in('quest_id', exclusiveIds).eq('date', today).neq('kid_id', id)
+      })(),
+    ])
+
     if (kidRes.data) setKid(kidRes.data)
+
     if (questsRes.data) {
       const allCompletions: Completion[] = completionsRes.data ?? []
       const approvedOnceIds = new Set(
-        allCompletions
-          .filter((c: Completion) => c.status === 'approved')
-          .map((c: Completion) => c.quest_id)
+        allCompletions.filter(c => c.status === 'approved').map(c => c.quest_id)
       )
+      const dayOfWeek = new Date().getDay()
       setQuests(
         questsRes.data.filter((q: Quest) => {
           if (q.assigned_to && q.assigned_to !== id) return false
           if (q.frequency === 'once' && approvedOnceIds.has(q.id)) return false
+          if (q.active_days?.length && !q.active_days.includes(dayOfWeek)) return false
           return true
         })
       )
     }
+
     if (completionsRes.data) setCompletions(completionsRes.data)
+    if (cursesRes.data) setActiveCurses(cursesRes.data as CurseInstance[])
+    setClaimedExclusiveIds(new Set((exclusiveRes.data ?? []).map(c => c.quest_id)))
     if (rewardsRes.data) setRewards(rewardsRes.data)
     setLoading(false)
-  }, [id, supabase])
+  }, [id, supabase, resetHour])
 
   useEffect(() => {
     fetchData()
@@ -80,6 +103,7 @@ export default function KidPage({ params }: { params: Promise<{ id: string }> })
       .channel(`kid-${id}`)
       .on('postgres_changes', { event: '*', schema: 'public', table: 'completions', filter: `kid_id=eq.${id}` }, fetchData)
       .on('postgres_changes', { event: 'UPDATE', schema: 'public', table: 'kids', filter: `id=eq.${id}` }, fetchData)
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'curse_instances', filter: `kid_id=eq.${id}` }, fetchData)
       .subscribe()
 
     return () => { supabase.removeChannel(channel) }
@@ -87,8 +111,8 @@ export default function KidPage({ params }: { params: Promise<{ id: string }> })
 
   useEffect(() => {
     if (!lockedUntil) return
-    const id = setInterval(() => setNow(Date.now()), 1000)
-    return () => clearInterval(id)
+    const timerId = setInterval(() => setNow(Date.now()), 1000)
+    return () => clearInterval(timerId)
   }, [lockedUntil])
 
   const handlePinDigit = async (digit: string) => {
@@ -128,11 +152,23 @@ export default function KidPage({ params }: { params: Promise<{ id: string }> })
       const quest = quests.find((q) => q.id === questId)
       if (!quest) return
 
+      const today = questDateString(resetHour)
+
+      if (quest.weekly_target != null) {
+        const weekCount = completions.filter(c =>
+          c.quest_id === questId && (c.status === 'approved' || c.status === 'pending')
+        ).length
+        if (weekCount >= quest.weekly_target) {
+          toast.error('Weekly target already reached!')
+          return
+        }
+      }
+
       const { error } = await supabase.from('completions').insert({
         quest_id: questId,
         kid_id: id,
         status: 'pending',
-        date: questDateString(resetHour),
+        date: today,
       })
 
       if (error) {
@@ -143,7 +179,7 @@ export default function KidPage({ params }: { params: Promise<{ id: string }> })
       toast.success(`Quest submitted! ✨`, { description: `+${quest.coins} coins once approved` })
       await fetchData()
     },
-    [quests, id, supabase, fetchData, resetHour]
+    [quests, id, supabase, fetchData, resetHour, completions]
   )
 
   const handleRedeem = useCallback(
@@ -219,7 +255,6 @@ export default function KidPage({ params }: { params: Promise<{ id: string }> })
             </p>
           )}
 
-          {/* PIN dots */}
           <div className="flex justify-center gap-4 mb-8">
             {Array.from({ length: 4 }, (_, i) => (
               <motion.div
@@ -237,7 +272,6 @@ export default function KidPage({ params }: { params: Promise<{ id: string }> })
             ))}
           </div>
 
-          {/* Numpad */}
           <div className="grid grid-cols-3 gap-3 max-w-[240px] mx-auto">
             {['1','2','3','4','5','6','7','8','9','','0','⌫'].map((d) => (
               <motion.button
@@ -336,6 +370,30 @@ export default function KidPage({ params }: { params: Promise<{ id: string }> })
               exit={{ opacity: 0, x: 10 }}
               transition={{ duration: 0.2 }}
             >
+              {/* Active curses */}
+              {activeCurses.length > 0 && (
+                <motion.div
+                  initial={{ opacity: 0, y: -8 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  className="rounded-2xl p-4 flex flex-col gap-2"
+                  style={{ background: 'rgba(239,68,68,0.08)', border: '1px solid rgba(239,68,68,0.25)' }}
+                >
+                  <p className="text-xs font-bold uppercase tracking-widest text-red-400/80">⚠️ Afflictions</p>
+                  {activeCurses.map(ci => {
+                    const curse = ci.curse as { title: string; icon: string; penalty: number } | undefined
+                    return (
+                      <div key={ci.id} className="flex items-center gap-3">
+                        <span className="text-xl">{curse?.icon ?? '☠️'}</span>
+                        <div className="flex-1">
+                          <p className="text-sm font-semibold text-red-300">{curse?.title ?? 'Curse'}</p>
+                          <p className="text-xs text-red-400/60">−{ci.coins_deducted} coins deducted</p>
+                        </div>
+                      </div>
+                    )
+                  })}
+                </motion.div>
+              )}
+
               {quests.length === 0 ? (
                 <div className="text-center py-16 text-white/30">
                   <p className="text-4xl mb-3">🧙</p>
@@ -343,9 +401,21 @@ export default function KidPage({ params }: { params: Promise<{ id: string }> })
                 </div>
               ) : (
                 quests.map((quest, i) => {
-                  const completion = quest.frequency === 'once'
-                    ? completions.find((c) => c.quest_id === quest.id)
-                    : completions.find((c) => c.quest_id === quest.id && c.date === today)
+                  const completion = quest.frequency === 'weekly'
+                    ? completions.find(c => c.quest_id === quest.id)
+                    : quest.frequency === 'once'
+                    ? completions.find(c => c.quest_id === quest.id)
+                    : completions.find(c => c.quest_id === quest.id && c.date === today)
+
+                  const weeklyCount = quest.weekly_target != null
+                    ? completions.filter(c =>
+                        c.quest_id === quest.id &&
+                        (c.status === 'approved' || c.status === 'pending')
+                      ).length
+                    : undefined
+
+                  const isExclusiveLocked = quest.exclusive && !completion && claimedExclusiveIds.has(quest.id)
+
                   return (
                     <motion.div
                       key={quest.id}
@@ -356,6 +426,8 @@ export default function KidPage({ params }: { params: Promise<{ id: string }> })
                       <QuestCard
                         quest={quest}
                         completion={completion}
+                        weeklyCount={weeklyCount}
+                        isExclusiveLocked={isExclusiveLocked}
                         kidColor={kid.color}
                         onComplete={() => handleComplete(quest.id)}
                       />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,7 +9,7 @@ import { createClient } from '@/lib/supabase/client'
 import { StarField } from '@/components/star-field'
 import { KidColumn } from '@/components/kid-column'
 import type { Kid, Quest, Completion, Family } from '@/lib/types'
-import { questDateString } from '@/lib/utils'
+import { questDateString, questWeekKey } from '@/lib/utils'
 import { toast } from 'sonner'
 
 export default function WallDisplay() {
@@ -17,6 +17,7 @@ export default function WallDisplay() {
   const [kids, setKids] = useState<Kid[]>([])
   const [quests, setQuests] = useState<Quest[]>([])
   const [completions, setCompletions] = useState<Completion[]>([])
+  const [activeCurseCounts, setActiveCurseCounts] = useState<Record<string, number>>({})
   const [loading, setLoading] = useState(true)
   const [pendingCount, setPendingCount] = useState(0)
   const [supabase] = useState(createClient)
@@ -35,19 +36,28 @@ export default function WallDisplay() {
       supabase.from('quests').select('*').eq('family_id', profile.family_id).eq('active', true).order('created_at'),
     ])
 
-    const today = questDateString(familyRes.data?.daily_reset_hour ?? 0)
-    const { data: completionsData } = await supabase
-      .from('completions')
-      .select('*')
-      .eq('date', today)
+    const resetHour = familyRes.data?.daily_reset_hour ?? 0
+    const today = questDateString(resetHour)
+    const weekStart = questWeekKey(resetHour)
+
+    const [completionsRes, cursesRes] = await Promise.all([
+      supabase.from('completions').select('*').gte('date', weekStart).lte('date', today),
+      supabase.from('curse_instances').select('kid_id').eq('status', 'active'),
+    ])
 
     if (familyRes.data) setFamily({ ...familyRes.data, has_parent_pin: false })
     if (kidsRes.data) setKids(kidsRes.data)
     if (questsRes.data) setQuests(questsRes.data)
-    if (completionsData) {
-      setCompletions(completionsData)
-      setPendingCount(completionsData.filter((c) => c.status === 'pending').length)
+
+    const allCompletions = completionsRes.data ?? []
+    setCompletions(allCompletions)
+    setPendingCount(allCompletions.filter(c => c.status === 'pending' && c.date === today).length)
+
+    const counts: Record<string, number> = {}
+    for (const ci of cursesRes.data ?? []) {
+      counts[ci.kid_id] = (counts[ci.kid_id] ?? 0) + 1
     }
+    setActiveCurseCounts(counts)
 
     setLoading(false)
   }, [supabase])
@@ -59,6 +69,7 @@ export default function WallDisplay() {
       .channel('wall-realtime')
       .on('postgres_changes', { event: '*', schema: 'public', table: 'completions' }, fetchData)
       .on('postgres_changes', { event: 'UPDATE', schema: 'public', table: 'kids' }, fetchData)
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'curse_instances' }, fetchData)
       .subscribe()
 
     return () => { supabase.removeChannel(channel) }
@@ -69,11 +80,25 @@ export default function WallDisplay() {
       const quest = quests.find((q) => q.id === questId)
       if (!quest) return
 
+      const today = questDateString(family?.daily_reset_hour ?? 0)
+
+      // Weekly_target guard: prevent over-submission
+      if (quest.weekly_target != null) {
+        const weekCount = completions.filter(c =>
+          c.quest_id === questId && c.kid_id === kidId &&
+          (c.status === 'approved' || c.status === 'pending')
+        ).length
+        if (weekCount >= quest.weekly_target) {
+          toast.error('Weekly target already reached!')
+          return
+        }
+      }
+
       const { error } = await supabase.from('completions').insert({
         quest_id: questId,
         kid_id: kidId,
         status: 'pending',
-        date: questDateString(family?.daily_reset_hour ?? 0),
+        date: today,
       })
 
       if (error) {
@@ -87,14 +112,28 @@ export default function WallDisplay() {
 
       await fetchData()
     },
-    [quests, supabase, fetchData, family?.daily_reset_hour]
+    [quests, supabase, fetchData, family?.daily_reset_hour, completions]
   )
 
+  const today = questDateString(family?.daily_reset_hour ?? 0)
+  const dayOfWeek = new Date().getDay()
+
   const getKidQuests = (kid: Kid) =>
-    quests.filter((q) => !q.assigned_to || q.assigned_to === kid.id)
+    quests.filter(q => {
+      if (q.assigned_to && q.assigned_to !== kid.id) return false
+      if (q.active_days?.length && !q.active_days.includes(dayOfWeek)) return false
+      return true
+    })
 
   const getKidCompletions = (kid: Kid) =>
     completions.filter((c) => c.kid_id === kid.id)
+
+  const todayCompletions = completions.filter(c => c.date === today)
+  const claimedExclusiveIds = new Set(
+    todayCompletions
+      .filter(c => quests.find(q => q.id === c.quest_id)?.exclusive)
+      .map(c => c.quest_id)
+  )
 
   if (loading) {
     return (
@@ -214,6 +253,9 @@ export default function WallDisplay() {
               kid={kid}
               quests={getKidQuests(kid)}
               completions={getKidCompletions(kid)}
+              today={today}
+              claimedExclusiveIds={claimedExclusiveIds}
+              activeCurseCount={activeCurseCounts[kid.id] ?? 0}
               onComplete={(questId) => handleComplete(questId, kid.id)}
               linkToKidView
             />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,6 +9,7 @@ import { createClient } from '@/lib/supabase/client'
 import { StarField } from '@/components/star-field'
 import { KidColumn } from '@/components/kid-column'
 import type { Kid, Quest, Completion, Family } from '@/lib/types'
+import { questDateString } from '@/lib/utils'
 import { toast } from 'sonner'
 
 export default function WallDisplay() {
@@ -29,18 +30,18 @@ export default function WallDisplay() {
     if (!profile) return
 
     const [familyRes, kidsRes, questsRes] = await Promise.all([
-      supabase.from('families').select('*').eq('id', profile.family_id).single(),
-      supabase.from('kids').select('*').eq('family_id', profile.family_id).order('created_at'),
+      supabase.from('families').select('id, name, invite_token, daily_reset_hour, created_at').eq('id', profile.family_id).single(),
+      supabase.from('kids').select('id, name, avatar, color, coins, streak, last_completed_date, family_id, created_at').eq('family_id', profile.family_id).order('created_at'),
       supabase.from('quests').select('*').eq('family_id', profile.family_id).eq('active', true).order('created_at'),
     ])
 
-    const today = new Date().toISOString().split('T')[0]
+    const today = questDateString(familyRes.data?.daily_reset_hour ?? 0)
     const { data: completionsData } = await supabase
       .from('completions')
       .select('*')
       .eq('date', today)
 
-    if (familyRes.data) setFamily(familyRes.data)
+    if (familyRes.data) setFamily({ ...familyRes.data, has_parent_pin: false })
     if (kidsRes.data) setKids(kidsRes.data)
     if (questsRes.data) setQuests(questsRes.data)
     if (completionsData) {
@@ -72,7 +73,7 @@ export default function WallDisplay() {
         quest_id: questId,
         kid_id: kidId,
         status: 'pending',
-        date: new Date().toISOString().split('T')[0],
+        date: questDateString(family?.daily_reset_hour ?? 0),
       })
 
       if (error) {
@@ -86,7 +87,7 @@ export default function WallDisplay() {
 
       await fetchData()
     },
-    [quests, supabase, fetchData]
+    [quests, supabase, fetchData, family?.daily_reset_hour]
   )
 
   const getKidQuests = (kid: Kid) =>

--- a/src/app/parent/page.tsx
+++ b/src/app/parent/page.tsx
@@ -9,7 +9,7 @@ import { useRouter } from 'next/navigation'
 import { createClient } from '@/lib/supabase/client'
 import { StarField } from '@/components/star-field'
 import { QuestCard } from '@/components/quest-card'
-import type { Kid, Quest, Completion, Reward, Redemption, Family } from '@/lib/types'
+import type { Kid, Quest, Completion, Reward, Redemption, Family, Curse, CurseInstance } from '@/lib/types'
 import { KID_COLORS, KID_AVATARS, QUEST_ICONS, DEFAULT_QUESTS, TIER_CONFIG, getLockDurationMs } from '@/lib/constants'
 import { questDateString } from '@/lib/utils'
 import type { QuestTier } from '@/lib/types'
@@ -18,7 +18,7 @@ import { toast } from 'sonner'
 
 const PARENT_PIN_SESSION_KEY = 'cq_parent_unlocked'
 
-type Tab = 'approvals' | 'quests' | 'family' | 'rewards'
+type Tab = 'approvals' | 'quests' | 'family' | 'rewards' | 'curses'
 
 export default function ParentDashboard() {
   const [tab, setTab] = useState<Tab>('approvals')
@@ -28,6 +28,8 @@ export default function ParentDashboard() {
   const [completions, setCompletions] = useState<Completion[]>([])
   const [rewards, setRewards] = useState<Reward[]>([])
   const [redemptions, setRedemptions] = useState<Redemption[]>([])
+  const [curses, setCurses] = useState<Curse[]>([])
+  const [activeCurseInstances, setActiveCurseInstances] = useState<CurseInstance[]>([])
   const [loading, setLoading] = useState(true)
 
   // Forms
@@ -47,6 +49,10 @@ export default function ParentDashboard() {
   const [newRewardDesc, setNewRewardDesc] = useState('')
   const [newRewardIcon, setNewRewardIcon] = useState('🎁')
   const [newRewardCost, setNewRewardCost] = useState(50)
+  const [newCurseTitle, setNewCurseTitle] = useState('')
+  const [newCurseIcon, setNewCurseIcon] = useState('☠️')
+  const [newCursePenalty, setNewCursePenalty] = useState(10)
+  const [castingCurseId, setCastingCurseId] = useState<string | null>(null)
   const [familyName, setFamilyName] = useState('')
   const [savingFamily, setSavingFamily] = useState(false)
   const [parentLocked, setParentLocked] = useState(false)
@@ -75,13 +81,15 @@ export default function ParentDashboard() {
 
     const kidCols = 'id, name, avatar, color, coins, streak, last_completed_date, family_id, created_at'
 
-    const [familyRes, kidsRes, questsRes, completionsRes, rewardsRes, redemptionsRes] = await Promise.all([
+    const [familyRes, kidsRes, questsRes, completionsRes, rewardsRes, redemptionsRes, cursesRes, curseInstancesRes] = await Promise.all([
       supabase.from('families').select('id, name, invite_token, api_key, daily_reset_hour, created_at, parent_pin').eq('id', profile.family_id).single(),
       supabase.from('kids').select(kidCols).eq('family_id', profile.family_id).order('created_at'),
       supabase.from('quests').select('*').eq('family_id', profile.family_id).order('created_at'),
       supabase.from('completions').select(`*, quest:quests(*), kid:kids(${kidCols})`).eq('date', today).order('completed_at', { ascending: false }),
       supabase.from('rewards').select('*').eq('family_id', profile.family_id).order('created_at'),
       supabase.from('redemptions').select(`*, reward:rewards(*), kid:kids(${kidCols})`).eq('status', 'pending').order('redeemed_at', { ascending: false }),
+      supabase.from('curses').select('*').eq('family_id', profile.family_id).order('created_at'),
+      supabase.from('curse_instances').select(`*, curse:curses(*), kid:kids(${kidCols})`).eq('status', 'active').order('cast_at', { ascending: false }),
     ])
 
     if (familyRes.data) {
@@ -94,6 +102,8 @@ export default function ParentDashboard() {
     if (completionsRes.data) setCompletions(completionsRes.data)
     if (rewardsRes.data) setRewards(rewardsRes.data)
     if (redemptionsRes.data) setRedemptions(redemptionsRes.data)
+    if (cursesRes.data) setCurses(cursesRes.data)
+    if (curseInstancesRes.data) setActiveCurseInstances(curseInstancesRes.data as CurseInstance[])
     setLoading(false)
   }, [supabase])
 
@@ -425,6 +435,55 @@ export default function ParentDashboard() {
     await fetchData()
   }
 
+  const handleAddCurse = async () => {
+    if (!newCurseTitle.trim() || !family) return
+    const { error } = await supabase.from('curses').insert({
+      family_id: family.id,
+      title: newCurseTitle.trim(),
+      icon: newCurseIcon,
+      penalty: newCursePenalty,
+    })
+    if (!error) {
+      toast.success('Curse added to the arsenal! ☠️')
+      setNewCurseTitle('')
+      await fetchData()
+    }
+  }
+
+  const handleCastCurse = async (curseId: string, kidId: string) => {
+    const curse = curses.find(c => c.id === curseId)
+    const kid = kids.find(k => k.id === kidId)
+    if (!curse || !kid) return
+
+    const { error: instanceError } = await supabase.from('curse_instances').insert({
+      curse_id: curseId,
+      kid_id: kidId,
+      coins_deducted: curse.penalty,
+      status: 'active',
+    })
+    if (instanceError) { toast.error('Failed to cast curse'); return }
+
+    await supabase.from('kids').update({ coins: Math.max(0, kid.coins - curse.penalty) }).eq('id', kidId)
+    toast.success(`${curse.icon} ${curse.title} cast on ${kid.name}! −${curse.penalty} coins`)
+    setCastingCurseId(null)
+    await fetchData()
+  }
+
+  const handleResolveCurse = async (instanceId: string, refund: boolean) => {
+    const instance = activeCurseInstances.find(ci => ci.id === instanceId)
+    const kid = instance?.kid as Kid | undefined
+    if (!instance || !kid) return
+
+    await supabase.from('curse_instances').update({ status: 'resolved', resolved_at: new Date().toISOString() }).eq('id', instanceId)
+    if (refund) {
+      await supabase.from('kids').update({ coins: kid.coins + instance.coins_deducted }).eq('id', kid.id)
+      toast.success(`Curse lifted — ${instance.coins_deducted} coins refunded to ${kid.name}`)
+    } else {
+      toast.success('Curse resolved')
+    }
+    await fetchData()
+  }
+
   const pendingCompletions = completions.filter((c) => c.status === 'pending')
   const pendingRedemptions = redemptions.filter((r) => r.status === 'pending')
 
@@ -524,8 +583,9 @@ export default function ParentDashboard() {
   const tabs: { id: Tab; label: string; badge?: number }[] = [
     { id: 'approvals', label: '✓ Approvals', badge: pendingCompletions.length + pendingRedemptions.length },
     { id: 'quests', label: '⚔️ Quests' },
-    { id: 'family', label: '👨‍👩‍👧 Family' },
     { id: 'rewards', label: '🎁 Rewards' },
+    { id: 'curses', label: '☠️ Curses', badge: activeCurseInstances.length || undefined },
+    { id: 'family', label: '👨‍👩‍👧 Family' },
   ]
 
   return (
@@ -1184,6 +1244,162 @@ export default function ParentDashboard() {
                   </div>
                 </Section>
               )}
+            </motion.div>
+          )}
+
+          {tab === 'curses' && (
+            <motion.div key="curses" {...fadeSlide} className="flex flex-col gap-6">
+              {/* Define curses */}
+              <Section title="Define Curses">
+                <div className="flex flex-col gap-3">
+                  <p className="text-white/45 text-xs">
+                    Create named penalties you can cast instantly when bad behavior happens.
+                  </p>
+                  <div className="flex gap-2 flex-wrap">
+                    {['☠️','😈','🌩️','🔥','💀','👿','🦂','🕸️'].map((icon) => (
+                      <button
+                        key={icon}
+                        onClick={() => setNewCurseIcon(icon)}
+                        className="text-xl w-10 h-10 rounded-xl transition-all"
+                        style={{
+                          background: newCurseIcon === icon ? 'rgba(239,68,68,0.2)' : 'rgba(255,255,255,0.05)',
+                          border: `1px solid ${newCurseIcon === icon ? 'rgba(239,68,68,0.4)' : 'rgba(255,255,255,0.08)'}`,
+                        }}
+                      >
+                        {icon}
+                      </button>
+                    ))}
+                  </div>
+                  <FormInput placeholder="Curse name (e.g. Whining, Tantrum)..." value={newCurseTitle} onChange={setNewCurseTitle} />
+                  <div>
+                    <label className="text-xs text-white/40 mb-1 block">Coin penalty</label>
+                    <input
+                      type="number"
+                      min={1}
+                      max={200}
+                      value={newCursePenalty}
+                      onChange={(e) => setNewCursePenalty(Number(e.target.value))}
+                      className="w-full px-3 py-2.5 rounded-xl text-sm text-white/90 outline-none"
+                      style={{ background: 'rgba(255,255,255,0.06)', border: '1px solid rgba(255,255,255,0.1)' }}
+                    />
+                  </div>
+                  <motion.button
+                    onClick={handleAddCurse}
+                    disabled={!newCurseTitle.trim()}
+                    className="w-full py-2.5 rounded-xl text-sm font-bold transition-all disabled:opacity-40"
+                    style={{ background: 'rgba(239,68,68,0.15)', border: '1px solid rgba(239,68,68,0.35)', color: '#f87171' }}
+                    whileHover={{ background: 'rgba(239,68,68,0.22)' }}
+                    whileTap={{ scale: 0.98 }}
+                  >
+                    + Add Curse
+                  </motion.button>
+
+                  {curses.length > 0 && (
+                    <div className="flex flex-col gap-2 mt-1">
+                      {curses.map(curse => (
+                        <div
+                          key={curse.id}
+                          className="flex items-center gap-3 p-3 rounded-xl"
+                          style={{ background: 'rgba(239,68,68,0.06)', border: '1px solid rgba(239,68,68,0.15)' }}
+                        >
+                          <span className="text-xl">{curse.icon}</span>
+                          <div className="flex-1">
+                            <p className="text-white/85 text-sm font-semibold">{curse.title}</p>
+                            <p className="text-red-400/60 text-xs">−{curse.penalty} coins</p>
+                          </div>
+                          {/* Cast button */}
+                          {castingCurseId === curse.id ? (
+                            <div className="flex gap-1 flex-wrap">
+                              {kids.map(k => (
+                                <button
+                                  key={k.id}
+                                  onClick={() => handleCastCurse(curse.id, k.id)}
+                                  className="px-2.5 py-1 rounded-lg text-xs font-bold transition-all"
+                                  style={{ background: 'rgba(239,68,68,0.2)', border: '1px solid rgba(239,68,68,0.35)', color: '#f87171' }}
+                                >
+                                  {k.avatar} {k.name}
+                                </button>
+                              ))}
+                              <button
+                                onClick={() => setCastingCurseId(null)}
+                                className="px-2 py-1 rounded-lg text-xs text-white/30 hover:text-white/60 transition-all"
+                              >
+                                ✕
+                              </button>
+                            </div>
+                          ) : (
+                            <div className="flex items-center gap-2">
+                              <button
+                                onClick={() => setCastingCurseId(curse.id)}
+                                className="px-3 py-1.5 rounded-xl text-xs font-bold transition-all"
+                                style={{ background: 'rgba(239,68,68,0.15)', border: '1px solid rgba(239,68,68,0.3)', color: '#f87171' }}
+                              >
+                                Cast ⚡
+                              </button>
+                              <button
+                                onClick={async () => {
+                                  await supabase.from('curses').delete().eq('id', curse.id)
+                                  await fetchData()
+                                }}
+                                className="text-white/20 hover:text-red-400 transition-all text-xs"
+                              >
+                                ✕
+                              </button>
+                            </div>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </Section>
+
+              {/* Active curses */}
+              <Section title="Active Afflictions">
+                {activeCurseInstances.length === 0 ? (
+                  <Empty icon="✨" message="No active curses — all is well!" />
+                ) : (
+                  <div className="flex flex-col gap-2">
+                    {activeCurseInstances.map(ci => {
+                      const curse = ci.curse as Curse | undefined
+                      const kid = ci.kid as Kid | undefined
+                      return (
+                        <div
+                          key={ci.id}
+                          className="flex items-center gap-3 p-3 rounded-xl"
+                          style={{ background: 'rgba(239,68,68,0.07)', border: '1px solid rgba(239,68,68,0.2)' }}
+                        >
+                          <span className="text-xl">{curse?.icon ?? '☠️'}</span>
+                          <div className="flex-1 min-w-0">
+                            <p className="text-white/85 text-sm font-semibold truncate">{curse?.title ?? 'Curse'}</p>
+                            <p className="text-white/40 text-xs">
+                              {kid?.avatar} {kid?.name} · −{ci.coins_deducted} coins
+                            </p>
+                          </div>
+                          <div className="flex gap-1.5 flex-shrink-0">
+                            <button
+                              onClick={() => handleResolveCurse(ci.id, true)}
+                              className="px-2.5 py-1 rounded-lg text-xs font-bold transition-all"
+                              style={{ background: 'rgba(74,222,128,0.12)', border: '1px solid rgba(74,222,128,0.25)', color: '#4ade80' }}
+                              title="Lift curse and refund coins"
+                            >
+                              ↩ Forgive
+                            </button>
+                            <button
+                              onClick={() => handleResolveCurse(ci.id, false)}
+                              className="px-2.5 py-1 rounded-lg text-xs font-bold transition-all"
+                              style={{ background: 'rgba(255,255,255,0.06)', border: '1px solid rgba(255,255,255,0.1)', color: 'rgba(255,255,255,0.5)' }}
+                              title="Resolve without refund"
+                            >
+                              Resolve
+                            </button>
+                          </div>
+                        </div>
+                      )
+                    })}
+                  </div>
+                )}
+              </Section>
             </motion.div>
           )}
 

--- a/src/app/parent/page.tsx
+++ b/src/app/parent/page.tsx
@@ -11,6 +11,7 @@ import { StarField } from '@/components/star-field'
 import { QuestCard } from '@/components/quest-card'
 import type { Kid, Quest, Completion, Reward, Redemption, Family } from '@/lib/types'
 import { KID_COLORS, KID_AVATARS, QUEST_ICONS, DEFAULT_QUESTS, TIER_CONFIG, getLockDurationMs } from '@/lib/constants'
+import { questDateString } from '@/lib/utils'
 import type { QuestTier } from '@/lib/types'
 import QRCode from 'react-qr-code'
 import { toast } from 'sonner'
@@ -68,12 +69,14 @@ export default function ParentDashboard() {
     const { data: profile } = await supabase.from('profiles').select('family_id').single()
     if (!profile) return
 
-    const today = new Date().toISOString().split('T')[0]
+    // Fetch reset hour first so today is always computed against the correct boundary
+    const { data: resetData } = await supabase.from('families').select('daily_reset_hour').eq('id', profile.family_id).single()
+    const today = questDateString(resetData?.daily_reset_hour ?? 0)
 
     const kidCols = 'id, name, avatar, color, coins, streak, last_completed_date, family_id, created_at'
 
     const [familyRes, kidsRes, questsRes, completionsRes, rewardsRes, redemptionsRes] = await Promise.all([
-      supabase.from('families').select('id, name, invite_token, api_key, created_at, parent_pin').eq('id', profile.family_id).single(),
+      supabase.from('families').select('id, name, invite_token, api_key, daily_reset_hour, created_at, parent_pin').eq('id', profile.family_id).single(),
       supabase.from('kids').select(kidCols).eq('family_id', profile.family_id).order('created_at'),
       supabase.from('quests').select('*').eq('family_id', profile.family_id).order('created_at'),
       supabase.from('completions').select(`*, quest:quests(*), kid:kids(${kidCols})`).eq('date', today).order('completed_at', { ascending: false }),
@@ -83,7 +86,7 @@ export default function ParentDashboard() {
 
     if (familyRes.data) {
       const { parent_pin, ...rest } = familyRes.data
-      setFamily({ ...rest, has_parent_pin: parent_pin !== null, api_key: rest.api_key ?? undefined })
+      setFamily({ ...rest, has_parent_pin: parent_pin !== null, api_key: rest.api_key ?? undefined, daily_reset_hour: rest.daily_reset_hour ?? 0 })
       setFamilyName(familyRes.data.name)
     }
     if (kidsRes.data) setKids(kidsRes.data)
@@ -144,7 +147,7 @@ export default function ParentDashboard() {
         .update({ coins: (completion.kid?.coins ?? 0) + coinsAwarded })
         .eq('id', completion.kid_id)
 
-      const today = new Date().toISOString().split('T')[0]
+      const today = questDateString(family?.daily_reset_hour ?? 0)
       const lastDate = completion.kid?.last_completed_date
       const newStreak = lastDate === yesterday() ? (completion.kid?.streak ?? 0) + 1 : 1
 
@@ -269,6 +272,13 @@ export default function ParentDashboard() {
       setNewRewardDesc('')
       await fetchData()
     }
+  }
+
+  const handleSaveResetHour = async (hour: number) => {
+    if (!family) return
+    await supabase.from('families').update({ daily_reset_hour: hour }).eq('id', family.id)
+    toast.success('Daily reset time updated!')
+    await fetchData()
   }
 
   const handleSaveFamilyName = async () => {
@@ -844,6 +854,53 @@ export default function ParentDashboard() {
                 </div>
               </Section>
 
+              {/* Daily reset */}
+              <Section title="Daily Quest Reset">
+                <div className="flex flex-col gap-3">
+                  <p className="text-white/45 text-xs">
+                    Quests reset each day at this time
+                    {typeof window !== 'undefined' && (
+                      <span className="text-white/30"> · {Intl.DateTimeFormat().resolvedOptions().timeZone}</span>
+                    )}
+                  </p>
+                  <div className="grid grid-cols-4 gap-2">
+                    {([0, 3, 5, 6] as const).map((h) => {
+                      const label = h === 0 ? '12 AM' : `${h} AM`
+                      const selected = (family?.daily_reset_hour ?? 0) === h
+                      return (
+                        <button
+                          key={h}
+                          onClick={() => handleSaveResetHour(h)}
+                          className="py-2.5 rounded-xl text-sm font-semibold transition-all"
+                          style={{
+                            background: selected ? 'rgba(251,191,36,0.14)' : 'rgba(255,255,255,0.05)',
+                            border: `1px solid ${selected ? 'rgba(251,191,36,0.35)' : 'rgba(255,255,255,0.08)'}`,
+                            color: selected ? '#fbbf24' : 'rgba(255,255,255,0.5)',
+                          }}
+                        >
+                          {label}
+                        </button>
+                      )
+                    })}
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <label className="text-xs text-white/30 flex-shrink-0">Custom hour (0–23):</label>
+                    <input
+                      type="number"
+                      min={0}
+                      max={23}
+                      value={family?.daily_reset_hour ?? 0}
+                      onChange={(e) => {
+                        const v = Math.max(0, Math.min(23, parseInt(e.target.value, 10) || 0))
+                        handleSaveResetHour(v)
+                      }}
+                      className="w-16 px-2 py-1 rounded-lg text-xs text-white/90 outline-none"
+                      style={{ background: 'rgba(255,255,255,0.06)', border: '1px solid rgba(255,255,255,0.1)' }}
+                    />
+                  </div>
+                </div>
+              </Section>
+
               {/* Parent lock */}
               <Section title="Parent Lock">
                 {family?.has_parent_pin ? (
@@ -1410,7 +1467,7 @@ function getStreakBonus(streak: number): number {
 function yesterday(): string {
   const d = new Date()
   d.setDate(d.getDate() - 1)
-  return d.toISOString().split('T')[0]
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
 }
 
 const fadeSlide = {

--- a/src/components/kid-column.tsx
+++ b/src/components/kid-column.tsx
@@ -150,14 +150,14 @@ export function KidColumn({
       </motion.div>
 
       {/* Quest list */}
-      <div className="flex flex-col gap-2.5 flex-1 overflow-y-auto scrollbar-thin-glass min-h-0 pb-1">
-        {quests.length === 0 ? (
-          <div className="flex flex-col items-center justify-center h-32 text-white/25">
-            <span className="text-3xl mb-2">🧙</span>
-            <p className="text-sm">No quests yet</p>
-          </div>
-        ) : (
-          quests.map((quest, i) => (
+      {(() => {
+        const personalQuests = quests.filter(q => q.weekly_target == null && !q.exclusive)
+        const bountyQuests = quests.filter(q => q.weekly_target != null || q.exclusive)
+        let cardIndex = 0
+
+        const renderCard = (quest: Quest) => {
+          const i = cardIndex++
+          return (
             <motion.div
               key={quest.id}
               initial={{ opacity: 0, x: -12 }}
@@ -176,9 +176,48 @@ export function KidColumn({
                 onReject={onReject}
               />
             </motion.div>
-          ))
-        )}
-      </div>
+          )
+        }
+
+        if (quests.length === 0) {
+          return (
+            <div className="flex flex-col gap-2.5 flex-1 overflow-y-auto scrollbar-thin-glass min-h-0 pb-1">
+              <div className="flex flex-col items-center justify-center h-32 text-white/25">
+                <span className="text-3xl mb-2">🧙</span>
+                <p className="text-sm">No quests yet</p>
+              </div>
+            </div>
+          )
+        }
+
+        return (
+          <div className="flex flex-col gap-2.5 flex-1 overflow-y-auto scrollbar-thin-glass min-h-0 pb-1">
+            {personalQuests.map(renderCard)}
+
+            {bountyQuests.length > 0 && (
+              <>
+                {/* Bounty section divider */}
+                <div className="flex items-center gap-2 py-1 mt-1">
+                  <div className="flex-1 h-px" style={{ background: 'rgba(251,191,36,0.2)' }} />
+                  <span
+                    className="text-xs font-bold tracking-widest uppercase px-2 py-0.5 rounded-full flex-shrink-0"
+                    style={{
+                      background: 'rgba(251,191,36,0.1)',
+                      border: '1px solid rgba(251,191,36,0.25)',
+                      color: 'rgba(251,191,36,0.75)',
+                    }}
+                  >
+                    ⚡ Bounties
+                  </span>
+                  <div className="flex-1 h-px" style={{ background: 'rgba(251,191,36,0.2)' }} />
+                </div>
+
+                {bountyQuests.map(renderCard)}
+              </>
+            )}
+          </div>
+        )
+      })()}
     </div>
   )
 }

--- a/src/components/kid-column.tsx
+++ b/src/components/kid-column.tsx
@@ -12,6 +12,9 @@ interface KidColumnProps {
   kid: Kid
   quests: Quest[]
   completions: Completion[]
+  today: string
+  claimedExclusiveIds?: Set<string>
+  activeCurseCount?: number
   onComplete?: (questId: string) => Promise<void>
   isParent?: boolean
   onApprove?: (completionId: string) => Promise<void>
@@ -23,6 +26,9 @@ export function KidColumn({
   kid,
   quests,
   completions,
+  today,
+  claimedExclusiveIds,
+  activeCurseCount = 0,
   onComplete,
   isParent,
   onApprove,
@@ -30,10 +36,25 @@ export function KidColumn({
   linkToKidView = true,
 }: KidColumnProps) {
   const colors = KID_COLORS[kid.color]
-  const getCompletion = (questId: string) =>
-    completions.find((c) => c.quest_id === questId && c.kid_id === kid.id)
 
-  const completedCount = completions.filter((c) => c.kid_id === kid.id && c.status === 'approved').length
+  const getCompletion = (quest: Quest): Completion | undefined => {
+    if (quest.frequency === 'weekly') {
+      return completions.find(c => c.quest_id === quest.id && c.kid_id === kid.id)
+    }
+    return completions.find(c => c.quest_id === quest.id && c.kid_id === kid.id && c.date === today)
+  }
+
+  const getWeeklyCount = (quest: Quest): number =>
+    completions.filter(c =>
+      c.quest_id === quest.id &&
+      c.kid_id === kid.id &&
+      (c.status === 'approved' || c.status === 'pending')
+    ).length
+
+  const completedCount = quests.filter(quest => {
+    if (quest.weekly_target != null) return getWeeklyCount(quest) >= quest.weekly_target
+    return getCompletion(quest)?.status === 'approved'
+  }).length
   const totalCount = quests.length
   const progress = totalCount > 0 ? completedCount / totalCount : 0
 
@@ -94,7 +115,19 @@ export function KidColumn({
 
         <CoinCounter value={kid.coins} size="md" />
 
-        {kid.streak > 1 && <StreakBadge streak={kid.streak} />}
+        <div className="flex items-center gap-2">
+          {kid.streak > 1 && <StreakBadge streak={kid.streak} />}
+          {activeCurseCount > 0 && (
+            <motion.span
+              className="text-xs px-2 py-0.5 rounded-full font-bold"
+              style={{ background: 'rgba(239,68,68,0.2)', border: '1px solid rgba(239,68,68,0.35)', color: '#f87171' }}
+              animate={{ scale: [1, 1.06, 1] }}
+              transition={{ duration: 2, repeat: Infinity }}
+            >
+              ☠️ {activeCurseCount} curse{activeCurseCount > 1 ? 's' : ''}
+            </motion.span>
+          )}
+        </div>
 
         {/* Progress bar */}
         {totalCount > 0 && (
@@ -133,7 +166,9 @@ export function KidColumn({
             >
               <QuestCard
                 quest={quest}
-                completion={getCompletion(quest.id)}
+                completion={getCompletion(quest)}
+                weeklyCount={quest.weekly_target != null ? getWeeklyCount(quest) : undefined}
+                isExclusiveLocked={quest.exclusive && !getCompletion(quest) && (claimedExclusiveIds?.has(quest.id) ?? false)}
                 kidColor={kid.color}
                 onComplete={onComplete ? () => onComplete(quest.id) : undefined}
                 isParent={isParent}

--- a/src/components/quest-card.tsx
+++ b/src/components/quest-card.tsx
@@ -20,6 +20,18 @@ interface QuestCardProps {
 
 const DAY_LABELS = ['S', 'M', 'T', 'W', 'T', 'F', 'S']
 
+function frequencyLabel(quest: Quest): string | null {
+  if (quest.frequency === 'once') return 'one-time'
+  if (quest.exclusive) return '1st claim wins'
+  if (quest.weekly_target != null) return `${quest.weekly_target}× per week`
+  if (quest.active_days && quest.active_days.length > 0 && quest.active_days.length < 7) {
+    const abbreviated = quest.active_days.map(d => DAY_LABELS[d]).join(' ')
+    return abbreviated
+  }
+  if (quest.frequency === 'weekly') return 'weekly'
+  return null // daily — obvious, no label needed
+}
+
 export function QuestCard({
   quest,
   completion,
@@ -38,11 +50,13 @@ export function QuestCard({
   const isWeeklyFull = quest.weekly_target != null && weeklyCount >= quest.weekly_target
   const status = completion?.status
   const isTodo = !isExclusiveLocked && !isWeeklyFull && !status
-  const isPending = status === 'pending'
+  const isPending = status === 'pending' && !isWeeklyFull
   const isApproved = status === 'approved' || isWeeklyFull
   const isRejected = status === 'rejected' && !isWeeklyFull
 
   const tier = TIER_CONFIG[quest.tier ?? 'normal']
+  const isNormal = (quest.tier ?? 'normal') === 'normal'
+  const hasCompletionState = isApproved || isPending || isRejected || isExclusiveLocked
 
   const cardBg = isApproved
     ? 'rgba(74, 222, 128, 0.06)'
@@ -68,7 +82,11 @@ export function QuestCard({
     ? '0 0 20px rgba(251, 191, 36, 0.12)'
     : isApproved
     ? '0 0 16px rgba(74, 222, 128, 0.1)'
+    : isExclusiveLocked
+    ? 'none'
     : tier.glow ?? 'none'
+
+  const freqLabel = frequencyLabel(quest)
 
   const handleComplete = async () => {
     if (!onComplete || loading || !isTodo) return
@@ -78,8 +96,6 @@ export function QuestCard({
     setLoading(false)
     setTimeout(() => setBursting(false), 1000)
   }
-
-  const showDays = quest.active_days && quest.active_days.length > 0 && quest.active_days.length < 7
 
   return (
     <motion.div
@@ -98,6 +114,47 @@ export function QuestCard({
     >
       <CoinBurst coins={quest.coins} active={bursting} />
 
+      {/* Tier accent bar — thin colored line at top */}
+      {!isNormal && !hasCompletionState && (
+        <div
+          className="absolute top-0 left-0 right-0 h-px"
+          style={{
+            background: `linear-gradient(90deg, transparent 0%, ${tier.color} 40%, ${tier.color} 60%, transparent 100%)`,
+            opacity: 0.8,
+          }}
+        />
+      )}
+
+      {/* Legendary shimmer sweep */}
+      {quest.tier === 'legendary' && !hasCompletionState && (
+        <motion.div
+          className="absolute inset-0 pointer-events-none rounded-2xl overflow-hidden"
+          initial={{ x: '-120%' }}
+          animate={{ x: '220%' }}
+          transition={{ duration: 2.4, repeat: Infinity, repeatDelay: 5, ease: 'easeInOut' }}
+        >
+          <div
+            className="absolute inset-y-0 w-1/3 -skew-x-12"
+            style={{ background: 'linear-gradient(90deg, transparent, rgba(251,191,36,0.1), transparent)' }}
+          />
+        </motion.div>
+      )}
+
+      {/* Epic shimmer — slower, purple */}
+      {quest.tier === 'epic' && !hasCompletionState && (
+        <motion.div
+          className="absolute inset-0 pointer-events-none rounded-2xl overflow-hidden"
+          initial={{ x: '-120%' }}
+          animate={{ x: '220%' }}
+          transition={{ duration: 3, repeat: Infinity, repeatDelay: 7, ease: 'easeInOut' }}
+        >
+          <div
+            className="absolute inset-y-0 w-1/3 -skew-x-12"
+            style={{ background: 'linear-gradient(90deg, transparent, rgba(167,139,250,0.12), transparent)' }}
+          />
+        </motion.div>
+      )}
+
       <div className="p-4">
         <div className="flex items-start gap-3">
           <span className="text-2xl leading-none mt-0.5 flex-shrink-0">{quest.icon}</span>
@@ -111,18 +168,12 @@ export function QuestCard({
               >
                 {quest.title}
               </p>
-              {(quest.tier ?? 'normal') !== 'normal' && (
+              {!isNormal && (
                 <span
-                  className="text-xs px-1.5 py-0.5 rounded-md font-semibold flex-shrink-0"
-                  style={{ background: tier.bg, color: tier.color, border: `1px solid ${tier.border}` }}
+                  className="text-xs px-1.5 py-0.5 rounded-md font-bold flex-shrink-0"
+                  style={{ background: `${tier.color}18`, color: tier.color, border: `1px solid ${tier.color}40` }}
                 >
                   {tier.label}
-                </span>
-              )}
-              {quest.exclusive && (
-                <span className="text-xs px-1.5 py-0.5 rounded-md font-semibold flex-shrink-0"
-                  style={{ background: 'rgba(251,191,36,0.1)', color: '#fbbf24', border: '1px solid rgba(251,191,36,0.2)' }}>
-                  1st only
                 </span>
               )}
             </div>
@@ -131,23 +182,33 @@ export function QuestCard({
               <p className="text-white/40 text-xs mt-0.5 truncate">{quest.description}</p>
             )}
 
-            {/* Day-of-week schedule */}
-            {showDays && (
-              <div className="flex gap-0.5 mt-1.5">
-                {DAY_LABELS.map((label, i) => (
-                  <span
-                    key={i}
-                    className="text-xs w-4 h-4 flex items-center justify-center rounded font-mono"
-                    style={{
-                      background: quest.active_days!.includes(i) ? 'rgba(255,255,255,0.12)' : 'transparent',
-                      color: quest.active_days!.includes(i) ? 'rgba(255,255,255,0.7)' : 'rgba(255,255,255,0.18)',
-                    }}
-                  >
-                    {label}
-                  </span>
-                ))}
-              </div>
-            )}
+            {/* Frequency / schedule info */}
+            <div className="flex items-center gap-2 mt-1.5 flex-wrap">
+              {freqLabel && (
+                <span className="text-xs px-1.5 py-0.5 rounded-md"
+                  style={{ background: 'rgba(255,255,255,0.06)', color: 'rgba(255,255,255,0.4)', border: '1px solid rgba(255,255,255,0.08)' }}>
+                  {freqLabel}
+                </span>
+              )}
+
+              {/* Day-of-week pills inline with freq label */}
+              {quest.active_days && quest.active_days.length > 0 && quest.active_days.length < 7 && (
+                <div className="flex gap-0.5">
+                  {DAY_LABELS.map((label, i) => (
+                    <span
+                      key={i}
+                      className="text-xs w-4 h-4 flex items-center justify-center rounded font-mono"
+                      style={{
+                        background: quest.active_days!.includes(i) ? 'rgba(255,255,255,0.12)' : 'transparent',
+                        color: quest.active_days!.includes(i) ? 'rgba(255,255,255,0.7)' : 'rgba(255,255,255,0.18)',
+                      }}
+                    >
+                      {label}
+                    </span>
+                  ))}
+                </div>
+              )}
+            </div>
 
             {/* Weekly target progress */}
             {quest.weekly_target != null && (
@@ -160,9 +221,11 @@ export function QuestCard({
           <div className="flex-shrink-0 text-right">
             <div className="flex items-center gap-1 justify-end">
               <span className="text-sm">🪙</span>
-              <span className="font-heading font-bold text-cq-gold text-sm">{quest.coins}</span>
+              <span className="font-heading font-bold text-sm" style={{ color: isNormal ? '#fbbf24' : tier.color }}>
+                {quest.coins}
+              </span>
             </div>
-            {isPending && !isWeeklyFull && (
+            {isPending && (
               <motion.p
                 className="text-xs text-amber-400 mt-0.5"
                 animate={{ opacity: [0.5, 1, 0.5] }}

--- a/src/components/quest-card.tsx
+++ b/src/components/quest-card.tsx
@@ -9,6 +9,8 @@ import { CoinBurst } from './coin-burst'
 interface QuestCardProps {
   quest: Quest
   completion?: Completion
+  weeklyCount?: number
+  isExclusiveLocked?: boolean
   kidColor: KidColor
   onComplete?: () => Promise<void>
   isParent?: boolean
@@ -16,9 +18,13 @@ interface QuestCardProps {
   onReject?: (completionId: string) => Promise<void>
 }
 
+const DAY_LABELS = ['S', 'M', 'T', 'W', 'T', 'F', 'S']
+
 export function QuestCard({
   quest,
   completion,
+  weeklyCount = 0,
+  isExclusiveLocked = false,
   kidColor,
   onComplete,
   isParent,
@@ -29,11 +35,12 @@ export function QuestCard({
   const [bursting, setBursting] = useState(false)
   const colors = KID_COLORS[kidColor]
 
+  const isWeeklyFull = quest.weekly_target != null && weeklyCount >= quest.weekly_target
   const status = completion?.status
-  const isTodo = !status
+  const isTodo = !isExclusiveLocked && !isWeeklyFull && !status
   const isPending = status === 'pending'
-  const isApproved = status === 'approved'
-  const isRejected = status === 'rejected'
+  const isApproved = status === 'approved' || isWeeklyFull
+  const isRejected = status === 'rejected' && !isWeeklyFull
 
   const tier = TIER_CONFIG[quest.tier ?? 'normal']
 
@@ -43,6 +50,8 @@ export function QuestCard({
     ? 'rgba(251, 191, 36, 0.06)'
     : isRejected
     ? 'rgba(239, 68, 68, 0.05)'
+    : isExclusiveLocked
+    ? 'rgba(255,255,255,0.02)'
     : tier.bg
 
   const cardBorder = isApproved
@@ -51,6 +60,8 @@ export function QuestCard({
     ? 'rgba(251, 191, 36, 0.35)'
     : isRejected
     ? 'rgba(239, 68, 68, 0.2)'
+    : isExclusiveLocked
+    ? 'rgba(255,255,255,0.06)'
     : tier.border
 
   const cardShadow = isPending
@@ -68,6 +79,8 @@ export function QuestCard({
     setTimeout(() => setBursting(false), 1000)
   }
 
+  const showDays = quest.active_days && quest.active_days.length > 0 && quest.active_days.length < 7
+
   return (
     <motion.div
       className="relative rounded-2xl overflow-hidden"
@@ -76,6 +89,7 @@ export function QuestCard({
         border: `1px solid ${cardBorder}`,
         boxShadow: cardShadow,
         backdropFilter: 'blur(10px)',
+        opacity: isExclusiveLocked ? 0.45 : 1,
       }}
       whileHover={isTodo && onComplete ? { scale: 1.015 } : {}}
       whileTap={isTodo && onComplete ? { scale: 0.985 } : {}}
@@ -92,7 +106,7 @@ export function QuestCard({
             <div className="flex items-center gap-1.5 flex-wrap">
               <p
                 className={`font-semibold text-sm leading-snug ${
-                  isApproved ? 'line-through opacity-40' : 'text-white/90'
+                  isApproved ? 'line-through opacity-40' : isExclusiveLocked ? 'text-white/35' : 'text-white/90'
                 }`}
               >
                 {quest.title}
@@ -105,9 +119,41 @@ export function QuestCard({
                   {tier.label}
                 </span>
               )}
+              {quest.exclusive && (
+                <span className="text-xs px-1.5 py-0.5 rounded-md font-semibold flex-shrink-0"
+                  style={{ background: 'rgba(251,191,36,0.1)', color: '#fbbf24', border: '1px solid rgba(251,191,36,0.2)' }}>
+                  1st only
+                </span>
+              )}
             </div>
+
             {quest.description && (
               <p className="text-white/40 text-xs mt-0.5 truncate">{quest.description}</p>
+            )}
+
+            {/* Day-of-week schedule */}
+            {showDays && (
+              <div className="flex gap-0.5 mt-1.5">
+                {DAY_LABELS.map((label, i) => (
+                  <span
+                    key={i}
+                    className="text-xs w-4 h-4 flex items-center justify-center rounded font-mono"
+                    style={{
+                      background: quest.active_days!.includes(i) ? 'rgba(255,255,255,0.12)' : 'transparent',
+                      color: quest.active_days!.includes(i) ? 'rgba(255,255,255,0.7)' : 'rgba(255,255,255,0.18)',
+                    }}
+                  >
+                    {label}
+                  </span>
+                ))}
+              </div>
+            )}
+
+            {/* Weekly target progress */}
+            {quest.weekly_target != null && (
+              <p className="text-xs mt-1" style={{ color: isWeeklyFull ? '#4ade80' : 'rgba(255,255,255,0.4)' }}>
+                {isWeeklyFull ? '✓ ' : ''}{weeklyCount}/{quest.weekly_target}× this week
+              </p>
             )}
           </div>
 
@@ -116,7 +162,7 @@ export function QuestCard({
               <span className="text-sm">🪙</span>
               <span className="font-heading font-bold text-cq-gold text-sm">{quest.coins}</span>
             </div>
-            {isPending && (
+            {isPending && !isWeeklyFull && (
               <motion.p
                 className="text-xs text-amber-400 mt-0.5"
                 animate={{ opacity: [0.5, 1, 0.5] }}
@@ -125,11 +171,14 @@ export function QuestCard({
                 awaiting...
               </motion.p>
             )}
-            {isApproved && (
+            {isApproved && !isPending && (
               <p className="text-xs text-cq-forest mt-0.5">✓ done!</p>
             )}
             {isRejected && (
               <p className="text-xs text-red-400 mt-0.5">✗ retry</p>
+            )}
+            {isExclusiveLocked && (
+              <p className="text-xs text-white/30 mt-0.5">claimed</p>
             )}
           </div>
         </div>

--- a/src/lib/__tests__/utils.test.ts
+++ b/src/lib/__tests__/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { isValidPin } from '../utils'
+import { isValidPin, questDateString } from '../utils'
 
 describe('isValidPin', () => {
   it('accepts exactly 4 numeric digits', () => {
@@ -39,5 +39,35 @@ describe('isValidPin', () => {
     expect(isValidPin(' 1234')).toBe(false)
     expect(isValidPin('1234 ')).toBe(false)
     expect(isValidPin(' 1234 ')).toBe(false)
+  })
+})
+
+describe('questDateString', () => {
+  const date = (h: number, min = 0) => {
+    const d = new Date(2025, 5, 15, h, min) // 2025-06-15, local time
+    return d
+  }
+
+  it('returns today when current hour is at or after resetHour', () => {
+    expect(questDateString(0, date(0))).toBe('2025-06-15')   // midnight reset, midnight
+    expect(questDateString(3, date(3))).toBe('2025-06-15')   // 3 AM reset, exactly 3 AM
+    expect(questDateString(3, date(9))).toBe('2025-06-15')   // 3 AM reset, 9 AM
+    expect(questDateString(6, date(23))).toBe('2025-06-15')  // 6 AM reset, 11 PM
+  })
+
+  it('returns yesterday when current hour is before resetHour', () => {
+    expect(questDateString(3, date(2))).toBe('2025-06-14')   // 3 AM reset, 2 AM → still yesterday
+    expect(questDateString(6, date(5))).toBe('2025-06-14')   // 6 AM reset, 5 AM → still yesterday
+    expect(questDateString(3, date(0))).toBe('2025-06-14')   // 3 AM reset, midnight → still yesterday
+  })
+
+  it('defaults to midnight reset (resetHour=0)', () => {
+    expect(questDateString(0, date(0))).toBe('2025-06-15')
+    expect(questDateString(0, date(23, 59))).toBe('2025-06-15')
+  })
+
+  it('handles month boundary correctly', () => {
+    const lastDayOfMonth = new Date(2025, 5, 1, 2) // June 1 at 2 AM, resetHour=3
+    expect(questDateString(3, lastDayOfMonth)).toBe('2025-05-31') // rolls back to May 31
   })
 })

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -9,36 +9,36 @@ export const TIER_CONFIG: Record<QuestTier, {
   glow: string | null
 }> = {
   normal: {
-    label: 'Normal',
+    label: 'Common',
     icon: '⚔️',
     color: 'rgba(255,255,255,0.55)',
-    bg: 'rgba(255,255,255,0.05)',
-    border: 'rgba(255,255,255,0.12)',
+    bg: 'rgba(255,255,255,0.04)',
+    border: 'rgba(255,255,255,0.1)',
     glow: null,
   },
   heroic: {
     label: 'Heroic',
     icon: '🔵',
     color: '#38bdf8',
-    bg: 'rgba(56,189,248,0.08)',
-    border: 'rgba(56,189,248,0.25)',
-    glow: null,
+    bg: 'linear-gradient(135deg, rgba(56,189,248,0.14) 0%, rgba(56,189,248,0.05) 100%)',
+    border: 'rgba(56,189,248,0.48)',
+    glow: '0 0 20px rgba(56,189,248,0.2), 0 0 0 1px rgba(56,189,248,0.14)',
   },
   legendary: {
     label: 'Legendary',
     icon: '🌟',
     color: '#fbbf24',
-    bg: 'rgba(251,191,36,0.08)',
-    border: 'rgba(251,191,36,0.28)',
-    glow: null,
+    bg: 'linear-gradient(135deg, rgba(251,191,36,0.18) 0%, rgba(251,191,36,0.07) 100%)',
+    border: 'rgba(251,191,36,0.55)',
+    glow: '0 0 28px rgba(251,191,36,0.28), 0 0 0 1px rgba(251,191,36,0.2)',
   },
   epic: {
     label: 'Epic',
     icon: '💜',
     color: '#a78bfa',
-    bg: 'rgba(167,139,250,0.1)',
-    border: 'rgba(167,139,250,0.3)',
-    glow: '0 0 20px rgba(167,139,250,0.2)',
+    bg: 'linear-gradient(135deg, rgba(167,139,250,0.18) 0%, rgba(167,139,250,0.07) 100%)',
+    border: 'rgba(167,139,250,0.55)',
+    glow: '0 0 28px rgba(167,139,250,0.28), 0 0 0 1px rgba(167,139,250,0.2)',
   },
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -9,6 +9,7 @@ export interface Family {
   has_parent_pin: boolean
   invite_token: string
   api_key?: string
+  daily_reset_hour: number
   created_at: string
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -43,7 +43,31 @@ export interface Quest {
   frequency: QuestFrequency
   tier: QuestTier
   active: boolean
+  exclusive: boolean
+  active_days: number[] | null
+  weekly_target: number | null
   created_at: string
+}
+
+export interface Curse {
+  id: string
+  family_id: string
+  title: string
+  icon: string
+  penalty: number
+  created_at: string
+}
+
+export interface CurseInstance {
+  id: string
+  curse_id: string
+  kid_id: string
+  status: 'active' | 'resolved'
+  cast_at: string
+  resolved_at: string | null
+  coins_deducted: number
+  curse?: Curse
+  kid?: Kid
 }
 
 export interface Completion {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -9,3 +9,24 @@ export function cn(...inputs: ClassValue[]) {
 export function isValidPin(pin: unknown): pin is string {
   return typeof pin === 'string' && /^\d{4}$/.test(pin)
 }
+
+/** Returns a date as YYYY-MM-DD in the browser's local timezone. */
+export function localDateString(date = new Date()): string {
+  const y = date.getFullYear()
+  const m = String(date.getMonth() + 1).padStart(2, '0')
+  const d = String(date.getDate()).padStart(2, '0')
+  return `${y}-${m}-${d}`
+}
+
+/**
+ * Returns the effective quest-day date string (YYYY-MM-DD).
+ * Before `resetHour` each day, completions still belong to the previous day.
+ * e.g. resetHour=3 means dailies reset at 3 AM — 1 AM is still "yesterday".
+ */
+export function questDateString(resetHour = 0, now = new Date()): string {
+  const effective = new Date(now)
+  if (now.getHours() < resetHour) {
+    effective.setDate(effective.getDate() - 1)
+  }
+  return localDateString(effective)
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -30,3 +30,19 @@ export function questDateString(resetHour = 0, now = new Date()): string {
   }
   return localDateString(effective)
 }
+
+/**
+ * Returns the Monday of the current quest-week as YYYY-MM-DD.
+ * Used to scope "weekly" and weekly_target quest completions.
+ */
+export function questWeekKey(resetHour = 0, now = new Date()): string {
+  const effective = new Date(now)
+  if (now.getHours() < resetHour) {
+    effective.setDate(effective.getDate() - 1)
+  }
+  const day = effective.getDay() // 0=Sun … 6=Sat
+  const daysFromMonday = day === 0 ? 6 : day - 1
+  const monday = new Date(effective)
+  monday.setDate(effective.getDate() - daysFromMonday)
+  return localDateString(monday)
+}

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -9,6 +9,7 @@ create table families (
   parent_pin text check (parent_pin ~ '^[0-9]{4}$'), -- optional 4-digit lock PIN
   invite_token uuid not null default gen_random_uuid() unique,
   api_key uuid not null default gen_random_uuid() unique,
+  daily_reset_hour integer not null default 0 check (daily_reset_hour >= 0 and daily_reset_hour <= 23),
   created_at timestamptz default now()
 );
 


### PR DESCRIPTION
## Summary

- **Tier-based quest cards**: loot-rarity visual treatment (common/heroic/epic/legendary) with gradient backgrounds, glow shadows, and shimmer animations for legendary/epic
- **Frequency display on cards**: schedule pill badge shows "3× per week", "M W F", "1st claim wins", etc. with day-of-week grid
- **Recurring quests**: `active_days` (day-of-week scheduling), `weekly_target` (N×/week cap), `exclusive` (first-claim-only)
- **Curses system**: parent defines templates, casts with immediate coin deduction, kids see active afflictions, parent can Forgive (refund) or Resolve (no refund)
- **Bounty section split**: KidColumn splits into personal daily quests + ⚡ Bounties section (weekly bounties and exclusive quests)
- **Configurable daily reset hour**: family can set what time the quest day resets

## Test plan

- [ ] Verify tier card visuals appear correctly (heroic blue, epic purple, legendary gold shimmer)
- [ ] Confirm frequency labels show on cards
- [ ] Test weekly_target quest caps work (can't over-submit)
- [ ] Test exclusive quest locking (second kid sees "claimed")
- [ ] Test curse cast → coin deduction → kid affliction panel → Forgive/Resolve
- [ ] Confirm bounty section divider appears in kid columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)