### PR TITLE
fix: prevent stale-UI coin deduction on redemption race condition

### DIFF
--- a/src/app/api/kid/[id]/redeem/__tests__/cancel.test.ts
+++ b/src/app/api/kid/[id]/redeem/__tests__/cancel.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/supabase/service', () => ({
+  createServiceClient: vi.fn(),
+}))
+
+import { createServiceClient } from '@/lib/supabase/service'
+import { DELETE } from '../[redemptionId]/route'
+
+function makeRequest() {
+  return new NextRequest('http://localhost/api/kid/kid-1/redeem/rdm-1', { method: 'DELETE' })
+}
+
+function makeParams(id = 'kid-1', redemptionId = 'rdm-1') {
+  return { params: Promise.resolve({ id, redemptionId }) }
+}
+
+function makeClient(opts: {
+  singleData?: { id: string } | null
+  deleteError?: { message: string } | null
+}) {
+  const { singleData = null, deleteError = null } = opts
+
+  const deleteChain = { eq: vi.fn().mockReturnThis(), then: undefined as unknown }
+  Object.defineProperty(deleteChain, 'then', {
+    get: () => (resolve: (v: { error: typeof deleteError }) => void) => resolve({ error: deleteError }),
+  })
+
+  const selectChain = {
+    eq: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue({ data: singleData, error: singleData ? null : { message: 'Not found' } }),
+  }
+
+  return {
+    from: vi.fn(() => ({
+      select: vi.fn().mockReturnValue(selectChain),
+      delete: vi.fn().mockReturnValue(deleteChain),
+    })),
+  }
+}
+
+beforeEach(() => { vi.clearAllMocks() })
+
+describe('DELETE /api/kid/[id]/redeem/[redemptionId]', () => {
+  it('returns 404 when redemption not found or already approved', async () => {
+    vi.mocked(createServiceClient).mockReturnValue(
+      makeClient({ singleData: null }) as unknown as ReturnType<typeof createServiceClient>
+    )
+    const res = await DELETE(makeRequest(), makeParams())
+    expect(res.status).toBe(404)
+    expect((await res.json()).error).toMatch(/not found|already approved/i)
+  })
+
+  it('returns 200 when redemption is pending and belongs to kid', async () => {
+    vi.mocked(createServiceClient).mockReturnValue(
+      makeClient({ singleData: { id: 'rdm-1' } }) as unknown as ReturnType<typeof createServiceClient>
+    )
+    const res = await DELETE(makeRequest(), makeParams())
+    expect(res.status).toBe(200)
+    expect((await res.json()).success).toBe(true)
+  })
+
+  it('returns 500 when the database delete fails', async () => {
+    vi.mocked(createServiceClient).mockReturnValue(
+      makeClient({ singleData: { id: 'rdm-1' }, deleteError: { message: 'DB error' } }) as unknown as ReturnType<typeof createServiceClient>
+    )
+    const res = await DELETE(makeRequest(), makeParams())
+    expect(res.status).toBe(500)
+  })
+
+  it('is idempotent: re-cancelling an already-cancelled redemption returns 404', async () => {
+    vi.mocked(createServiceClient).mockReturnValue(
+      makeClient({ singleData: null }) as unknown as ReturnType<typeof createServiceClient>
+    )
+    const res = await DELETE(makeRequest(), makeParams('kid-1', 'already-gone'))
+    expect(res.status).toBe(404)
+  })
+})

