### PR TITLE
feat: shared bounty board with family-wide pool tracking

### DIFF
--- a/src/app/kid/[id]/page.tsx
+++ b/src/app/kid/[id]/page.tsx
@@ -11,7 +11,7 @@ import { QuestCard } from '@/components/quest-card'
 import { CoinCounter } from '@/components/coin-counter'
 import { StreakBadge } from '@/components/streak-badge'
 import type { Kid, Quest, Completion, Reward, CurseInstance } from '@/lib/types'
-import { KID_COLORS, getLockDurationMs } from '@/lib/constants'
+import { KID_COLORS, TIER_CONFIG, getLockDurationMs } from '@/lib/constants'
 import { questDateString, questWeekKey } from '@/lib/utils'
 import { toast } from 'sonner'
 
@@ -26,6 +26,8 @@ export default function KidPage({ params }: { params: Promise<{ id: string }> })
   const [rewards, setRewards] = useState<Reward[]>([])
   const [activeCurses, setActiveCurses] = useState<CurseInstance[]>([])
   const [claimedExclusiveIds, setClaimedExclusiveIds] = useState<Set<string>>(new Set())
+  const [familyBountyCompletions, setFamilyBountyCompletions] = useState<Array<{quest_id: string, kid_id: string, status: string}>>([])
+  const [tab, setTab] = useState<'quests' | 'bounties' | 'rewards'>('quests')
   const [pinVerified, setPinVerified] = useState(() =>
     typeof window !== 'undefined'
       ? sessionStorage.getItem(PIN_SESSION_KEY + id) === 'verified'
@@ -37,7 +39,6 @@ export default function KidPage({ params }: { params: Promise<{ id: string }> })
   const [lockedUntil, setLockedUntil] = useState<number | null>(null)
   const [now, setNow] = useState(() => Date.now())
   const [loading, setLoading] = useState(true)
-  const [tab, setTab] = useState<'quests' | 'rewards'>('quests')
   const [supabase] = useState(createClient)
   const [resetHour, setResetHour] = useState(0)
 
@@ -60,15 +61,25 @@ export default function KidPage({ params }: { params: Promise<{ id: string }> })
     const today = questDateString(fetchedResetHour)
     const weekStart = questWeekKey(fetchedResetHour)
 
-    const [completionsRes, cursesRes, exclusiveRes] = await Promise.all([
+    const bountyQuestIds = (questsRes.data ?? [])
+      .filter((q: Quest) => q.weekly_target != null && q.exclusive)
+      .map((q: Quest) => q.id)
+
+    const [completionsRes, cursesRes, exclusiveRes, familyBountyRes] = await Promise.all([
       supabase.from('completions').select('*').eq('kid_id', id).gte('date', weekStart),
       supabase.from('curse_instances').select('*, curse:curses(*)').eq('kid_id', id).eq('status', 'active'),
-      // Check exclusive quests claimed by other kids today
+      // Check exclusive (non-bounty) quests claimed by other kids today
       (async () => {
-        const exclusiveIds = (questsRes.data ?? []).filter(q => q.exclusive).map(q => q.id)
+        const exclusiveIds = (questsRes.data ?? [])
+          .filter((q: Quest) => q.exclusive && !(q.weekly_target != null && q.exclusive))
+          .map((q: Quest) => q.id)
         if (exclusiveIds.length === 0) return { data: [] }
         return supabase.from('completions').select('quest_id').in('quest_id', exclusiveIds).eq('date', today).neq('kid_id', id)
       })(),
+      // Family-wide completions for bounty quests (shared pool)
+      bountyQuestIds.length > 0
+        ? supabase.from('completions').select('quest_id, kid_id, status').in('quest_id', bountyQuestIds).gte('date', weekStart)
+        : Promise.resolve({ data: [] }),
     ])
 
     if (kidRes.data) setKid(kidRes.data)
@@ -92,6 +103,7 @@ export default function KidPage({ params }: { params: Promise<{ id: string }> })
     if (completionsRes.data) setCompletions(completionsRes.data)
     if (cursesRes.data) setActiveCurses(cursesRes.data as CurseInstance[])
     setClaimedExclusiveIds(new Set((exclusiveRes.data ?? []).map(c => c.quest_id)))
+    setFamilyBountyCompletions((familyBountyRes.data ?? []) as Array<{quest_id: string, kid_id: string, status: string}>)
     if (rewardsRes.data) setRewards(rewardsRes.data)
     setLoading(false)
   }, [id, supabase, resetHour])
@@ -155,11 +167,14 @@ export default function KidPage({ params }: { params: Promise<{ id: string }> })
       const today = questDateString(resetHour)
 
       if (quest.weekly_target != null) {
-        const weekCount = completions.filter(c =>
+        // Bounties use family-wide count; personal recurring use per-kid count
+        const isBounty = quest.weekly_target != null && quest.exclusive
+        const pool = isBounty ? familyBountyCompletions : completions
+        const weekCount = pool.filter(c =>
           c.quest_id === questId && (c.status === 'approved' || c.status === 'pending')
         ).length
         if (weekCount >= quest.weekly_target) {
-          toast.error('Weekly target already reached!')
+          toast.error(isBounty ? 'Bounty fully claimed this week!' : 'Weekly target already reached!')
           return
         }
       }
@@ -179,7 +194,7 @@ export default function KidPage({ params }: { params: Promise<{ id: string }> })
       toast.success(`Quest submitted! ✨`, { description: `+${quest.coins} coins once approved` })
       await fetchData()
     },
-    [quests, id, supabase, fetchData, resetHour, completions]
+    [quests, id, supabase, fetchData, resetHour, completions, familyBountyCompletions]
   )
 
   const handleRedeem = useCallback(
@@ -342,24 +357,35 @@ export default function KidPage({ params }: { params: Promise<{ id: string }> })
 
       {/* Tab bar */}
       <div className="flex px-6 gap-2 mb-4 flex-shrink-0">
-        {(['quests', 'rewards'] as const).map((t) => (
-          <button
-            key={t}
-            onClick={() => setTab(t)}
-            className="px-5 py-2 rounded-xl text-sm font-semibold capitalize transition-all"
-            style={{
-              background: tab === t ? colors.bg : 'rgba(255,255,255,0.04)',
-              border: `1px solid ${tab === t ? colors.border : 'rgba(255,255,255,0.07)'}`,
-              color: tab === t ? colors.primary : 'rgba(255,255,255,0.45)',
-            }}
-          >
-            {t === 'quests' ? '⚔️ Quests' : '🎁 Rewards'}
-          </button>
-        ))}
+        {(['quests', 'bounties', 'rewards'] as const).map((t) => {
+          const labels = { quests: '⚔️ Quests', bounties: '⚡ Bounties', rewards: '🎁 Rewards' }
+          return (
+            <button
+              key={t}
+              onClick={() => setTab(t)}
+              className="flex-1 py-2 rounded-xl text-sm font-semibold transition-all"
+              style={{
+                background: tab === t ? colors.bg : 'rgba(255,255,255,0.04)',
+                border: `1px solid ${tab === t ? colors.border : 'rgba(255,255,255,0.07)'}`,
+                color: tab === t ? colors.primary : 'rgba(255,255,255,0.45)',
+              }}
+            >
+              {labels[t]}
+            </button>
+          )
+        })}
       </div>
 
       {/* Content */}
       <main className="flex-1 px-6 pb-8 overflow-y-auto scrollbar-thin-glass">
+        {(() => {
+          const isFamilyBounty = (q: Quest) => q.weekly_target != null && q.exclusive
+          const personalQuests = quests.filter(q => !isFamilyBounty(q))
+          const bountyQuestList = quests.filter(q => isFamilyBounty(q))
+
+          return null
+        })()}
+
         <AnimatePresence mode="wait">
           {tab === 'quests' ? (
             <motion.div
@@ -394,16 +420,14 @@ export default function KidPage({ params }: { params: Promise<{ id: string }> })
                 </motion.div>
               )}
 
-              {quests.length === 0 ? (
+              {quests.filter(q => !(q.weekly_target != null && q.exclusive)).length === 0 ? (
                 <div className="text-center py-16 text-white/30">
                   <p className="text-4xl mb-3">🧙</p>
                   <p>No quests yet — ask a parent to add some!</p>
                 </div>
               ) : (
-                quests.map((quest, i) => {
-                  const completion = quest.frequency === 'weekly'
-                    ? completions.find(c => c.quest_id === quest.id)
-                    : quest.frequency === 'once'
+                quests.filter(q => !(q.weekly_target != null && q.exclusive)).map((quest, i) => {
+                  const completion = quest.frequency === 'once'
                     ? completions.find(c => c.quest_id === quest.id)
                     : completions.find(c => c.quest_id === quest.id && c.date === today)
 
@@ -431,6 +455,101 @@ export default function KidPage({ params }: { params: Promise<{ id: string }> })
                         kidColor={kid.color}
                         onComplete={() => handleComplete(quest.id)}
                       />
+                    </motion.div>
+                  )
+                })
+              )}
+            </motion.div>
+          ) : tab === 'bounties' ? (
+            <motion.div
+              key="bounties"
+              className="flex flex-col gap-3"
+              initial={{ opacity: 0, x: -10 }}
+              animate={{ opacity: 1, x: 0 }}
+              exit={{ opacity: 0, x: 10 }}
+              transition={{ duration: 0.2 }}
+            >
+              <p className="text-xs text-white/30 text-center pb-1">
+                Shared tasks — first to claim each slot earns the coins
+              </p>
+              {quests.filter(q => q.weekly_target != null && q.exclusive).length === 0 ? (
+                <div className="text-center py-16 text-white/30">
+                  <p className="text-4xl mb-3">⚡</p>
+                  <p>No bounties available today</p>
+                </div>
+              ) : (
+                quests.filter(q => q.weekly_target != null && q.exclusive).map((quest, i) => {
+                  const familyCount = familyBountyCompletions.filter(c =>
+                    c.quest_id === quest.id && (c.status === 'approved' || c.status === 'pending')
+                  ).length
+                  const isFull = quest.weekly_target != null && familyCount >= quest.weekly_target
+                  const myCompletion = completions.find(c => c.quest_id === quest.id && (c.date === today || quest.frequency === 'weekly'))
+                  const tier = TIER_CONFIG[quest.tier ?? 'normal']
+
+                  return (
+                    <motion.div
+                      key={quest.id}
+                      initial={{ opacity: 0, y: 12 }}
+                      animate={{ opacity: 1, y: 0 }}
+                      transition={{ delay: i * 0.06 }}
+                      className="rounded-2xl p-4"
+                      style={{
+                        background: isFull && !myCompletion ? 'rgba(255,255,255,0.02)' : tier.bg,
+                        border: `1px solid ${isFull && !myCompletion ? 'rgba(255,255,255,0.06)' : tier.border}`,
+                        boxShadow: isFull && !myCompletion ? 'none' : (tier.glow ?? 'none'),
+                        opacity: isFull && !myCompletion ? 0.5 : 1,
+                      }}
+                    >
+                      <div className="flex items-start gap-3">
+                        <span className="text-2xl leading-none mt-0.5">{quest.icon}</span>
+                        <div className="flex-1 min-w-0">
+                          <div className="flex items-center gap-1.5 flex-wrap">
+                            <p className={`font-semibold text-sm ${myCompletion?.status === 'approved' ? 'line-through opacity-40' : 'text-white/90'}`}>
+                              {quest.title}
+                            </p>
+                            <span
+                              className="text-xs px-1.5 py-0.5 rounded-md font-bold flex-shrink-0"
+                              style={{ background: `${tier.color}18`, color: tier.color, border: `1px solid ${tier.color}40` }}
+                            >
+                              {tier.label}
+                            </span>
+                          </div>
+                          <p className="text-xs mt-1" style={{ color: isFull ? 'rgba(74,222,128,0.7)' : 'rgba(255,255,255,0.35)' }}>
+                            {isFull ? '✓ fully claimed this week' : `${familyCount}/${quest.weekly_target} claimed this week`}
+                          </p>
+                        </div>
+                        <div className="flex-shrink-0 text-right">
+                          <div className="flex items-center gap-1 justify-end">
+                            <span className="text-sm">🪙</span>
+                            <span className="font-bold text-sm" style={{ color: tier.color }}>{quest.coins}</span>
+                          </div>
+                          {myCompletion?.status === 'pending' && (
+                            <p className="text-xs text-amber-400 mt-0.5">awaiting...</p>
+                          )}
+                          {myCompletion?.status === 'approved' && (
+                            <p className="text-xs text-green-400 mt-0.5">✓ done!</p>
+                          )}
+                          {isFull && !myCompletion && (
+                            <p className="text-xs text-white/30 mt-0.5">all taken</p>
+                          )}
+                        </div>
+                      </div>
+
+                      {!isFull && !myCompletion && (
+                        <motion.button
+                          onClick={() => handleComplete(quest.id)}
+                          className="mt-3 w-full py-2.5 rounded-xl text-sm font-bold tracking-wide"
+                          style={{
+                            background: `linear-gradient(135deg, ${colors.bg}, transparent)`,
+                            border: `1px solid ${colors.border}`,
+                            color: colors.primary,
+                          }}
+                          whileHover={{ scale: 1.01 }}
+                          whileTap={{ scale: 0.98 }}
+                        >
+                          ⚡ Claim Bounty
+                        </motion.button>
+                      )}
                     </motion.div>
                   )
                 })

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,12 +3,13 @@
 export const dynamic = 'force-dynamic'
 
 import { useEffect, useState, useCallback } from 'react'
-import { motion } from 'framer-motion'
+import { motion, AnimatePresence } from 'framer-motion'
 import Link from 'next/link'
 import { createClient } from '@/lib/supabase/client'
 import { StarField } from '@/components/star-field'
 import { KidColumn } from '@/components/kid-column'
 import type { Kid, Quest, Completion, Family } from '@/lib/types'
+import { KID_COLORS, TIER_CONFIG } from '@/lib/constants'
 import { questDateString, questWeekKey } from '@/lib/utils'
 import { toast } from 'sonner'
 
@@ -20,6 +21,7 @@ export default function WallDisplay() {
   const [activeCurseCounts, setActiveCurseCounts] = useState<Record<string, number>>({})
   const [loading, setLoading] = useState(true)
   const [pendingCount, setPendingCount] = useState(0)
+  const [claimingBounty, setClaimingBounty] = useState<Quest | null>(null)
   const [supabase] = useState(createClient)
 
   const fetchData = useCallback(async () => {
@@ -82,13 +84,12 @@ export default function WallDisplay() {
 
       const today = questDateString(family?.daily_reset_hour ?? 0)
 
-      // Weekly_target guard: prevent over-submission
       if (quest.weekly_target != null) {
-        const weekCount = completions.filter(c =>
-          c.quest_id === questId && c.kid_id === kidId &&
+        const familyCount = completions.filter(c =>
+          c.quest_id === questId &&
           (c.status === 'approved' || c.status === 'pending')
         ).length
-        if (weekCount >= quest.weekly_target) {
+        if (familyCount >= quest.weekly_target) {
           toast.error('Weekly target already reached!')
           return
         }
@@ -115,15 +116,39 @@ export default function WallDisplay() {
     [quests, supabase, fetchData, family?.daily_reset_hour, completions]
   )
 
+  const handleClaimBounty = useCallback(
+    async (questId: string, kidId: string) => {
+      await handleComplete(questId, kidId)
+      setClaimingBounty(null)
+    },
+    [handleComplete]
+  )
+
   const today = questDateString(family?.daily_reset_hour ?? 0)
   const dayOfWeek = new Date().getDay()
 
-  const getKidQuests = (kid: Kid) =>
+  // Family bounties: weekly_target + exclusive = shared pool
+  const isFamilyBounty = (q: Quest) => q.weekly_target != null && q.exclusive
+
+  const getKidPersonalQuests = (kid: Kid) =>
     quests.filter(q => {
+      if (isFamilyBounty(q)) return false
       if (q.assigned_to && q.assigned_to !== kid.id) return false
       if (q.active_days?.length && !q.active_days.includes(dayOfWeek)) return false
       return true
     })
+
+  const bountyQuests = quests.filter(q => {
+    if (!isFamilyBounty(q)) return false
+    if (q.active_days?.length && !q.active_days.includes(dayOfWeek)) return false
+    return true
+  })
+
+  const getFamilyCount = (questId: string) =>
+    completions.filter(c =>
+      c.quest_id === questId &&
+      (c.status === 'approved' || c.status === 'pending')
+    ).length
 
   const getKidCompletions = (kid: Kid) =>
     completions.filter((c) => c.kid_id === kid.id)
@@ -131,7 +156,7 @@ export default function WallDisplay() {
   const todayCompletions = completions.filter(c => c.date === today)
   const claimedExclusiveIds = new Set(
     todayCompletions
-      .filter(c => quests.find(q => q.id === c.quest_id)?.exclusive)
+      .filter(c => quests.find(q => q.id === c.quest_id)?.exclusive && !isFamilyBounty(quests.find(q => q.id === c.quest_id)!))
       .map(c => c.quest_id)
   )
 
@@ -238,7 +263,7 @@ export default function WallDisplay() {
 
       {/* Kid columns */}
       <main
-        className="relative z-10 flex-1 grid gap-6 px-8 pb-8 min-h-0"
+        className="relative z-10 flex-1 grid gap-6 px-8 pb-4 min-h-0"
         style={{ gridTemplateColumns: `repeat(${kids.length}, 1fr)` }}
       >
         {kids.map((kid, i) => (
@@ -251,7 +276,7 @@ export default function WallDisplay() {
           >
             <KidColumn
               kid={kid}
-              quests={getKidQuests(kid)}
+              quests={getKidPersonalQuests(kid)}
               completions={getKidCompletions(kid)}
               today={today}
               claimedExclusiveIds={claimedExclusiveIds}
@@ -263,6 +288,93 @@ export default function WallDisplay() {
         ))}
       </main>
 
+      {/* Bounty Board */}
+      {bountyQuests.length > 0 && (
+        <motion.section
+          className="relative z-10 px-8 pb-6 flex-shrink-0"
+          initial={{ opacity: 0, y: 16 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.5 }}
+        >
+          <div className="flex items-center gap-3 mb-4">
+            <div className="flex-1 h-px" style={{ background: 'rgba(251,191,36,0.18)' }} />
+            <span
+              className="text-xs font-bold tracking-[0.2em] uppercase px-3 py-1 rounded-full flex-shrink-0"
+              style={{
+                background: 'rgba(251,191,36,0.1)',
+                border: '1px solid rgba(251,191,36,0.25)',
+                color: 'rgba(251,191,36,0.8)',
+              }}
+            >
+              ⚡ Bounty Board
+            </span>
+            <div className="flex-1 h-px" style={{ background: 'rgba(251,191,36,0.18)' }} />
+          </div>
+
+          <div
+            className="grid gap-3"
+            style={{ gridTemplateColumns: `repeat(${Math.min(bountyQuests.length, 4)}, 1fr)` }}
+          >
+            {bountyQuests.map((quest, i) => {
+              const count = getFamilyCount(quest.id)
+              const isFull = quest.weekly_target != null && count >= quest.weekly_target
+              const tier = TIER_CONFIG[quest.tier ?? 'normal']
+              return (
+                <motion.button
+                  key={quest.id}
+                  onClick={() => !isFull && setClaimingBounty(quest)}
+                  disabled={isFull}
+                  className="rounded-2xl p-4 text-left relative overflow-hidden"
+                  style={{
+                    background: isFull ? 'rgba(255,255,255,0.02)' : tier.bg,
+                    border: `1px solid ${isFull ? 'rgba(255,255,255,0.06)' : tier.border}`,
+                    boxShadow: isFull ? 'none' : (tier.glow ?? 'none'),
+                    opacity: isFull ? 0.5 : 1,
+                  }}
+                  initial={{ opacity: 0, y: 12 }}
+                  animate={{ opacity: isFull ? 0.5 : 1, y: 0 }}
+                  transition={{ delay: 0.55 + i * 0.06 }}
+                  whileHover={!isFull ? { scale: 1.02 } : {}}
+                  whileTap={!isFull ? { scale: 0.97 } : {}}
+                >
+                  <div className="flex items-start justify-between gap-2 mb-2">
+                    <span className="text-2xl">{quest.icon}</span>
+                    <div className="text-right">
+                      <div className="flex items-center gap-1 justify-end">
+                        <span className="text-sm">🪙</span>
+                        <span className="font-bold text-sm" style={{ color: isFull ? 'rgba(255,255,255,0.3)' : tier.color }}>
+                          {quest.coins}
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+
+                  <p className={`text-sm font-semibold leading-snug mb-2 ${isFull ? 'text-white/30' : 'text-white/90'}`}>
+                    {quest.title}
+                  </p>
+
+                  <div className="flex items-center justify-between">
+                    <span
+                      className="text-xs px-1.5 py-0.5 rounded-md font-semibold"
+                      style={{
+                        background: `${tier.color}18`,
+                        color: isFull ? 'rgba(255,255,255,0.25)' : tier.color,
+                        border: `1px solid ${tier.color}30`,
+                      }}
+                    >
+                      {tier.label}
+                    </span>
+                    <span className="text-xs" style={{ color: isFull ? 'rgba(74,222,128,0.7)' : 'rgba(255,255,255,0.4)' }}>
+                      {isFull ? '✓ all claimed' : `${count}/${quest.weekly_target} taken`}
+                    </span>
+                  </div>
+                </motion.button>
+              )
+            })}
+          </div>
+        </motion.section>
+      )}
+
       <motion.footer
         className="relative z-10 text-center pb-4 text-white/20 text-xs tracking-[0.25em] uppercase flex-shrink-0"
         initial={{ opacity: 0 }}
@@ -271,6 +383,66 @@ export default function WallDisplay() {
       >
         ✦ tap a quest to complete it ✦
       </motion.footer>
+
+      {/* Kid picker modal for bounty claims */}
+      <AnimatePresence>
+        {claimingBounty && (
+          <motion.div
+            className="fixed inset-0 z-50 flex items-center justify-center"
+            style={{ background: 'rgba(0,0,0,0.75)', backdropFilter: 'blur(8px)' }}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            onClick={() => setClaimingBounty(null)}
+          >
+            <motion.div
+              className="rounded-3xl p-7 mx-4 max-w-sm w-full"
+              style={{
+                background: 'rgba(12,8,32,0.97)',
+                border: '1px solid rgba(255,255,255,0.1)',
+                boxShadow: '0 0 60px rgba(0,0,0,0.6)',
+              }}
+              initial={{ scale: 0.88, opacity: 0, y: 16 }}
+              animate={{ scale: 1, opacity: 1, y: 0 }}
+              exit={{ scale: 0.88, opacity: 0, y: 16 }}
+              transition={{ type: 'spring', stiffness: 340, damping: 28 }}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className="flex items-center gap-3 justify-center mb-2">
+                <span className="text-3xl">{claimingBounty.icon}</span>
+                <p className="font-heading font-bold text-lg text-white/90">{claimingBounty.title}</p>
+              </div>
+              <p className="text-center text-white/40 text-sm mb-6">Who&apos;s doing this bounty?</p>
+
+              <div className="flex gap-4 justify-center">
+                {kids.map(kid => {
+                  const colors = KID_COLORS[kid.color]
+                  return (
+                    <motion.button
+                      key={kid.id}
+                      onClick={() => handleClaimBounty(claimingBounty.id, kid.id)}
+                      className="flex flex-col items-center gap-2 px-6 py-4 rounded-2xl"
+                      style={{ background: colors.bg, border: `1px solid ${colors.border}` }}
+                      whileHover={{ scale: 1.06, boxShadow: `0 0 20px ${colors.glow}` }}
+                      whileTap={{ scale: 0.95 }}
+                    >
+                      <span className="text-4xl">{kid.avatar}</span>
+                      <span className="text-sm font-bold" style={{ color: colors.primary }}>{kid.name}</span>
+                    </motion.button>
+                  )
+                })}
+              </div>
+
+              <button
+                onClick={() => setClaimingBounty(null)}
+                className="mt-5 w-full text-center text-white/25 text-sm hover:text-white/50 transition-all"
+              >
+                Cancel
+              </button>
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </div>
   )
 }

--- a/src/components/kid-column.tsx
+++ b/src/components/kid-column.tsx
@@ -151,8 +151,10 @@ export function KidColumn({
 
       {/* Quest list */}
       {(() => {
-        const personalQuests = quests.filter(q => q.weekly_target == null && !q.exclusive)
-        const bountyQuests = quests.filter(q => q.weekly_target != null || q.exclusive)
+        // Family bounties (weekly_target + exclusive) live on the bounty board, not here
+        const personalQuests = quests.filter(q => !(q.weekly_target != null && q.exclusive))
+        const bountyQuests = [] as Quest[]
+        void bountyQuests
         let cardIndex = 0
 
         const renderCard = (quest: Quest) => {
@@ -193,28 +195,6 @@ export function KidColumn({
         return (
           <div className="flex flex-col gap-2.5 flex-1 overflow-y-auto scrollbar-thin-glass min-h-0 pb-1">
             {personalQuests.map(renderCard)}
-
-            {bountyQuests.length > 0 && (
-              <>
-                {/* Bounty section divider */}
-                <div className="flex items-center gap-2 py-1 mt-1">
-                  <div className="flex-1 h-px" style={{ background: 'rgba(251,191,36,0.2)' }} />
-                  <span
-                    className="text-xs font-bold tracking-widest uppercase px-2 py-0.5 rounded-full flex-shrink-0"
-                    style={{
-                      background: 'rgba(251,191,36,0.1)',
-                      border: '1px solid rgba(251,191,36,0.25)',
-                      color: 'rgba(251,191,36,0.75)',
-                    }}
-                  >
-                    ⚡ Bounties
-                  </span>
-                  <div className="flex-1 h-px" style={{ background: 'rgba(251,191,36,0.2)' }} />
-                </div>
-
-                {bountyQuests.map(renderCard)}
-              </>
-            )}
           </div>
         )
       })()}


### PR DESCRIPTION
## Summary

- **Bounty Board** section on wall display below kid columns — shared family pool
- Tap a bounty card to open a kid picker modal (who's doing this?)
- Family-wide completion counting — Isaac claiming dishes reduces the pool for Katherine too
- Kid personal view gets a new ⚡ Bounties tab showing available/taken slots
- Kid columns now show only personal quests (daily quests + fold laundry + feed dog)

## Rules
- `weekly_target != null && exclusive=true` → Bounty Board (family pool)
- `exclusive=true, weekly_target=null` → personal column first-claim (feed dog)
- `weekly_target != null, exclusive=false` → personal per-kid recurring (fold laundry)
- Everything else → personal column daily quests

## Live data updated
- Do dishes: `exclusive=true` (4× family pool/week)
- Sunday clean: `exclusive=true, weekly_target=1` (1× family pool/Sunday)

🤖 Generated with [Claude Code](https://claude.com/claude-code)