### PR TITLE
ci: switch db push to --db-url with transaction pooler

### DIFF
--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -19,14 +19,8 @@ jobs:
         with:
           version: latest
 
-      - name: Link project
-        run: supabase link --project-ref xdidpzzsfoxijugvrjvc --password "$SUPABASE_DB_PASSWORD"
-        env:
-          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
-
       - name: Apply pending migrations
-        run: supabase db push --password "$SUPABASE_DB_PASSWORD"
+        run: supabase db push --db-url "$SUPABASE_DB_URL"
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+          SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}


### PR DESCRIPTION
Session pooler (port 5432) rejects SASL auth in CI. Transaction pooler (port 6543) works. Switches to `--db-url` so the link step isn't needed at all.

Also adds `SUPABASE_DB_URL` as the single secret (full connection string) instead of a bare password.

🤖 Generated with [Claude Code](https://claude.com/claude-code)