### PR TITLE
fix: unit tests after tier card redesign

### DIFF
--- a/src/lib/__tests__/constants.test.ts
+++ b/src/lib/__tests__/constants.test.ts
@@ -65,15 +65,15 @@ describe('TIER_CONFIG', () => {
       const cfg = TIER_CONFIG[tier]
       expect(cfg.label).toBeTruthy()
       expect(cfg.color).toMatch(/^(#|rgba)/)
-      expect(cfg.bg).toMatch(/^rgba/)
+      expect(cfg.bg).toBeTruthy()
       expect(cfg.border).toMatch(/^rgba/)
     })
   })
 
-  it('only epic tier has a glow', () => {
+  it('non-normal tiers have glows; normal does not', () => {
     expect(TIER_CONFIG.normal.glow).toBeNull()
-    expect(TIER_CONFIG.heroic.glow).toBeNull()
-    expect(TIER_CONFIG.legendary.glow).toBeNull()
+    expect(TIER_CONFIG.heroic.glow).toBeTruthy()
+    expect(TIER_CONFIG.legendary.glow).toBeTruthy()
     expect(TIER_CONFIG.epic.glow).toBeTruthy()
   })
 })


### PR DESCRIPTION
## Summary

- `bg` values for heroic/legendary/epic are now CSS gradients (not `rgba(...)`) — loosen the regex check
- All non-normal tiers now have glows — update the glow test to match

🤖 Generated with [Claude Code](https://claude.com/claude-code)