--- a/src/app/api/kid/[id]/redeem/__tests__/redeem.test.ts
+++ b/src/app/api/kid/[id]/redeem/__tests__/redeem.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/supabase/service', () => ({
+  createServiceClient: vi.fn(),
+}))
+
+import { createServiceClient } from '@/lib/supabase/service'
+import { POST } from '../route'
+
+function makeRequest(body: object) {
+  return new NextRequest('http://localhost/api/kid/kid-1/redeem', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function makeParams(id = 'kid-1') {
+  return { params: Promise.resolve({ id }) }
+}
+
+type Opts = {
+  kid?: { id: string; coins: number } | null
+  reward?: { id: string; cost: number } | null
+  pendingRedemptions?: Array<{ reward: { cost: number } | null }>
+  insertError?: object | null
+}
+
+function makeClient(opts: Opts) {
+  const {
+    kid = { id: 'kid-1', coins: 100 },
+    reward = { id: 'reward-1', cost: 20 },
+    pendingRedemptions = [],
+    insertError = null,
+  } = opts
+
+  // The route calls from('redemptions') twice: first a select for pending, then an insert.
+  const redemptionCalls = [
+    {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      then: (resolve: (v: { data: typeof pendingRedemptions; error: null }) => void) =>
+        resolve({ data: pendingRedemptions, error: null }),
+    },
+    { insert: vi.fn().mockResolvedValue({ error: insertError }) },
+  ]
+  let redemptionIdx = 0
+
+  return {
+    from: vi.fn((table: string) => {
+      if (table === 'kids') return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis(), single: vi.fn().mockResolvedValue({ data: kid }) }
+      if (table === 'rewards') return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis(), single: vi.fn().mockResolvedValue({ data: reward }) }
+      if (table === 'redemptions') return redemptionCalls[redemptionIdx++]
+      return {}
+    }),
+  }
+}
+
+beforeEach(() => { vi.clearAllMocks() })
+
+describe('POST /api/kid/[id]/redeem — available coins guard', () => {
+  it('returns 400 when pending deductions leave insufficient coins', async () => {
+    // 30 coins, 20 locked → 10 available, reward costs 15
+    vi.mocked(createServiceClient).mockReturnValue(
+      makeClient({ kid: { id: 'kid-1', coins: 30 }, reward: { id: 'r', cost: 15 }, pendingRedemptions: [{ reward: { cost: 20 } }] }) as unknown as ReturnType<typeof createServiceClient>
+    )
+    const res = await POST(makeRequest({ reward_id: 'r' }), makeParams())
+    expect(res.status).toBe(400)
+    expect((await res.json()).error).toMatch(/insufficient/i)
+  })
+
+  it('returns 200 when kid has exactly enough available coins', async () => {
+    // 35 coins, 20 locked → 15 available, reward costs 15
+    vi.mocked(createServiceClient).mockReturnValue(
+      makeClient({ kid: { id: 'kid-1', coins: 35 }, reward: { id: 'r', cost: 15 }, pendingRedemptions: [{ reward: { cost: 20 } }] }) as unknown as ReturnType<typeof createServiceClient>
+    )
+    const res = await POST(makeRequest({ reward_id: 'r' }), makeParams())
+    expect(res.status).toBe(200)
+    expect((await res.json()).success).toBe(true)
+  })
+
+  it('returns 400 when multiple pending redemptions lock up coins', async () => {
+    // 50 coins, 45 locked → 5 available, reward costs 10
+    vi.mocked(createServiceClient).mockReturnValue(
+      makeClient({ kid: { id: 'kid-1', coins: 50 }, reward: { id: 'r', cost: 10 }, pendingRedemptions: [{ reward: { cost: 30 } }, { reward: { cost: 15 } }] }) as unknown as ReturnType<typeof createServiceClient>
+    )
+    const res = await POST(makeRequest({ reward_id: 'r' }), makeParams())
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 on invalid request body', async () => {
+    vi.mocked(createServiceClient).mockReturnValue(
+      makeClient({}) as unknown as ReturnType<typeof createServiceClient>
+    )
+    const res = await POST(makeRequest({}), makeParams())
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 404 when kid does not exist', async () => {
+    vi.mocked(createServiceClient).mockReturnValue(
+      makeClient({ kid: null }) as unknown as ReturnType<typeof createServiceClient>
+    )
+    const res = await POST(makeRequest({ reward_id: 'r' }), makeParams())
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 404 when reward does not exist', async () => {
+    vi.mocked(createServiceClient).mockReturnValue(
+      makeClient({ reward: null }) as unknown as ReturnType<typeof createServiceClient>
+    )
+    const res = await POST(makeRequest({ reward_id: 'nonexistent' }), makeParams())
+    expect(res.status).toBe(404)
+  })
+
+  it('treats pending redemptions with null reward join as 0 cost', async () => {
+    // null reward row should not crash, counts as 0
+    vi.mocked(createServiceClient).mockReturnValue(
+      makeClient({ kid: { id: 'kid-1', coins: 50 }, reward: { id: 'r', cost: 10 }, pendingRedemptions: [{ reward: null }, { reward: { cost: 5 } }] }) as unknown as ReturnType<typeof createServiceClient>
+    )
+    const res = await POST(makeRequest({ reward_id: 'r' }), makeParams())
+    expect(res.status).toBe(200)
+  })
+})

--- a/src/app/parent/use-parent-actions.ts
+++ b/src/app/parent/use-parent-actions.ts
@@ -139,17 +139,31 @@ export function useParentActions(deps: Deps): ParentActions {
     const reward = redemption.reward as Reward | undefined
     if (!kid || !reward) return
 
-    const { error } = await supabase.from('redemptions').update({ status: 'approved' }).eq('id', redemptionId)
-    if (!error) {
-      await supabase.from('kids').update({ coins: Math.max(0, kid.coins - reward.cost) }).eq('id', kid.id)
-      toast.success(`${kid.name} got ${reward.title}! 🎁 -${reward.cost} coins`)
+    const { data: updated, error } = await supabase
+      .from('redemptions')
+      .update({ status: 'approved' })
+      .eq('id', redemptionId)
+      .eq('status', 'pending')
+      .select('id')
+
+    if (error || !updated || updated.length === 0) {
+      toast.error('Request was already cancelled by the kid')
       await refetch()
+      return
     }
+
+    await supabase.from('kids').update({ coins: Math.max(0, kid.coins - reward.cost) }).eq('id', kid.id)
+    toast.success(`${kid.name} got ${reward.title}! 🎁 -${reward.cost} coins`)
+    await refetch()
   }, [redemptions, refetch, supabase])
 
   const denyRedemption = useCallback(async (redemptionId: string) => {
-    await supabase.from('redemptions').delete().eq('id', redemptionId)
-    toast.success('Reward request denied')
+    const { count } = await supabase.from('redemptions').delete({ count: 'exact' }).eq('id', redemptionId)
+    if (count === 0) {
+      toast.success('Already cancelled by the kid')
+    } else {
+      toast.success('Reward request denied')
+    }
     await refetch()
   }, [refetch, supabase])
 


### PR DESCRIPTION
## Summary

- **`fulfillRedemption` race guard**: UPDATE now filters `.eq('status', 'pending')` and checks row count. If the kid cancelled before the parent clicked Approve, 0 rows update → error toast fires, no coins deducted.
- **`denyRedemption` race guard**: DELETE now checks `count`; if 0 rows affected the kid already cancelled → shows "Already cancelled by the kid" instead of "Reward request denied".
- **11 unit tests** covering the cancel DELETE route (404/200/500/idempotent) and the POST redeem route (available-coins guard with pending deductions, null reward join, missing kid/reward).

## Test plan

- [x] `npm test` — 83/83 passing
- [x] `npm run build` — clean
- [ ] Manual: parent approves a redemption the kid already cancelled → "Request was already cancelled by the kid" toast, coins unchanged
- [ ] Manual: parent denies a redemption the kid already cancelled → "Already cancelled by the kid" toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)