### PR TITLE
test: quest model coverage — questWeekKey, shared/oneoff rules, E2E gates

### DIFF
--- a/e2e/quest-model.spec.ts
+++ b/e2e/quest-model.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Structural E2E tests for the quest model that don't require authentication.
+ * Authenticated flows (claim race, approval, undo) require a test family seeded
+ * in Supabase — these tests verify public/loading-state behavior and auth gates.
+ */
+
+test.describe('Quest board — unauthenticated gates', () => {
+  test('kid page with unknown UUID loads without crashing', async ({ page }) => {
+    await page.goto('/kid/00000000-0000-0000-0000-000000000001')
+    await page.waitForLoadState('networkidle')
+    await expect(page.locator('body')).not.toContainText('Internal Server Error')
+    await expect(page.locator('body')).not.toContainText('Application error')
+  })
+
+  test('parent page requires auth', async ({ page }) => {
+    await page.goto('/parent')
+    await page.waitForLoadState('networkidle')
+    await expect(page).toHaveURL(/login/, { timeout: 5000 })
+  })
+
+  test('wall display loads without crashing', async ({ page }) => {
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+    await expect(page.locator('body')).not.toContainText('Internal Server Error')
+    await expect(page.locator('body')).not.toContainText('Application error')
+  })
+})
+
+test.describe('Complete API — public error handling', () => {
+  test('POST /api/kid/:id/complete returns 400 on bad body', async ({ request }) => {
+    const res = await request.post('/api/kid/00000000-0000-0000-0000-000000000001/complete', {
+      data: {},
+    })
+    expect(res.status()).toBe(400)
+  })
+
+  test('POST /api/kid/:id/complete returns 404 for unknown kid', async ({ request }) => {
+    const res = await request.post('/api/kid/00000000-0000-0000-0000-000000000001/complete', {
+      data: { quest_id: '00000000-0000-0000-0000-000000000099', date: '2025-01-01' },
+    })
+    expect(res.status()).toBe(404)
+  })
+
+  test('DELETE /api/kid/:id/complete/:completionId returns 404 for unknown completion', async ({ request }) => {
+    const res = await request.delete(
+      '/api/kid/00000000-0000-0000-0000-000000000001/complete/00000000-0000-0000-0000-000000000099',
+    )
+    expect(res.status()).toBe(404)
+  })
+})
+
+test.describe('Join page', () => {
+  test('unknown invite token shows not-found state without crashing', async ({ page }) => {
+    await page.goto('/join/00000000-0000-0000-0000-000000000000')
+    await page.waitForLoadState('networkidle')
+    await expect(page.locator('body')).not.toContainText('Internal Server Error')
+    await expect(page.locator('body')).not.toContainText('Application error')
+  })
+})

--- a/src/app/parent/_streak.ts
+++ b/src/app/parent/_streak.ts
@@ -1,9 +1,4 @@
-export function getStreakBonus(streak: number): number {
-  if (streak >= 14) return 2.0
-  if (streak >= 7) return 1.5
-  if (streak >= 3) return 1.25
-  return 1.0
-}
+export { getStreakBonus } from '@/lib/constants'
 
 export function yesterday(): string {
   const d = new Date()

--- a/src/lib/__tests__/quest-rules.test.ts
+++ b/src/lib/__tests__/quest-rules.test.ts
@@ -76,6 +76,19 @@ describe('isQuestVisibleToKid', () => {
     const q = { ...baseQuest, active_days: [] }
     expect(isQuestVisibleToKid(q, 'kid-a', today, new Set())).toBe(true)
   })
+
+  it('shows shared quests to all kids — approved family completions do NOT hide them', () => {
+    const q = { ...baseQuest, kind: 'shared' as const, assigned_to: null }
+    // shared quests stay visible even when they appear in the approvedSet
+    // (they're not oneoff — they reset each period)
+    expect(isQuestVisibleToKid(q, 'kid-a', today, new Set(['q1']))).toBe(true)
+    expect(isQuestVisibleToKid(q, 'kid-b', today, new Set(['q1']))).toBe(true)
+  })
+
+  it('active_days with all 7 days behaves like no filter', () => {
+    const q = { ...baseQuest, active_days: [0, 1, 2, 3, 4, 5, 6] }
+    expect(isQuestVisibleToKid(q, 'kid-a', today, new Set())).toBe(true)
+  })
 })
 
 describe('countActiveCompletions', () => {
@@ -87,6 +100,27 @@ describe('countActiveCompletions', () => {
       { ...baseCompletion, id: 'd', quest_id: 'other', status: 'approved' },
     ]
     expect(countActiveCompletions(baseQuest, completions)).toBe(2)
+  })
+
+  it('returns 0 with no completions', () => {
+    expect(countActiveCompletions(baseQuest, [])).toBe(0)
+  })
+
+  it('does not count completions for other quests', () => {
+    const completions: Completion[] = [
+      { ...baseCompletion, id: 'a', quest_id: 'other-quest', status: 'approved' },
+      { ...baseCompletion, id: 'b', quest_id: 'another', status: 'pending' },
+    ]
+    expect(countActiveCompletions(baseQuest, completions)).toBe(0)
+  })
+
+  it('counts completions from multiple kids (shared quest scenario)', () => {
+    const completions: Completion[] = [
+      { ...baseCompletion, id: 'a', kid_id: 'kid-a', status: 'approved' },
+      { ...baseCompletion, id: 'b', kid_id: 'kid-b', status: 'pending' },
+      { ...baseCompletion, id: 'c', kid_id: 'kid-c', status: 'approved' },
+    ]
+    expect(countActiveCompletions(baseQuest, completions)).toBe(3)
   })
 })
 
