### PR TITLE
fix: pass --password explicitly to supabase CLI commands

### DIFF
--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -20,13 +20,13 @@ jobs:
           version: latest
 
       - name: Link project
-        run: supabase link --project-ref xdidpzzsfoxijugvrjvc
+        run: supabase link --project-ref xdidpzzsfoxijugvrjvc --password "$SUPABASE_DB_PASSWORD"
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
           SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
 
       - name: Apply pending migrations
-        run: supabase db push
+        run: supabase db push --password "$SUPABASE_DB_PASSWORD"
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
           SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}


### PR DESCRIPTION
Fixes the db-migrate workflow failure: `supabase link` and `db push` need `--password` passed as a flag in non-interactive CI mode, not just as an env var.

🤖 Generated with [Claude Code](https://claude.com/claude-code)