### PR TITLE
ci: auto-apply Supabase migrations on push to main

### DIFF
--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -1,0 +1,32 @@
+name: DB Migrate
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'supabase/migrations/**'
+  workflow_dispatch:
+
+jobs:
+  migrate:
+    name: apply migrations
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Link project
+        run: supabase link --project-ref xdidpzzsfoxijugvrjvc
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+
+      - name: Apply pending migrations
+        run: supabase db push
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,8 +145,12 @@ vercel --prod        # Deploy to production (CI/CD via GitHub is preferred)
 - Preview deploys: every branch/PR gets a unique Vercel URL
 - **CI jobs** (`.github/workflows/ci.yml`):
   - `typecheck` + `lint` + `unit tests` — run on every push to main and every PR
-  - `playwright` (E2E) — **PRs only**, not on direct pushes to main (too slow for routine commits)
-- Supabase env vars are set as GitHub Actions secrets (`NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`)
+  - `playwright` (E2E) — **manual trigger only** (`workflow_dispatch`)
+- **DB migrate** (`.github/workflows/db-migrate.yml`):
+  - Runs on push to main when any file under `supabase/migrations/**` changes, or via manual trigger
+  - Calls `supabase link` + `supabase db push` — applies only unapplied migrations (idempotent)
+  - Requires two GH Actions secrets: `SUPABASE_ACCESS_TOKEN` (personal access token from supabase.com) and `SUPABASE_DB_PASSWORD` (project DB password)
+- Supabase env vars as GitHub Actions secrets: `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_ACCESS_TOKEN`, `SUPABASE_DB_PASSWORD`
 
 ## Environment Variables
 


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/db-migrate.yml` that runs on push to `main` when `supabase/migrations/**` changes (or via manual dispatch)
- Uses `supabase/setup-cli` + `supabase link` + `supabase db push` — applies only unapplied migrations, idempotent
- Free tier only — no Supabase Branches or paid features involved

## Secrets required

Add these two secrets to the GitHub repo before merging:

| Secret | Where to get it |
|--------|----------------|
| `SUPABASE_ACCESS_TOKEN` | supabase.com > Account > Access Tokens |
| `SUPABASE_DB_PASSWORD` | Supabase project > Settings > Database > Database password |

## Test plan

- [ ] Add the two secrets to GitHub repo settings
- [ ] Merge this PR
- [ ] Verify the `apply migrations` step completes on the next migration file push

🤖 Generated with [Claude Code](https://claude.com/claude-code)