@@ -125,13 +159,27 @@ describe('kidHasActiveCompletion', () => {
     expect(kidHasActiveCompletion(baseQuest, 'kid-a', completions)).toBe(true)
   })
 
+  it('returns true for approved', () => {
+    const completions: Completion[] = [{ ...baseCompletion, status: 'approved' }]
+    expect(kidHasActiveCompletion(baseQuest, 'kid-a', completions)).toBe(true)
+  })
+
   it('returns false when only rejected', () => {
     const completions: Completion[] = [{ ...baseCompletion, status: 'rejected' }]
     expect(kidHasActiveCompletion(baseQuest, 'kid-a', completions)).toBe(false)
   })
 
-  it('returns false for other kids', () => {
+  it('returns false with empty completions list', () => {
+    expect(kidHasActiveCompletion(baseQuest, 'kid-a', [])).toBe(false)
+  })
+
+  it('returns false for other kids even if they have active completions', () => {
     const completions: Completion[] = [{ ...baseCompletion, kid_id: 'kid-b', status: 'approved' }]
+    expect(kidHasActiveCompletion(baseQuest, 'kid-a', completions)).toBe(false)
+  })
+
+  it('returns false for other quests even for the same kid', () => {
+    const completions: Completion[] = [{ ...baseCompletion, quest_id: 'other', status: 'approved' }]
     expect(kidHasActiveCompletion(baseQuest, 'kid-a', completions)).toBe(false)
   })
 })

--- a/src/lib/__tests__/utils.test.ts
+++ b/src/lib/__tests__/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { isValidPin, questDateString } from '../utils'
+import { isValidPin, questDateString, questWeekKey, localDateString } from '../utils'
 
 describe('isValidPin', () => {
   it('accepts exactly 4 numeric digits', () => {
@@ -69,5 +69,47 @@ describe('questDateString', () => {
   it('handles month boundary correctly', () => {
     const lastDayOfMonth = new Date(2025, 5, 1, 2) // June 1 at 2 AM, resetHour=3
     expect(questDateString(3, lastDayOfMonth)).toBe('2025-05-31') // rolls back to May 31
+  })
+})
+
+describe('questWeekKey', () => {
+  // 2025-06-15 is a Sunday; its Monday is 2025-06-09
+  const date = (y: number, mo: number, d: number, h = 10) => new Date(y, mo - 1, d, h)
+
+  it('returns the Monday of the week for any weekday', () => {
+    expect(questWeekKey(0, date(2025, 6, 9))).toBe('2025-06-09')   // Monday
+    expect(questWeekKey(0, date(2025, 6, 11))).toBe('2025-06-09')  // Wednesday
+    expect(questWeekKey(0, date(2025, 6, 14))).toBe('2025-06-09')  // Saturday
+    expect(questWeekKey(0, date(2025, 6, 15))).toBe('2025-06-09')  // Sunday
+  })
+
+  it('respects resetHour — before reset still belongs to the previous day', () => {
+    // Mon June 9 at 2 AM, resetHour=3 → effective day is Sunday June 8
+    // Sunday June 8's Monday is June 2
+    expect(questWeekKey(3, date(2025, 6, 9, 2))).toBe('2025-06-02')
+
+    // Mon June 9 at 4 AM (after 3 AM reset) → effective day is Monday June 9
+    expect(questWeekKey(3, date(2025, 6, 9, 4))).toBe('2025-06-09')
+  })
+
+  it('handles cross-month boundary (Wednesday July 2 → Monday June 30)', () => {
+    expect(questWeekKey(0, date(2025, 7, 2))).toBe('2025-06-30')
+  })
+
+  it('handles cross-year boundary (Wednesday Jan 1 2025 → Monday Dec 30 2024)', () => {
+    expect(questWeekKey(0, date(2025, 1, 1))).toBe('2024-12-30')
+  })
+})
+
+describe('localDateString', () => {
+  it('formats a date as YYYY-MM-DD', () => {
+    expect(localDateString(new Date(2025, 0, 1))).toBe('2025-01-01')
+    expect(localDateString(new Date(2025, 11, 31))).toBe('2025-12-31')
+    expect(localDateString(new Date(2025, 5, 9))).toBe('2025-06-09')
+  })
+
+  it('zero-pads month and day', () => {
+    expect(localDateString(new Date(2025, 0, 9))).toBe('2025-01-09')
+    expect(localDateString(new Date(2025, 8, 1))).toBe('2025-09-01')
   })
 })


### PR DESCRIPTION
## Summary

### Unit tests (72 total, all passing)

- **`questWeekKey`** — completely uncovered before; added 4 cases: any weekday → Monday, resetHour boundary on a Monday morning, cross-month (July 2 → June 30), cross-year (Jan 1 → Dec 30)
- **`localDateString`** — zero-padding and basic format coverage
- **`quest-rules` — shared quest visibility**: confirmed approved family completions do NOT hide shared quests (only `oneoff` kind is hidden after approval — important distinction)
- **`countActiveCompletions`** — empty list, other-quest filter, multi-kid shared scenario
- **`kidHasActiveCompletion`** — approved state, empty list, other-quest filter

### Refactor

- `src/app/parent/_streak.ts`: removed duplicate `getStreakBonus` definition (was identical to `src/lib/constants.ts`); now re-exports from the canonical location

### E2E (`e2e/quest-model.spec.ts`)

Authenticated quest flows (claim race, undo, approval) require a seeded test family in Supabase — not possible without test credentials. These tests cover what's testable without auth:
- Auth gate verification: kid page, parent page, wall display
- Complete API error handling: 400 on bad body, 404 on unknown kid, 404 on undo of nonexistent completion
- Join page: unknown invite token doesn't crash

## Test plan

- [x] `npm test` — 72 passing
- [x] `npm run build` — clean
- [ ] CI: lint, typecheck, unit tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)