### PR TITLE
feat: marketing landing page + move wall display to /display

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,8 @@ ChoreQuest is a fantasy-themed family chore app. Parents manage quests and rewar
 ```
 src/
   app/
-    page.tsx                        # Wall display — real-time grid of kid columns (always fullscreen)
+    page.tsx                        # Marketing landing page (public, unauthenticated visitors)
+    display/page.tsx                # Wall display — real-time grid of kid columns (always fullscreen)
     login/page.tsx                  # Auth — email/password login and signup
     parent/page.tsx                 # Parent dashboard — 4 tabs: Approvals, Quests, Family, Rewards
     kid/[id]/page.tsx               # Kid view — PIN lock + quest board + rewards tab

--- a/src/app/display/page.tsx
+++ b/src/app/display/page.tsx
@@ -1,0 +1,572 @@
+'use client'
+
+export const dynamic = 'force-dynamic'
+
+import { useEffect, useState, useCallback } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+import Link from 'next/link'
+import { createClient } from '@/lib/supabase/client'
+import { StarField } from '@/components/star-field'
+import { KidColumn } from '@/components/kid-column'
+import type { Kid, Quest, Completion, Family, Reward } from '@/lib/types'
+import { KID_COLORS, TIER_CONFIG } from '@/lib/constants'
+import { questDateString, questWeekKey } from '@/lib/utils'
+import { toast } from 'sonner'
+
+export default function WallDisplay() {
+  const [family, setFamily] = useState<Family | null>(null)
+  const [kids, setKids] = useState<Kid[]>([])
+  const [quests, setQuests] = useState<Quest[]>([])
+  const [completions, setCompletions] = useState<Completion[]>([])
+  const [activeCurseCounts, setActiveCurseCounts] = useState<Record<string, number>>({})
+  const [loading, setLoading] = useState(true)
+  const [pendingCount, setPendingCount] = useState(0)
+  const [claimingBounty, setClaimingBounty] = useState<Quest | null>(null)
+  const [rewards, setRewards] = useState<Reward[]>([])
+  const [showRewards, setShowRewards] = useState(false)
+  const [isMobile, setIsMobile] = useState(false)
+  const [supabase] = useState(createClient)
+
+  const fetchData = useCallback(async () => {
+    const { data: profile } = await supabase
+      .from('profiles')
+      .select('family_id')
+      .single()
+
+    if (!profile) return
+
+    const [familyRes, kidsRes, questsRes, rewardsRes] = await Promise.all([
+      supabase.from('families').select('id, name, invite_token, daily_reset_hour, created_at').eq('id', profile.family_id).single(),
+      supabase.from('kids').select('id, name, avatar, color, coins, streak, last_completed_date, family_id, created_at').eq('family_id', profile.family_id).order('created_at'),
+      supabase.from('quests').select('*').eq('family_id', profile.family_id).eq('active', true).order('created_at'),
+      supabase.from('rewards').select('*').eq('available', true).order('cost'),
+    ])
+
+    const resetHour = familyRes.data?.daily_reset_hour ?? 0
+    const today = questDateString(resetHour)
+    const weekStart = questWeekKey(resetHour)
+
+    const [completionsRes, cursesRes] = await Promise.all([
+      supabase.from('completions').select('*').gte('date', weekStart).lte('date', today),
+      supabase.from('curse_instances').select('kid_id').eq('status', 'active'),
+    ])
+
+    if (familyRes.data) setFamily({ ...familyRes.data, has_parent_pin: false })
+    if (kidsRes.data) setKids(kidsRes.data)
+    if (questsRes.data) setQuests(questsRes.data)
+    if (rewardsRes.data) setRewards(rewardsRes.data)
+
+    const allCompletions = completionsRes.data ?? []
+    setCompletions(allCompletions)
+    setPendingCount(allCompletions.filter(c => c.status === 'pending' && c.date === today).length)
+
+    const counts: Record<string, number> = {}
+    for (const ci of cursesRes.data ?? []) {
+      counts[ci.kid_id] = (counts[ci.kid_id] ?? 0) + 1
+    }
+    setActiveCurseCounts(counts)
+
+    setLoading(false)
+  }, [supabase])
+
+  useEffect(() => {
+    const update = () => setIsMobile(window.innerWidth < 640)
+    update()
+    window.addEventListener('resize', update)
+    return () => window.removeEventListener('resize', update)
+  }, [])
+
+  useEffect(() => {
+    fetchData()
+
+    const channel = supabase
+      .channel('wall-realtime')
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'completions' }, fetchData)
+      .on('postgres_changes', { event: 'UPDATE', schema: 'public', table: 'kids' }, fetchData)
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'curse_instances' }, fetchData)
+      .subscribe()
+
+    return () => { supabase.removeChannel(channel) }
+  }, [fetchData, supabase])
+
+  const handleComplete = useCallback(
+    async (questId: string, kidId: string) => {
+      const quest = quests.find((q) => q.id === questId)
+      if (!quest) return
+
+      const today = questDateString(family?.daily_reset_hour ?? 0)
+
+      if (quest.kind === 'shared') {
+        const familyCount = completions.filter(c =>
+          c.quest_id === questId &&
+          (c.status === 'approved' || c.status === 'pending')
+        ).length
+        if (familyCount >= quest.slots) {
+          toast.error('All slots claimed!')
+          return
+        }
+      }
+
+      const { error } = await supabase.from('completions').insert({
+        quest_id: questId,
+        kid_id: kidId,
+        status: 'pending',
+        date: today,
+      })
+
+      if (error) {
+        toast.error(error.code === '23505' ? 'Already completed today!' : 'Something went wrong')
+        return
+      }
+
+      toast.success(`Quest submitted! ✨`, {
+        description: `${quest.coins} coins pending approval`,
+      })
+
+      await fetchData()
+    },
+    [quests, supabase, fetchData, family?.daily_reset_hour, completions]
+  )
+
+  const handleClaimBounty = useCallback(
+    async (questId: string, kidId: string) => {
+      await handleComplete(questId, kidId)
+      setClaimingBounty(null)
+    },
+    [handleComplete]
+  )
+
+  const today = questDateString(family?.daily_reset_hour ?? 0)
+  const dayOfWeek = new Date().getDay()
+
+  const getKidPersonalQuests = (kid: Kid) =>
+    quests.filter(q => {
+      if (q.kind !== 'personal') return false
+      if (q.assigned_to && q.assigned_to !== kid.id) return false
+      if (q.active_days?.length && !q.active_days.includes(dayOfWeek)) return false
+      return true
+    })
+
+  const bountyQuests = quests.filter(q => {
+    if (q.kind !== 'shared' && q.kind !== 'oneoff') return false
+    if (q.active_days?.length && !q.active_days.includes(dayOfWeek)) return false
+    return true
+  })
+
+  const getFamilyCount = (questId: string) =>
+    completions.filter(c =>
+      c.quest_id === questId &&
+      (c.status === 'approved' || c.status === 'pending')
+    ).length
+
+  const getKidCompletions = (kid: Kid) =>
+    completions.filter((c) => c.kid_id === kid.id)
+
+  const familySharedCompletions = completions.filter(c => {
+    const q = quests.find(qq => qq.id === c.quest_id)
+    return q?.kind === 'shared' || q?.kind === 'oneoff'
+  })
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-quest-void flex items-center justify-center">
+        <StarField />
+        <motion.p
+          className="relative z-10 font-heading text-3xl text-white/40"
+          animate={{ opacity: [0.3, 0.8, 0.3] }}
+          transition={{ duration: 2, repeat: Infinity }}
+        >
+          ✦ Loading the realm ✦
+        </motion.p>
+      </div>
+    )
+  }
+
+  if (kids.length === 0) {
+    return (
+      <div className="min-h-screen bg-quest-void flex items-center justify-center">
+        <StarField />
+        <motion.div
+          className="relative z-10 text-center px-6 max-w-md"
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+        >
+          <p className="text-7xl mb-6">🏰</p>
+          <h1 className="font-heading text-4xl font-bold text-white mb-4">Welcome, Realm Master</h1>
+          <p className="text-white/50 text-lg mb-8">
+            Add your young adventurers to begin the quests.
+          </p>
+          <Link
+            href="/parent"
+            className="inline-flex items-center gap-2 px-8 py-4 rounded-2xl font-bold text-lg transition-all"
+            style={{
+              background: 'rgba(251, 191, 36, 0.15)',
+              border: '1px solid rgba(251, 191, 36, 0.35)',
+              color: '#fbbf24',
+            }}
+          >
+            ⚙️ Set Up Your Realm
+          </Link>
+        </motion.div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-quest-void flex flex-col">
+      <StarField />
+
+      {/* Header */}
+      <motion.header
+        className="relative z-10 flex items-center justify-between px-4 sm:px-8 py-3 sm:py-5 flex-shrink-0"
+        initial={{ opacity: 0, y: -16 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.1 }}
+      >
+        <div className="flex-1" />
+
+        <div className="text-center">
+          <h1 className="font-heading text-2xl sm:text-4xl font-black text-gradient-gold tracking-widest">
+            ChoreQuest
+          </h1>
+          {family && (
+            <p className="hidden sm:block text-white/35 text-xs tracking-[0.3em] uppercase mt-1">
+              The {family.name} Realm
+            </p>
+          )}
+        </div>
+
+        <div className="flex-1 flex justify-end items-center gap-2 sm:gap-3">
+          <button
+            onClick={() => setShowRewards(true)}
+            className="flex items-center gap-1.5 px-2.5 sm:px-4 py-2 rounded-xl text-sm font-semibold transition-all"
+            style={{
+              background: 'rgba(251,191,36,0.08)',
+              border: '1px solid rgba(251,191,36,0.2)',
+              color: 'rgba(251,191,36,0.7)',
+            }}
+          >
+            🎁<span className="hidden sm:inline"> Rewards</span>
+          </button>
+          {pendingCount > 0 && (
+            <motion.div
+              animate={{ scale: [1, 1.04, 1] }}
+              transition={{ duration: 1.8, repeat: Infinity }}
+            >
+              <Link
+                href="/parent"
+                className="flex items-center gap-1.5 px-2.5 sm:px-4 py-2 rounded-xl text-sm font-semibold transition-all"
+                style={{
+                  background: 'rgba(251, 191, 36, 0.14)',
+                  border: '1px solid rgba(251, 191, 36, 0.32)',
+                  color: '#fbbf24',
+                }}
+              >
+                <span className="relative flex h-2 w-2 flex-shrink-0">
+                  <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-cq-gold opacity-75" />
+                  <span className="relative inline-flex rounded-full h-2 w-2 bg-cq-gold" />
+                </span>
+                <span className="hidden sm:inline">{pendingCount} pending</span>
+              </Link>
+            </motion.div>
+          )}
+          <Link
+            href="/parent"
+            className="px-2.5 sm:px-4 py-2 rounded-xl text-sm text-white/50 hover:text-white/80 transition-all glass border-glass"
+          >
+            ⚙️<span className="hidden sm:inline"> Parent</span>
+          </Link>
+        </div>
+      </motion.header>
+
+      {/* Kid columns */}
+      <main
+        className="relative z-10 flex-1 grid gap-4 sm:gap-6 px-4 sm:px-8 pb-4 min-h-0"
+        style={{ gridTemplateColumns: `repeat(${isMobile ? 1 : kids.length}, 1fr)` }}
+      >
+        {kids.map((kid, i) => (
+          <motion.div
+            key={kid.id}
+            initial={{ opacity: 0, y: 24 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.2 + i * 0.08, type: 'spring', stiffness: 220, damping: 24 }}
+            className="min-h-0 flex flex-col"
+          >
+            <KidColumn
+              kid={kid}
+              quests={getKidPersonalQuests(kid)}
+              completions={getKidCompletions(kid)}
+              today={today}
+              familySharedCompletions={familySharedCompletions}
+              activeCurseCount={activeCurseCounts[kid.id] ?? 0}
+              onComplete={(questId) => handleComplete(questId, kid.id)}
+              linkToKidView
+            />
+          </motion.div>
+        ))}
+      </main>
+
+      {/* Bounty Board */}
+      {bountyQuests.length > 0 && (
+        <motion.section
+          className="relative z-10 px-4 sm:px-8 pb-6 flex-shrink-0"
+          initial={{ opacity: 0, y: 16 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.5 }}
+        >
+          <div className="flex items-center gap-3 mb-4">
+            <div className="flex-1 h-px" style={{ background: 'rgba(251,191,36,0.18)' }} />
+            <span
+              className="text-xs font-bold tracking-[0.2em] uppercase px-3 py-1 rounded-full flex-shrink-0"
+              style={{
+                background: 'rgba(251,191,36,0.1)',
+                border: '1px solid rgba(251,191,36,0.25)',
+                color: 'rgba(251,191,36,0.8)',
+              }}
+            >
+              ⚡ Bounty Board
+            </span>
+            <div className="flex-1 h-px" style={{ background: 'rgba(251,191,36,0.18)' }} />
+          </div>
+
+          <div
+            className="grid gap-3"
+            style={{ gridTemplateColumns: `repeat(${isMobile ? Math.min(bountyQuests.length, 2) : Math.min(bountyQuests.length, 4)}, 1fr)` }}
+          >
+            {bountyQuests.map((quest, i) => {
+              const count = getFamilyCount(quest.id)
+              const isFull = count >= quest.slots
+              const tier = TIER_CONFIG[quest.tier ?? 'normal']
+              return (
+                <motion.button
+                  key={quest.id}
+                  onClick={() => !isFull && setClaimingBounty(quest)}
+                  disabled={isFull}
+                  className="rounded-2xl p-4 text-left relative overflow-hidden"
+                  style={{
+                    background: isFull ? 'rgba(255,255,255,0.02)' : tier.bg,
+                    border: `1px solid ${isFull ? 'rgba(255,255,255,0.06)' : tier.border}`,
+                    boxShadow: isFull ? 'none' : (tier.glow ?? 'none'),
+                    opacity: isFull ? 0.5 : 1,
+                  }}
+                  initial={{ opacity: 0, y: 12 }}
+                  animate={{ opacity: isFull ? 0.5 : 1, y: 0 }}
+                  transition={{ delay: 0.55 + i * 0.06 }}
+                  whileHover={!isFull ? { scale: 1.02 } : {}}
+                  whileTap={!isFull ? { scale: 0.97 } : {}}
+                >
+                  <div className="flex items-start justify-between gap-2 mb-2">
+                    <span className="text-2xl">{quest.icon}</span>
+                    <div className="text-right">
+                      <div className="flex items-center gap-1 justify-end">
+                        <span className="text-sm">🪙</span>
+                        <span className="font-bold text-sm" style={{ color: isFull ? 'rgba(255,255,255,0.3)' : tier.color }}>
+                          {quest.coins}
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+
+                  <p className={`text-sm font-semibold leading-snug mb-2 ${isFull ? 'text-white/30' : 'text-white/90'}`}>
+                    {quest.title}
+                  </p>
+
+                  <div className="flex items-center justify-between">
+                    <span
+                      className="text-xs px-1.5 py-0.5 rounded-md font-semibold"
+                      style={{
+                        background: `${tier.color}18`,
+                        color: isFull ? 'rgba(255,255,255,0.25)' : tier.color,
+                        border: `1px solid ${tier.color}30`,
+                      }}
+                    >
+                      {tier.label}
+                    </span>
+                    <span className="text-xs" style={{ color: isFull ? 'rgba(74,222,128,0.7)' : 'rgba(255,255,255,0.4)' }}>
+                      {isFull ? '✓ all claimed' : `${count}/${quest.slots} taken`}
+                    </span>
+                  </div>
+                </motion.button>
+              )
+            })}
+          </div>
+        </motion.section>
+      )}
+
+      <motion.footer
+        className="relative z-10 text-center pb-4 text-white/20 text-xs tracking-[0.25em] uppercase flex-shrink-0"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ delay: 0.9 }}
+      >
+        ✦ tap a quest to complete it ✦
+      </motion.footer>
+
+      {/* Rewards quick-view modal */}
+      <AnimatePresence>
+        {showRewards && (
+          <motion.div
+            className="fixed inset-0 z-50 flex items-center justify-center"
+            style={{ background: 'rgba(0,0,0,0.8)', backdropFilter: 'blur(10px)' }}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            onClick={() => setShowRewards(false)}
+          >
+            <motion.div
+              className="rounded-3xl mx-4 w-full max-w-sm sm:max-w-lg overflow-hidden"
+              style={{
+                background: 'rgba(10,6,28,0.98)',
+                border: '1px solid rgba(251,191,36,0.18)',
+                boxShadow: '0 0 80px rgba(0,0,0,0.7), 0 0 40px rgba(251,191,36,0.06)',
+                maxHeight: '80vh',
+                display: 'flex',
+                flexDirection: 'column',
+              }}
+              initial={{ scale: 0.88, opacity: 0, y: 20 }}
+              animate={{ scale: 1, opacity: 1, y: 0 }}
+              exit={{ scale: 0.88, opacity: 0, y: 20 }}
+              transition={{ type: 'spring', stiffness: 340, damping: 28 }}
+              onClick={(e) => e.stopPropagation()}
+            >
+              {/* Modal header */}
+              <div
+                className="px-7 pt-6 pb-4 flex-shrink-0"
+                style={{ borderBottom: '1px solid rgba(255,255,255,0.06)' }}
+              >
+                <div className="flex items-center justify-between">
+                  <div>
+                    <h2 className="font-heading text-xl font-bold text-white/90 tracking-wide">
+                      🏆 Reward Vault
+                    </h2>
+                    <p className="text-white/35 text-xs mt-0.5">Spend your coins wisely, adventurer</p>
+                  </div>
+                  <button
+                    onClick={() => setShowRewards(false)}
+                    className="w-8 h-8 rounded-full flex items-center justify-center text-white/30 hover:text-white/60 transition-all"
+                    style={{ background: 'rgba(255,255,255,0.05)', border: '1px solid rgba(255,255,255,0.08)' }}
+                  >
+                    ✕
+                  </button>
+                </div>
+              </div>
+
+              {/* Rewards list */}
+              <div className="overflow-y-auto px-7 py-4 flex-1 flex flex-col gap-3">
+                {rewards.length === 0 ? (
+                  <div className="flex flex-col items-center justify-center py-12 text-white/25">
+                    <span className="text-4xl mb-3">🎁</span>
+                    <p className="text-sm">No rewards set up yet</p>
+                    <Link href="/parent" className="text-xs text-cq-gold/50 hover:text-cq-gold/80 mt-2 transition-all" onClick={() => setShowRewards(false)}>
+                      Add rewards in the parent dashboard →
+                    </Link>
+                  </div>
+                ) : (
+                  rewards.map((reward, i) => (
+                    <motion.div
+                      key={reward.id}
+                      className="flex items-center gap-4 rounded-2xl p-4"
+                      style={{
+                        background: 'rgba(255,255,255,0.03)',
+                        border: '1px solid rgba(255,255,255,0.07)',
+                      }}
+                      initial={{ opacity: 0, x: -10 }}
+                      animate={{ opacity: 1, x: 0 }}
+                      transition={{ delay: i * 0.04 }}
+                    >
+                      <span className="text-3xl flex-shrink-0">{reward.icon}</span>
+                      <div className="flex-1 min-w-0">
+                        <p className="text-sm font-semibold text-white/88 leading-snug">{reward.title}</p>
+                        {reward.description && (
+                          <p className="text-xs text-white/35 mt-0.5 truncate">{reward.description}</p>
+                        )}
+                      </div>
+                      <div className="flex-shrink-0 flex items-center gap-1.5 px-3 py-1.5 rounded-xl"
+                        style={{ background: 'rgba(251,191,36,0.1)', border: '1px solid rgba(251,191,36,0.22)' }}
+                      >
+                        <span className="text-sm">🪙</span>
+                        <span className="font-heading font-bold text-sm" style={{ color: '#fbbf24' }}>
+                          {reward.cost}
+                        </span>
+                      </div>
+                    </motion.div>
+                  ))
+                )}
+              </div>
+
+              {/* Footer hint */}
+              {rewards.length > 0 && (
+                <div
+                  className="px-7 py-4 flex-shrink-0 text-center"
+                  style={{ borderTop: '1px solid rgba(255,255,255,0.06)' }}
+                >
+                  <p className="text-white/25 text-xs">Visit your personal quest page to redeem rewards</p>
+                </div>
+              )}
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* Kid picker modal for bounty claims */}
+      <AnimatePresence>
+        {claimingBounty && (
+          <motion.div
+            className="fixed inset-0 z-50 flex items-center justify-center"
+            style={{ background: 'rgba(0,0,0,0.75)', backdropFilter: 'blur(8px)' }}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            onClick={() => setClaimingBounty(null)}
+          >
+            <motion.div
+              className="rounded-3xl p-7 mx-4 max-w-sm w-full"
+              style={{
+                background: 'rgba(12,8,32,0.97)',
+                border: '1px solid rgba(255,255,255,0.1)',
+                boxShadow: '0 0 60px rgba(0,0,0,0.6)',
+              }}
+              initial={{ scale: 0.88, opacity: 0, y: 16 }}
+              animate={{ scale: 1, opacity: 1, y: 0 }}
+              exit={{ scale: 0.88, opacity: 0, y: 16 }}
+              transition={{ type: 'spring', stiffness: 340, damping: 28 }}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className="flex items-center gap-3 justify-center mb-2">
+                <span className="text-3xl">{claimingBounty.icon}</span>
+                <p className="font-heading font-bold text-lg text-white/90">{claimingBounty.title}</p>
+              </div>
+              <p className="text-center text-white/40 text-sm mb-6">Who&apos;s doing this bounty?</p>
+
+              <div className="flex gap-4 justify-center">
+                {kids.map(kid => {
+                  const colors = KID_COLORS[kid.color]
+                  return (
+                    <motion.button
+                      key={kid.id}
+                      onClick={() => handleClaimBounty(claimingBounty.id, kid.id)}
+                      className="flex flex-col items-center gap-2 px-6 py-4 rounded-2xl"
+                      style={{ background: colors.bg, border: `1px solid ${colors.border}` }}
+                      whileHover={{ scale: 1.06, boxShadow: `0 0 20px ${colors.glow}` }}
+                      whileTap={{ scale: 0.95 }}
+                    >
+                      <span className="text-4xl">{kid.avatar}</span>
+                      <span className="text-sm font-bold" style={{ color: colors.primary }}>{kid.name}</span>
+                    </motion.button>
+                  )
+                })}
+              </div>
+
+              <button
+                onClick={() => setClaimingBounty(null)}
+                className="mt-5 w-full text-center text-white/25 text-sm hover:text-white/50 transition-all"
+              >
+                Cancel
+              </button>
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  )
+}

--- a/src/app/kid/[id]/page.tsx
+++ b/src/app/kid/[id]/page.tsx
@@ -312,7 +312,7 @@ export default function KidPage({ params }: { params: Promise<{ id: string }> })
           </div>
 
           <Link
-            href="/"
+            href="/display"
             className="mt-8 inline-block text-white/25 text-sm hover:text-white/50 transition-all"
           >
             ← Back to realm
@@ -353,7 +353,7 @@ export default function KidPage({ params }: { params: Promise<{ id: string }> })
           initial={{ opacity: 0, y: -16 }}
           animate={{ opacity: 1, y: 0 }}
         >
-          <Link href="/" className="text-white/40 hover:text-white/70 transition-all text-sm">
+          <Link href="/display" className="text-white/40 hover:text-white/70 transition-all text-sm">
             ← Realm
           </Link>
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,572 +1,621 @@
 'use client'
 
-export const dynamic = 'force-dynamic'
-
-import { useEffect, useState, useCallback } from 'react'
-import { motion, AnimatePresence } from 'framer-motion'
+import { useRef } from 'react'
+import { motion, useInView } from 'framer-motion'
 import Link from 'next/link'
-import { createClient } from '@/lib/supabase/client'
 import { StarField } from '@/components/star-field'
-import { KidColumn } from '@/components/kid-column'
-import type { Kid, Quest, Completion, Family, Reward } from '@/lib/types'
-import { KID_COLORS, TIER_CONFIG } from '@/lib/constants'
-import { questDateString, questWeekKey } from '@/lib/utils'
-import { toast } from 'sonner'
 
-export default function WallDisplay() {
-  const [family, setFamily] = useState<Family | null>(null)
-  const [kids, setKids] = useState<Kid[]>([])
-  const [quests, setQuests] = useState<Quest[]>([])
-  const [completions, setCompletions] = useState<Completion[]>([])
-  const [activeCurseCounts, setActiveCurseCounts] = useState<Record<string, number>>({})
-  const [loading, setLoading] = useState(true)
-  const [pendingCount, setPendingCount] = useState(0)
-  const [claimingBounty, setClaimingBounty] = useState<Quest | null>(null)
-  const [rewards, setRewards] = useState<Reward[]>([])
-  const [showRewards, setShowRewards] = useState(false)
-  const [isMobile, setIsMobile] = useState(false)
-  const [supabase] = useState(createClient)
-
-  const fetchData = useCallback(async () => {
-    const { data: profile } = await supabase
-      .from('profiles')
-      .select('family_id')
-      .single()
-
-    if (!profile) return
-
-    const [familyRes, kidsRes, questsRes, rewardsRes] = await Promise.all([
-      supabase.from('families').select('id, name, invite_token, daily_reset_hour, created_at').eq('id', profile.family_id).single(),
-      supabase.from('kids').select('id, name, avatar, color, coins, streak, last_completed_date, family_id, created_at').eq('family_id', profile.family_id).order('created_at'),
-      supabase.from('quests').select('*').eq('family_id', profile.family_id).eq('active', true).order('created_at'),
-      supabase.from('rewards').select('*').eq('available', true).order('cost'),
-    ])
-
-    const resetHour = familyRes.data?.daily_reset_hour ?? 0
-    const today = questDateString(resetHour)
-    const weekStart = questWeekKey(resetHour)
-
-    const [completionsRes, cursesRes] = await Promise.all([
-      supabase.from('completions').select('*').gte('date', weekStart).lte('date', today),
-      supabase.from('curse_instances').select('kid_id').eq('status', 'active'),
-    ])
-
-    if (familyRes.data) setFamily({ ...familyRes.data, has_parent_pin: false })
-    if (kidsRes.data) setKids(kidsRes.data)
-    if (questsRes.data) setQuests(questsRes.data)
-    if (rewardsRes.data) setRewards(rewardsRes.data)
-
-    const allCompletions = completionsRes.data ?? []
-    setCompletions(allCompletions)
-    setPendingCount(allCompletions.filter(c => c.status === 'pending' && c.date === today).length)
-
-    const counts: Record<string, number> = {}
-    for (const ci of cursesRes.data ?? []) {
-      counts[ci.kid_id] = (counts[ci.kid_id] ?? 0) + 1
-    }
-    setActiveCurseCounts(counts)
-
-    setLoading(false)
-  }, [supabase])
-
-  useEffect(() => {
-    const update = () => setIsMobile(window.innerWidth < 640)
-    update()
-    window.addEventListener('resize', update)
-    return () => window.removeEventListener('resize', update)
-  }, [])
-
-  useEffect(() => {
-    fetchData()
-
-    const channel = supabase
-      .channel('wall-realtime')
-      .on('postgres_changes', { event: '*', schema: 'public', table: 'completions' }, fetchData)
-      .on('postgres_changes', { event: 'UPDATE', schema: 'public', table: 'kids' }, fetchData)
-      .on('postgres_changes', { event: '*', schema: 'public', table: 'curse_instances' }, fetchData)
-      .subscribe()
-
-    return () => { supabase.removeChannel(channel) }
-  }, [fetchData, supabase])
-
-  const handleComplete = useCallback(
-    async (questId: string, kidId: string) => {
-      const quest = quests.find((q) => q.id === questId)
-      if (!quest) return
-
-      const today = questDateString(family?.daily_reset_hour ?? 0)
-
-      if (quest.kind === 'shared') {
-        const familyCount = completions.filter(c =>
-          c.quest_id === questId &&
-          (c.status === 'approved' || c.status === 'pending')
-        ).length
-        if (familyCount >= quest.slots) {
-          toast.error('All slots claimed!')
-          return
-        }
-      }
-
-      const { error } = await supabase.from('completions').insert({
-        quest_id: questId,
-        kid_id: kidId,
-        status: 'pending',
-        date: today,
-      })
-
-      if (error) {
-        toast.error(error.code === '23505' ? 'Already completed today!' : 'Something went wrong')
-        return
-      }
-
-      toast.success(`Quest submitted! ✨`, {
-        description: `${quest.coins} coins pending approval`,
-      })
-
-      await fetchData()
-    },
-    [quests, supabase, fetchData, family?.daily_reset_hour, completions]
+// ─── Scroll-reveal wrapper ────────────────────────────────────────────────────
+function Reveal({ children, delay = 0, className = '' }: { children: React.ReactNode; delay?: number; className?: string }) {
+  const ref = useRef(null)
+  const inView = useInView(ref, { once: true, margin: '-60px' })
+  return (
+    <motion.div
+      ref={ref}
+      className={className}
+      initial={{ opacity: 0, y: 28 }}
+      animate={inView ? { opacity: 1, y: 0 } : {}}
+      transition={{ duration: 0.65, delay, ease: [0.22, 1, 0.36, 1] }}
+    >
+      {children}
+    </motion.div>
   )
+}
 
-  const handleClaimBounty = useCallback(
-    async (questId: string, kidId: string) => {
-      await handleComplete(questId, kidId)
-      setClaimingBounty(null)
-    },
-    [handleComplete]
+// ─── Static app mockup shown in the hero ────────────────────────────────────
+function AppMockup() {
+  return (
+    <div
+      className="relative rounded-2xl overflow-hidden w-full max-w-2xl mx-auto"
+      style={{
+        background: 'rgba(5,3,16,0.95)',
+        border: '1px solid rgba(255,255,255,0.1)',
+        boxShadow: '0 0 80px rgba(56,189,248,0.08), 0 0 120px rgba(167,139,250,0.06), 0 40px 80px rgba(0,0,0,0.6)',
+      }}
+    >
+      {/* Top bar */}
+      <div className="flex items-center justify-between px-5 py-3 border-b border-white/[0.06]">
+        <span className="font-heading text-sm font-bold tracking-widest text-cq-gold">ChoreQuest</span>
+        <span className="text-white/30 text-xs tracking-widest uppercase">The Rivera Realm</span>
+        <div className="flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-xs font-semibold"
+          style={{ background: 'rgba(251,191,36,0.12)', border: '1px solid rgba(251,191,36,0.25)', color: '#fbbf24' }}>
+          <span className="relative flex h-1.5 w-1.5">
+            <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-cq-gold opacity-75" />
+            <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-cq-gold" />
+          </span>
+          2 pending
+        </div>
+      </div>
+
+      {/* Two kid columns */}
+      <div className="grid grid-cols-2 gap-3 p-4">
+        {/* Emma — azure */}
+        <MockKidColumn
+          name="Emma" avatar="🧙‍♀️" color="azure"
+          coins={340} streak={7}
+          quests={[
+            { title: 'Make your bed', icon: '🛏️', coins: 15, status: 'approved' },
+            { title: 'Feed the cat', icon: '🐱', coins: 20, status: 'pending', tier: 'heroic' },
+            { title: 'Clean desk', icon: '📚', coins: 25, status: 'todo' },
+          ]}
+        />
+        {/* Liam — mystic */}
+        <MockKidColumn
+          name="Liam" avatar="🧝‍♂️" color="mystic"
+          coins={210} streak={3}
+          quests={[
+            { title: 'Take out trash', icon: '🗑️', coins: 30, status: 'approved', tier: 'heroic' },
+            { title: 'Unload dishwasher', icon: '🍽️', coins: 20, status: 'todo' },
+            { title: 'Vacuum living room', icon: '🧹', coins: 50, status: 'todo', tier: 'legendary' },
+          ]}
+        />
+      </div>
+
+      {/* Bounty board strip */}
+      <div className="px-4 pb-4">
+        <div className="flex items-center gap-2 mb-2">
+          <div className="flex-1 h-px" style={{ background: 'rgba(251,191,36,0.15)' }} />
+          <span className="text-[10px] tracking-widest uppercase font-bold px-2 py-0.5 rounded-full"
+            style={{ background: 'rgba(251,191,36,0.1)', border: '1px solid rgba(251,191,36,0.2)', color: 'rgba(251,191,36,0.7)' }}>
+            ⚡ Bounty Board
+          </span>
+          <div className="flex-1 h-px" style={{ background: 'rgba(251,191,36,0.15)' }} />
+        </div>
+        <div className="flex gap-2">
+          <MockBountyCard title="Wash the car" icon="🚗" coins={100} claimed={0} slots={1} tier="epic" />
+          <MockBountyCard title="Mow the lawn" icon="🌿" coins={75} claimed={1} slots={2} tier="legendary" />
+        </div>
+      </div>
+    </div>
   )
+}
 
-  const today = questDateString(family?.daily_reset_hour ?? 0)
-  const dayOfWeek = new Date().getDay()
+type QuestStatus = 'todo' | 'pending' | 'approved'
+type QuestTier = 'normal' | 'heroic' | 'legendary' | 'epic'
 
-  const getKidPersonalQuests = (kid: Kid) =>
-    quests.filter(q => {
-      if (q.kind !== 'personal') return false
-      if (q.assigned_to && q.assigned_to !== kid.id) return false
-      if (q.active_days?.length && !q.active_days.includes(dayOfWeek)) return false
-      return true
-    })
+const TIER_COLORS: Record<QuestTier, string> = {
+  normal: '#fbbf24',
+  heroic: '#38bdf8',
+  legendary: '#fbbf24',
+  epic: '#a78bfa',
+}
 
-  const bountyQuests = quests.filter(q => {
-    if (q.kind !== 'shared' && q.kind !== 'oneoff') return false
-    if (q.active_days?.length && !q.active_days.includes(dayOfWeek)) return false
-    return true
-  })
-
-  const getFamilyCount = (questId: string) =>
-    completions.filter(c =>
-      c.quest_id === questId &&
-      (c.status === 'approved' || c.status === 'pending')
-    ).length
-
-  const getKidCompletions = (kid: Kid) =>
-    completions.filter((c) => c.kid_id === kid.id)
-
-  const familySharedCompletions = completions.filter(c => {
-    const q = quests.find(qq => qq.id === c.quest_id)
-    return q?.kind === 'shared' || q?.kind === 'oneoff'
-  })
-
-  if (loading) {
-    return (
-      <div className="min-h-screen bg-quest-void flex items-center justify-center">
-        <StarField />
-        <motion.p
-          className="relative z-10 font-heading text-3xl text-white/40"
-          animate={{ opacity: [0.3, 0.8, 0.3] }}
-          transition={{ duration: 2, repeat: Infinity }}
-        >
-          ✦ Loading the realm ✦
-        </motion.p>
-      </div>
-    )
-  }
-
-  if (kids.length === 0) {
-    return (
-      <div className="min-h-screen bg-quest-void flex items-center justify-center">
-        <StarField />
-        <motion.div
-          className="relative z-10 text-center px-6 max-w-md"
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-        >
-          <p className="text-7xl mb-6">🏰</p>
-          <h1 className="font-heading text-4xl font-bold text-white mb-4">Welcome, Realm Master</h1>
-          <p className="text-white/50 text-lg mb-8">
-            Add your young adventurers to begin the quests.
-          </p>
-          <Link
-            href="/parent"
-            className="inline-flex items-center gap-2 px-8 py-4 rounded-2xl font-bold text-lg transition-all"
-            style={{
-              background: 'rgba(251, 191, 36, 0.15)',
-              border: '1px solid rgba(251, 191, 36, 0.35)',
-              color: '#fbbf24',
-            }}
-          >
-            ⚙️ Set Up Your Realm
-          </Link>
-        </motion.div>
-      </div>
-    )
-  }
+function MockKidColumn({ name, avatar, color, coins, streak, quests }: {
+  name: string; avatar: string; color: 'azure' | 'mystic'
+  coins: number; streak: number
+  quests: { title: string; icon: string; coins: number; status: QuestStatus; tier?: QuestTier }[]
+}) {
+  const primary = color === 'azure' ? '#38bdf8' : '#a78bfa'
+  const bg = color === 'azure' ? 'rgba(56,189,248,0.07)' : 'rgba(167,139,250,0.07)'
+  const border = color === 'azure' ? 'rgba(56,189,248,0.25)' : 'rgba(167,139,250,0.25)'
 
   return (
-    <div className="min-h-screen bg-quest-void flex flex-col">
+    <div className="rounded-xl overflow-hidden" style={{ background: bg, border: `1px solid ${border}` }}>
+      {/* Kid header */}
+      <div className="px-3 py-2.5 flex items-center justify-between border-b" style={{ borderColor: `${primary}20` }}>
+        <div className="flex items-center gap-1.5">
+          <span className="text-lg">{avatar}</span>
+          <span className="font-heading text-sm font-bold" style={{ color: primary }}>{name}</span>
+          {streak >= 3 && <span className="text-xs text-cq-ember">🔥{streak}</span>}
+        </div>
+        <span className="text-xs font-bold text-cq-gold">🪙{coins}</span>
+      </div>
+      {/* Quest list */}
+      <div className="p-2 flex flex-col gap-1.5">
+        {quests.map((q, i) => {
+          const tier = (q.tier ?? 'normal') as QuestTier
+          const tc = TIER_COLORS[tier]
+          const statusBg = q.status === 'approved' ? 'rgba(74,222,128,0.07)' : q.status === 'pending' ? 'rgba(251,191,36,0.08)' : 'rgba(255,255,255,0.03)'
+          const statusBorder = q.status === 'approved' ? 'rgba(74,222,128,0.2)' : q.status === 'pending' ? 'rgba(251,191,36,0.25)' : 'rgba(255,255,255,0.07)'
+          return (
+            <div key={i} className="rounded-lg px-2.5 py-2 flex items-center gap-2"
+              style={{ background: statusBg, border: `1px solid ${statusBorder}` }}>
+              <span className="text-sm">{q.icon}</span>
+              <span className="flex-1 text-xs font-medium truncate" style={{
+                color: q.status === 'approved' ? 'rgba(255,255,255,0.35)' : 'rgba(255,255,255,0.85)',
+                textDecoration: q.status === 'approved' ? 'line-through' : 'none',
+              }}>{q.title}</span>
+              {q.status === 'pending' ? (
+                <motion.span className="text-[10px] text-amber-400"
+                  animate={{ opacity: [0.5, 1, 0.5] }}
+                  transition={{ duration: 1.6, repeat: Infinity }}>⏳</motion.span>
+              ) : q.status === 'approved' ? (
+                <span className="text-[10px] text-cq-forest">✓</span>
+              ) : (
+                <span className="text-[10px] font-bold" style={{ color: tc }}>🪙{q.coins}</span>
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+function MockBountyCard({ title, icon, coins, claimed, slots, tier }: {
+  title: string; icon: string; coins: number; claimed: number; slots: number; tier: QuestTier
+}) {
+  const tc = TIER_COLORS[tier]
+  const isFull = claimed >= slots
+  return (
+    <div className="flex-1 rounded-xl p-2.5" style={{
+      background: isFull ? 'rgba(255,255,255,0.02)' : `${tc}10`,
+      border: `1px solid ${isFull ? 'rgba(255,255,255,0.06)' : `${tc}30`}`,
+      opacity: isFull ? 0.5 : 1,
+    }}>
+      <div className="flex items-start justify-between mb-1">
+        <span className="text-base">{icon}</span>
+        <span className="text-[10px] font-bold" style={{ color: tc }}>🪙{coins}</span>
+      </div>
+      <p className="text-xs font-semibold text-white/80 leading-tight mb-1">{title}</p>
+      <span className="text-[10px]" style={{ color: isFull ? '#4ade80' : 'rgba(255,255,255,0.35)' }}>
+        {isFull ? '✓ claimed' : `${claimed}/${slots} taken`}
+      </span>
+    </div>
+  )
+}
+
+// ─── Feature cards ────────────────────────────────────────────────────────────
+const FEATURES = [
+  {
+    icon: '🖥️',
+    title: 'Live Wall Display',
+    desc: 'Put it on your TV or tablet. Every quest, every kid, updating in real time — the whole family can see who\'s crushing it.',
+    color: '#38bdf8',
+  },
+  {
+    icon: '⭐',
+    title: 'Quest Tiers',
+    desc: 'Normal, Heroic, Legendary, Epic. Bigger jobs earn bigger coins. Kids learn that effort has a reward scale.',
+    color: '#fbbf24',
+  },
+  {
+    icon: '🔥',
+    title: 'Streak Multipliers',
+    desc: '3-day streak: +25% coins. 7-day: 1.5×. 14-day: double coins. The longer they go, the more they earn.',
+    color: '#fb923c',
+  },
+  {
+    icon: '⚡',
+    title: 'Family Bounty Board',
+    desc: 'Shared quests siblings compete for. First to claim a slot wins — natural motivation without parent nagging.',
+    color: '#a78bfa',
+  },
+  {
+    icon: '🎁',
+    title: 'Custom Reward Store',
+    desc: 'You set the prizes: screen time, a trip to the movies, a new toy. Real-world rewards make coins matter.',
+    color: '#4ade80',
+  },
+  {
+    icon: '🔒',
+    title: 'PIN Protection',
+    desc: 'Every kid gets their own PIN. Parents lock their dashboard separately. No accidental approvals, no meddling.',
+    color: '#38bdf8',
+  },
+]
+
+const HOW_IT_WORKS = [
+  { step: '01', icon: '🗡️', title: 'You set the quests', desc: 'Create daily or weekly quests for each kid — or shared bounties the whole family can race to complete.' },
+  { step: '02', icon: '⚔️', title: 'Kids complete their board', desc: 'Each kid logs in with their PIN and taps quests done. The wall display updates instantly for the whole family to see.' },
+  { step: '03', icon: '🪙', title: 'Earn coins, claim rewards', desc: 'You approve completed quests and coins are awarded. Kids redeem coins from your custom reward store.' },
+]
+
+// ─── Main page ────────────────────────────────────────────────────────────────
+export default function MarketingPage() {
+  return (
+    <div className="min-h-screen bg-quest-void text-white overflow-x-hidden">
       <StarField />
 
-      {/* Header */}
-      <motion.header
-        className="relative z-10 flex items-center justify-between px-4 sm:px-8 py-3 sm:py-5 flex-shrink-0"
-        initial={{ opacity: 0, y: -16 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ delay: 0.1 }}
+      {/* ── Nav ── */}
+      <header
+        className="fixed top-0 left-0 right-0 z-50 flex items-center justify-between px-6 py-4"
+        style={{ background: 'rgba(5,3,16,0.8)', backdropFilter: 'blur(16px)', borderBottom: '1px solid rgba(255,255,255,0.06)' }}
       >
-        <div className="flex-1" />
-
-        <div className="text-center">
-          <h1 className="font-heading text-2xl sm:text-4xl font-black text-gradient-gold tracking-widest">
-            ChoreQuest
-          </h1>
-          {family && (
-            <p className="hidden sm:block text-white/35 text-xs tracking-[0.3em] uppercase mt-1">
-              The {family.name} Realm
-            </p>
-          )}
+        <div className="flex items-center gap-2">
+          <span className="text-xl">⚔️</span>
+          <span className="font-heading font-bold text-lg tracking-widest text-white/90">ChoreQuest</span>
         </div>
+        <nav className="hidden md:flex items-center gap-8 text-sm text-white/45 font-medium">
+          <a href="#how-it-works" className="hover:text-white/80 transition-colors">How It Works</a>
+          <a href="#features" className="hover:text-white/80 transition-colors">Features</a>
+          <a href="#pricing" className="hover:text-white/80 transition-colors">Pricing</a>
+        </nav>
+        <Link
+          href="/login"
+          className="px-5 py-2 rounded-xl text-sm font-bold transition-all"
+          style={{ background: 'rgba(251,191,36,0.15)', border: '1px solid rgba(251,191,36,0.35)', color: '#fbbf24' }}
+        >
+          Start Free →
+        </Link>
+      </header>
 
-        <div className="flex-1 flex justify-end items-center gap-2 sm:gap-3">
-          <button
-            onClick={() => setShowRewards(true)}
-            className="flex items-center gap-1.5 px-2.5 sm:px-4 py-2 rounded-xl text-sm font-semibold transition-all"
+      {/* ── Hero ── */}
+      <section className="relative z-10 pt-32 pb-20 px-6 text-center">
+        <motion.div
+          initial={{ opacity: 0, y: -12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5 }}
+          className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full text-xs font-semibold mb-8"
+          style={{ background: 'rgba(251,191,36,0.1)', border: '1px solid rgba(251,191,36,0.25)', color: 'rgba(251,191,36,0.9)' }}
+        >
+          ✦ The chore app kids actually want to use
+        </motion.div>
+
+        <motion.h1
+          className="font-heading font-black text-5xl sm:text-7xl leading-none tracking-tight mb-6"
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.7, delay: 0.1 }}
+        >
+          <span className="text-white/90">Turn chores into</span>
+          <br />
+          <span
+            className="inline-block mt-1"
             style={{
-              background: 'rgba(251,191,36,0.08)',
-              border: '1px solid rgba(251,191,36,0.2)',
-              color: 'rgba(251,191,36,0.7)',
+              background: 'linear-gradient(135deg, #fbbf24 0%, #fb923c 50%, #fbbf24 100%)',
+              backgroundClip: 'text',
+              WebkitBackgroundClip: 'text',
+              WebkitTextFillColor: 'transparent',
+              backgroundSize: '200%',
             }}
           >
-            🎁<span className="hidden sm:inline"> Rewards</span>
-          </button>
-          {pendingCount > 0 && (
-            <motion.div
-              animate={{ scale: [1, 1.04, 1] }}
-              transition={{ duration: 1.8, repeat: Infinity }}
-            >
-              <Link
-                href="/parent"
-                className="flex items-center gap-1.5 px-2.5 sm:px-4 py-2 rounded-xl text-sm font-semibold transition-all"
+            Legendary Quests
+          </span>
+        </motion.h1>
+
+        <motion.p
+          className="text-white/50 text-lg sm:text-xl max-w-xl mx-auto mb-10 leading-relaxed"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: 0.6, delay: 0.25 }}
+        >
+          A fantasy quest board that makes your kids compete to help around the house — with real-time family displays, coin rewards, and streak bonuses.
+        </motion.p>
+
+        <motion.div
+          className="flex flex-col sm:flex-row items-center justify-center gap-3 mb-16"
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5, delay: 0.35 }}
+        >
+          <Link
+            href="/login"
+            className="group w-full sm:w-auto px-8 py-4 rounded-2xl text-base font-bold transition-all"
+            style={{
+              background: 'linear-gradient(135deg, rgba(251,191,36,0.25), rgba(251,191,36,0.12))',
+              border: '1px solid rgba(251,191,36,0.45)',
+              color: '#fbbf24',
+              boxShadow: '0 0 30px rgba(251,191,36,0.12)',
+            }}
+          >
+            Start for free — no credit card
+          </Link>
+          <a
+            href="#how-it-works"
+            className="w-full sm:w-auto px-8 py-4 rounded-2xl text-base font-semibold text-white/50 hover:text-white/80 transition-all glass border-glass"
+          >
+            See how it works ↓
+          </a>
+        </motion.div>
+
+        {/* App mockup */}
+        <motion.div
+          initial={{ opacity: 0, y: 40, scale: 0.96 }}
+          animate={{ opacity: 1, y: 0, scale: 1 }}
+          transition={{ duration: 0.9, delay: 0.45, ease: [0.22, 1, 0.36, 1] }}
+          className="relative"
+        >
+          {/* Glow behind mockup */}
+          <div
+            className="absolute inset-0 -z-10 blur-3xl opacity-30"
+            style={{ background: 'radial-gradient(ellipse at center, rgba(56,189,248,0.4) 0%, rgba(167,139,250,0.3) 50%, transparent 70%)' }}
+          />
+          <AppMockup />
+        </motion.div>
+      </section>
+
+      {/* ── How it works ── */}
+      <section id="how-it-works" className="relative z-10 py-24 px-6">
+        <div className="max-w-4xl mx-auto">
+          <Reveal className="text-center mb-16">
+            <p className="text-xs font-bold tracking-[0.3em] uppercase text-white/30 mb-3">The System</p>
+            <h2 className="font-heading text-4xl sm:text-5xl font-bold text-white/90">Three steps to a calmer home</h2>
+          </Reveal>
+
+          <div className="grid sm:grid-cols-3 gap-6">
+            {HOW_IT_WORKS.map((step, i) => (
+              <Reveal key={step.step} delay={i * 0.1}>
+                <div
+                  className="rounded-2xl p-7 h-full"
+                  style={{ background: 'rgba(255,255,255,0.03)', border: '1px solid rgba(255,255,255,0.07)' }}
+                >
+                  <div className="flex items-center gap-3 mb-5">
+                    <span
+                      className="font-heading text-xs font-bold tracking-widest px-2 py-1 rounded-lg"
+                      style={{ background: 'rgba(251,191,36,0.1)', border: '1px solid rgba(251,191,36,0.2)', color: 'rgba(251,191,36,0.7)' }}
+                    >
+                      {step.step}
+                    </span>
+                    <span className="text-2xl">{step.icon}</span>
+                  </div>
+                  <h3 className="font-heading text-lg font-bold text-white/90 mb-3">{step.title}</h3>
+                  <p className="text-white/45 text-sm leading-relaxed">{step.desc}</p>
+                </div>
+              </Reveal>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── Features ── */}
+      <section id="features" className="relative z-10 py-24 px-6">
+        <div className="max-w-5xl mx-auto">
+          <Reveal className="text-center mb-16">
+            <p className="text-xs font-bold tracking-[0.3em] uppercase text-white/30 mb-3">Everything you need</p>
+            <h2 className="font-heading text-4xl sm:text-5xl font-bold text-white/90">Built different, on purpose</h2>
+            <p className="text-white/40 mt-4 max-w-lg mx-auto">Every other chore app looks like a spreadsheet. ChoreQuest looks like the game your kids already play.</p>
+          </Reveal>
+
+          <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {FEATURES.map((f, i) => (
+              <Reveal key={f.title} delay={i * 0.07}>
+                <div
+                  className="rounded-2xl p-6 h-full group hover:scale-[1.02] transition-transform"
+                  style={{
+                    background: `linear-gradient(135deg, ${f.color}08 0%, rgba(255,255,255,0.02) 100%)`,
+                    border: `1px solid ${f.color}20`,
+                  }}
+                >
+                  <span className="text-3xl block mb-4">{f.icon}</span>
+                  <h3 className="font-heading text-base font-bold mb-2" style={{ color: f.color }}>{f.title}</h3>
+                  <p className="text-white/45 text-sm leading-relaxed">{f.desc}</p>
+                </div>
+              </Reveal>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── For parents / for kids ── */}
+      <section className="relative z-10 py-24 px-6">
+        <div className="max-w-4xl mx-auto">
+          <Reveal className="text-center mb-16">
+            <h2 className="font-heading text-4xl sm:text-5xl font-bold text-white/90">Designed for both sides</h2>
+          </Reveal>
+
+          <div className="grid sm:grid-cols-2 gap-5">
+            {/* Parents */}
+            <Reveal>
+              <div
+                className="rounded-2xl p-8 h-full"
+                style={{ background: 'rgba(251,191,36,0.05)', border: '1px solid rgba(251,191,36,0.18)' }}
+              >
+                <p className="text-xs font-bold tracking-[0.3em] uppercase text-cq-gold/60 mb-4">For Parents</p>
+                <h3 className="font-heading text-2xl font-bold text-white/90 mb-6">Full control, less nagging</h3>
+                <ul className="flex flex-col gap-3">
+                  {[
+                    '✓ Create quests with tiers, schedules, and coins',
+                    '✓ Approve or reject completions with one tap',
+                    '✓ Set a custom reward store with real-world prizes',
+                    '✓ PIN-lock your dashboard so kids stay out',
+                    '✓ Cast "curses" — deduct coins for bad behavior',
+                    '✓ Invite kids via QR code or share link',
+                  ].map(item => (
+                    <li key={item} className="text-white/55 text-sm flex gap-2.5">
+                      <span className="text-cq-gold/70 flex-shrink-0">{item.slice(0, 1)}</span>
+                      <span>{item.slice(2)}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </Reveal>
+
+            {/* Kids */}
+            <Reveal delay={0.1}>
+              <div
+                className="rounded-2xl p-8 h-full"
+                style={{ background: 'rgba(167,139,250,0.05)', border: '1px solid rgba(167,139,250,0.18)' }}
+              >
+                <p className="text-xs font-bold tracking-[0.3em] uppercase text-cq-mystic/60 mb-4">For Kids</p>
+                <h3 className="font-heading text-2xl font-bold text-white/90 mb-6">Their own realm to conquer</h3>
+                <ul className="flex flex-col gap-3">
+                  {[
+                    '✓ Personal PIN — their space is theirs',
+                    '✓ Quest board sorted by daily and weekly goals',
+                    '✓ Watch coins build up in real time',
+                    '✓ Redeem coins for rewards parents actually give',
+                    '✓ Streak flames show daily consistency',
+                    '✓ Race siblings for shared bounty quests',
+                  ].map(item => (
+                    <li key={item} className="text-white/55 text-sm flex gap-2.5">
+                      <span className="text-cq-mystic/70 flex-shrink-0">{item.slice(0, 1)}</span>
+                      <span>{item.slice(2)}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </Reveal>
+          </div>
+        </div>
+      </section>
+
+      {/* ── Pricing ── */}
+      <section id="pricing" className="relative z-10 py-24 px-6">
+        <div className="max-w-3xl mx-auto">
+          <Reveal className="text-center mb-16">
+            <p className="text-xs font-bold tracking-[0.3em] uppercase text-white/30 mb-3">Pricing</p>
+            <h2 className="font-heading text-4xl sm:text-5xl font-bold text-white/90">Simple, honest pricing</h2>
+          </Reveal>
+
+          <div className="grid sm:grid-cols-2 gap-5">
+            {/* Free */}
+            <Reveal>
+              <div
+                className="rounded-2xl p-8 h-full"
+                style={{ background: 'rgba(255,255,255,0.03)', border: '1px solid rgba(255,255,255,0.1)' }}
+              >
+                <p className="font-heading text-xs tracking-widest uppercase text-white/35 mb-2">Free</p>
+                <div className="flex items-baseline gap-1 mb-1">
+                  <span className="font-heading text-5xl font-black text-white/90">$0</span>
+                  <span className="text-white/30 text-sm">/ forever</span>
+                </div>
+                <p className="text-white/35 text-sm mb-8">Everything you need to run the realm</p>
+                <ul className="flex flex-col gap-2.5 mb-8">
+                  {[
+                    'Up to 5 kids', 'Unlimited quests', 'All quest tiers', 'Custom rewards',
+                    'Wall display', 'Streak system', 'Bounty board', 'Family invite links',
+                  ].map(f => (
+                    <li key={f} className="text-white/55 text-sm flex items-center gap-2">
+                      <span className="text-cq-forest text-xs">✓</span> {f}
+                    </li>
+                  ))}
+                </ul>
+                <Link
+                  href="/login"
+                  className="block w-full text-center px-6 py-3 rounded-xl font-bold text-sm transition-all"
+                  style={{ background: 'rgba(255,255,255,0.08)', border: '1px solid rgba(255,255,255,0.12)', color: 'rgba(255,255,255,0.8)' }}
+                >
+                  Get started free
+                </Link>
+              </div>
+            </Reveal>
+
+            {/* Pro */}
+            <Reveal delay={0.1}>
+              <div
+                className="rounded-2xl p-8 h-full relative overflow-hidden"
                 style={{
-                  background: 'rgba(251, 191, 36, 0.14)',
-                  border: '1px solid rgba(251, 191, 36, 0.32)',
-                  color: '#fbbf24',
+                  background: 'linear-gradient(135deg, rgba(251,191,36,0.08) 0%, rgba(251,191,36,0.03) 100%)',
+                  border: '1px solid rgba(251,191,36,0.3)',
+                  boxShadow: '0 0 40px rgba(251,191,36,0.06)',
                 }}
               >
-                <span className="relative flex h-2 w-2 flex-shrink-0">
-                  <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-cq-gold opacity-75" />
-                  <span className="relative inline-flex rounded-full h-2 w-2 bg-cq-gold" />
-                </span>
-                <span className="hidden sm:inline">{pendingCount} pending</span>
-              </Link>
-            </motion.div>
-          )}
-          <Link
-            href="/parent"
-            className="px-2.5 sm:px-4 py-2 rounded-xl text-sm text-white/50 hover:text-white/80 transition-all glass border-glass"
-          >
-            ⚙️<span className="hidden sm:inline"> Parent</span>
-          </Link>
-        </div>
-      </motion.header>
-
-      {/* Kid columns */}
-      <main
-        className="relative z-10 flex-1 grid gap-4 sm:gap-6 px-4 sm:px-8 pb-4 min-h-0"
-        style={{ gridTemplateColumns: `repeat(${isMobile ? 1 : kids.length}, 1fr)` }}
-      >
-        {kids.map((kid, i) => (
-          <motion.div
-            key={kid.id}
-            initial={{ opacity: 0, y: 24 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: 0.2 + i * 0.08, type: 'spring', stiffness: 220, damping: 24 }}
-            className="min-h-0 flex flex-col"
-          >
-            <KidColumn
-              kid={kid}
-              quests={getKidPersonalQuests(kid)}
-              completions={getKidCompletions(kid)}
-              today={today}
-              familySharedCompletions={familySharedCompletions}
-              activeCurseCount={activeCurseCounts[kid.id] ?? 0}
-              onComplete={(questId) => handleComplete(questId, kid.id)}
-              linkToKidView
-            />
-          </motion.div>
-        ))}
-      </main>
-
-      {/* Bounty Board */}
-      {bountyQuests.length > 0 && (
-        <motion.section
-          className="relative z-10 px-4 sm:px-8 pb-6 flex-shrink-0"
-          initial={{ opacity: 0, y: 16 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.5 }}
-        >
-          <div className="flex items-center gap-3 mb-4">
-            <div className="flex-1 h-px" style={{ background: 'rgba(251,191,36,0.18)' }} />
-            <span
-              className="text-xs font-bold tracking-[0.2em] uppercase px-3 py-1 rounded-full flex-shrink-0"
-              style={{
-                background: 'rgba(251,191,36,0.1)',
-                border: '1px solid rgba(251,191,36,0.25)',
-                color: 'rgba(251,191,36,0.8)',
-              }}
-            >
-              ⚡ Bounty Board
-            </span>
-            <div className="flex-1 h-px" style={{ background: 'rgba(251,191,36,0.18)' }} />
-          </div>
-
-          <div
-            className="grid gap-3"
-            style={{ gridTemplateColumns: `repeat(${isMobile ? Math.min(bountyQuests.length, 2) : Math.min(bountyQuests.length, 4)}, 1fr)` }}
-          >
-            {bountyQuests.map((quest, i) => {
-              const count = getFamilyCount(quest.id)
-              const isFull = count >= quest.slots
-              const tier = TIER_CONFIG[quest.tier ?? 'normal']
-              return (
-                <motion.button
-                  key={quest.id}
-                  onClick={() => !isFull && setClaimingBounty(quest)}
-                  disabled={isFull}
-                  className="rounded-2xl p-4 text-left relative overflow-hidden"
-                  style={{
-                    background: isFull ? 'rgba(255,255,255,0.02)' : tier.bg,
-                    border: `1px solid ${isFull ? 'rgba(255,255,255,0.06)' : tier.border}`,
-                    boxShadow: isFull ? 'none' : (tier.glow ?? 'none'),
-                    opacity: isFull ? 0.5 : 1,
-                  }}
-                  initial={{ opacity: 0, y: 12 }}
-                  animate={{ opacity: isFull ? 0.5 : 1, y: 0 }}
-                  transition={{ delay: 0.55 + i * 0.06 }}
-                  whileHover={!isFull ? { scale: 1.02 } : {}}
-                  whileTap={!isFull ? { scale: 0.97 } : {}}
-                >
-                  <div className="flex items-start justify-between gap-2 mb-2">
-                    <span className="text-2xl">{quest.icon}</span>
-                    <div className="text-right">
-                      <div className="flex items-center gap-1 justify-end">
-                        <span className="text-sm">🪙</span>
-                        <span className="font-bold text-sm" style={{ color: isFull ? 'rgba(255,255,255,0.3)' : tier.color }}>
-                          {quest.coins}
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-
-                  <p className={`text-sm font-semibold leading-snug mb-2 ${isFull ? 'text-white/30' : 'text-white/90'}`}>
-                    {quest.title}
-                  </p>
-
-                  <div className="flex items-center justify-between">
-                    <span
-                      className="text-xs px-1.5 py-0.5 rounded-md font-semibold"
-                      style={{
-                        background: `${tier.color}18`,
-                        color: isFull ? 'rgba(255,255,255,0.25)' : tier.color,
-                        border: `1px solid ${tier.color}30`,
-                      }}
-                    >
-                      {tier.label}
-                    </span>
-                    <span className="text-xs" style={{ color: isFull ? 'rgba(74,222,128,0.7)' : 'rgba(255,255,255,0.4)' }}>
-                      {isFull ? '✓ all claimed' : `${count}/${quest.slots} taken`}
-                    </span>
-                  </div>
-                </motion.button>
-              )
-            })}
-          </div>
-        </motion.section>
-      )}
-
-      <motion.footer
-        className="relative z-10 text-center pb-4 text-white/20 text-xs tracking-[0.25em] uppercase flex-shrink-0"
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        transition={{ delay: 0.9 }}
-      >
-        ✦ tap a quest to complete it ✦
-      </motion.footer>
-
-      {/* Rewards quick-view modal */}
-      <AnimatePresence>
-        {showRewards && (
-          <motion.div
-            className="fixed inset-0 z-50 flex items-center justify-center"
-            style={{ background: 'rgba(0,0,0,0.8)', backdropFilter: 'blur(10px)' }}
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            onClick={() => setShowRewards(false)}
-          >
-            <motion.div
-              className="rounded-3xl mx-4 w-full max-w-sm sm:max-w-lg overflow-hidden"
-              style={{
-                background: 'rgba(10,6,28,0.98)',
-                border: '1px solid rgba(251,191,36,0.18)',
-                boxShadow: '0 0 80px rgba(0,0,0,0.7), 0 0 40px rgba(251,191,36,0.06)',
-                maxHeight: '80vh',
-                display: 'flex',
-                flexDirection: 'column',
-              }}
-              initial={{ scale: 0.88, opacity: 0, y: 20 }}
-              animate={{ scale: 1, opacity: 1, y: 0 }}
-              exit={{ scale: 0.88, opacity: 0, y: 20 }}
-              transition={{ type: 'spring', stiffness: 340, damping: 28 }}
-              onClick={(e) => e.stopPropagation()}
-            >
-              {/* Modal header */}
-              <div
-                className="px-7 pt-6 pb-4 flex-shrink-0"
-                style={{ borderBottom: '1px solid rgba(255,255,255,0.06)' }}
-              >
-                <div className="flex items-center justify-between">
-                  <div>
-                    <h2 className="font-heading text-xl font-bold text-white/90 tracking-wide">
-                      🏆 Reward Vault
-                    </h2>
-                    <p className="text-white/35 text-xs mt-0.5">Spend your coins wisely, adventurer</p>
-                  </div>
-                  <button
-                    onClick={() => setShowRewards(false)}
-                    className="w-8 h-8 rounded-full flex items-center justify-center text-white/30 hover:text-white/60 transition-all"
-                    style={{ background: 'rgba(255,255,255,0.05)', border: '1px solid rgba(255,255,255,0.08)' }}
-                  >
-                    ✕
-                  </button>
-                </div>
-              </div>
-
-              {/* Rewards list */}
-              <div className="overflow-y-auto px-7 py-4 flex-1 flex flex-col gap-3">
-                {rewards.length === 0 ? (
-                  <div className="flex flex-col items-center justify-center py-12 text-white/25">
-                    <span className="text-4xl mb-3">🎁</span>
-                    <p className="text-sm">No rewards set up yet</p>
-                    <Link href="/parent" className="text-xs text-cq-gold/50 hover:text-cq-gold/80 mt-2 transition-all" onClick={() => setShowRewards(false)}>
-                      Add rewards in the parent dashboard →
-                    </Link>
-                  </div>
-                ) : (
-                  rewards.map((reward, i) => (
-                    <motion.div
-                      key={reward.id}
-                      className="flex items-center gap-4 rounded-2xl p-4"
-                      style={{
-                        background: 'rgba(255,255,255,0.03)',
-                        border: '1px solid rgba(255,255,255,0.07)',
-                      }}
-                      initial={{ opacity: 0, x: -10 }}
-                      animate={{ opacity: 1, x: 0 }}
-                      transition={{ delay: i * 0.04 }}
-                    >
-                      <span className="text-3xl flex-shrink-0">{reward.icon}</span>
-                      <div className="flex-1 min-w-0">
-                        <p className="text-sm font-semibold text-white/88 leading-snug">{reward.title}</p>
-                        {reward.description && (
-                          <p className="text-xs text-white/35 mt-0.5 truncate">{reward.description}</p>
-                        )}
-                      </div>
-                      <div className="flex-shrink-0 flex items-center gap-1.5 px-3 py-1.5 rounded-xl"
-                        style={{ background: 'rgba(251,191,36,0.1)', border: '1px solid rgba(251,191,36,0.22)' }}
-                      >
-                        <span className="text-sm">🪙</span>
-                        <span className="font-heading font-bold text-sm" style={{ color: '#fbbf24' }}>
-                          {reward.cost}
-                        </span>
-                      </div>
-                    </motion.div>
-                  ))
-                )}
-              </div>
-
-              {/* Footer hint */}
-              {rewards.length > 0 && (
                 <div
-                  className="px-7 py-4 flex-shrink-0 text-center"
-                  style={{ borderTop: '1px solid rgba(255,255,255,0.06)' }}
+                  className="absolute top-4 right-4 text-[10px] font-bold tracking-wider uppercase px-2.5 py-1 rounded-full"
+                  style={{ background: 'rgba(251,191,36,0.15)', border: '1px solid rgba(251,191,36,0.3)', color: '#fbbf24' }}
                 >
-                  <p className="text-white/25 text-xs">Visit your personal quest page to redeem rewards</p>
+                  Coming soon
                 </div>
-              )}
-            </motion.div>
-          </motion.div>
-        )}
-      </AnimatePresence>
+                <p className="font-heading text-xs tracking-widest uppercase text-cq-gold/50 mb-2">Family Pro</p>
+                <div className="flex items-baseline gap-1 mb-1">
+                  <span className="font-heading text-5xl font-black text-cq-gold">$5</span>
+                  <span className="text-white/30 text-sm">/ month</span>
+                </div>
+                <p className="text-white/35 text-sm mb-8">For power families who want more</p>
+                <ul className="flex flex-col gap-2.5 mb-8">
+                  {[
+                    'Everything in Free',
+                    'Unlimited kids',
+                    'Quest completion history',
+                    'Coin analytics & charts',
+                    'Custom realm themes',
+                    'Multiple families / households',
+                    'Priority support',
+                    'Early access to new features',
+                  ].map(f => (
+                    <li key={f} className="text-white/55 text-sm flex items-center gap-2">
+                      <span className="text-cq-gold/60 text-xs">✦</span> {f}
+                    </li>
+                  ))}
+                </ul>
+                <button
+                  disabled
+                  className="block w-full text-center px-6 py-3 rounded-xl font-bold text-sm opacity-50 cursor-not-allowed"
+                  style={{ background: 'rgba(251,191,36,0.12)', border: '1px solid rgba(251,191,36,0.25)', color: '#fbbf24' }}
+                >
+                  Notify me when available
+                </button>
+              </div>
+            </Reveal>
+          </div>
+        </div>
+      </section>
 
-      {/* Kid picker modal for bounty claims */}
-      <AnimatePresence>
-        {claimingBounty && (
-          <motion.div
-            className="fixed inset-0 z-50 flex items-center justify-center"
-            style={{ background: 'rgba(0,0,0,0.75)', backdropFilter: 'blur(8px)' }}
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            onClick={() => setClaimingBounty(null)}
+      {/* ── CTA banner ── */}
+      <section className="relative z-10 py-24 px-6">
+        <Reveal>
+          <div
+            className="max-w-2xl mx-auto rounded-3xl p-12 text-center relative overflow-hidden"
+            style={{
+              background: 'linear-gradient(135deg, rgba(251,191,36,0.1) 0%, rgba(167,139,250,0.08) 100%)',
+              border: '1px solid rgba(251,191,36,0.25)',
+              boxShadow: '0 0 60px rgba(251,191,36,0.06)',
+            }}
           >
             <motion.div
-              className="rounded-3xl p-7 mx-4 max-w-sm w-full"
-              style={{
-                background: 'rgba(12,8,32,0.97)',
-                border: '1px solid rgba(255,255,255,0.1)',
-                boxShadow: '0 0 60px rgba(0,0,0,0.6)',
-              }}
-              initial={{ scale: 0.88, opacity: 0, y: 16 }}
-              animate={{ scale: 1, opacity: 1, y: 0 }}
-              exit={{ scale: 0.88, opacity: 0, y: 16 }}
-              transition={{ type: 'spring', stiffness: 340, damping: 28 }}
-              onClick={(e) => e.stopPropagation()}
+              className="absolute inset-0 pointer-events-none"
+              initial={{ x: '-120%' }}
+              animate={{ x: '220%' }}
+              transition={{ duration: 4, repeat: Infinity, repeatDelay: 6, ease: 'easeInOut' }}
             >
-              <div className="flex items-center gap-3 justify-center mb-2">
-                <span className="text-3xl">{claimingBounty.icon}</span>
-                <p className="font-heading font-bold text-lg text-white/90">{claimingBounty.title}</p>
-              </div>
-              <p className="text-center text-white/40 text-sm mb-6">Who&apos;s doing this bounty?</p>
-
-              <div className="flex gap-4 justify-center">
-                {kids.map(kid => {
-                  const colors = KID_COLORS[kid.color]
-                  return (
-                    <motion.button
-                      key={kid.id}
-                      onClick={() => handleClaimBounty(claimingBounty.id, kid.id)}
-                      className="flex flex-col items-center gap-2 px-6 py-4 rounded-2xl"
-                      style={{ background: colors.bg, border: `1px solid ${colors.border}` }}
-                      whileHover={{ scale: 1.06, boxShadow: `0 0 20px ${colors.glow}` }}
-                      whileTap={{ scale: 0.95 }}
-                    >
-                      <span className="text-4xl">{kid.avatar}</span>
-                      <span className="text-sm font-bold" style={{ color: colors.primary }}>{kid.name}</span>
-                    </motion.button>
-                  )
-                })}
-              </div>
-
-              <button
-                onClick={() => setClaimingBounty(null)}
-                className="mt-5 w-full text-center text-white/25 text-sm hover:text-white/50 transition-all"
-              >
-                Cancel
-              </button>
+              <div
+                className="absolute inset-y-0 w-1/3 -skew-x-12"
+                style={{ background: 'linear-gradient(90deg, transparent, rgba(251,191,36,0.06), transparent)' }}
+              />
             </motion.div>
-          </motion.div>
-        )}
-      </AnimatePresence>
+            <p className="text-4xl mb-5">🏰</p>
+            <h2 className="font-heading text-3xl sm:text-4xl font-bold text-white/90 mb-4">
+              Ready to begin the quest?
+            </h2>
+            <p className="text-white/45 mb-8 max-w-md mx-auto">
+              Free forever. No credit card. Set up your family realm in under 5 minutes.
+            </p>
+            <Link
+              href="/login"
+              className="inline-block px-10 py-4 rounded-2xl text-base font-bold transition-all"
+              style={{
+                background: 'linear-gradient(135deg, rgba(251,191,36,0.28), rgba(251,191,36,0.14))',
+                border: '1px solid rgba(251,191,36,0.5)',
+                color: '#fbbf24',
+                boxShadow: '0 0 30px rgba(251,191,36,0.15)',
+              }}
+            >
+              Create your realm — it&apos;s free →
+            </Link>
+          </div>
+        </Reveal>
+      </section>
+
+      {/* ── Footer ── */}
+      <footer
+        className="relative z-10 py-12 px-6"
+        style={{ borderTop: '1px solid rgba(255,255,255,0.06)' }}
+      >
+        <div className="max-w-4xl mx-auto flex flex-col sm:flex-row items-center justify-between gap-6">
+          <div className="flex items-center gap-2">
+            <span className="text-xl">⚔️</span>
+            <span className="font-heading font-bold tracking-widest text-white/60">ChoreQuest</span>
+          </div>
+          <p className="text-white/25 text-sm text-center">
+            No ads. No tracking. Family-safe. Built with love for our own chaotic household.
+          </p>
+          <div className="flex items-center gap-5 text-white/30 text-sm">
+            <Link href="/login" className="hover:text-white/60 transition-colors">Sign in</Link>
+            <Link href="/login" className="hover:text-white/60 transition-colors">Sign up</Link>
+          </div>
+        </div>
+      </footer>
     </div>
   )
 }

--- a/src/app/parent/page.tsx
+++ b/src/app/parent/page.tsx
@@ -85,7 +85,7 @@ export default function ParentDashboard() {
           initial={{ opacity: 0, y: -12 }}
           animate={{ opacity: 1, y: 0 }}
         >
-          <Link href="/" className="text-white/40 hover:text-white/70 transition-all text-sm flex-shrink-0">
+          <Link href="/display" className="text-white/40 hover:text-white/70 transition-all text-sm flex-shrink-0">
             ← Realm
           </Link>
           <div className="flex-1 text-center">

--- a/src/app/parent/pin-lock-screen.tsx
+++ b/src/app/parent/pin-lock-screen.tsx
@@ -79,7 +79,7 @@ export function PinLockScreen({ lockPinInput, lockPinError, parentLockedUntil, n
           ))}
         </div>
 
-        <Link href="/" className="block mt-8 text-white/25 text-sm hover:text-white/50 transition-all">
+        <Link href="/display" className="block mt-8 text-white/25 text-sm hover:text-white/50 transition-all">
           ← Back to Realm
         </Link>
       </motion.div>

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -30,6 +30,7 @@ export async function proxy(request: NextRequest) {
 
   const path = request.nextUrl.pathname
   const isPublic =
+    path === '/' ||
     path === '/login' ||
     path.startsWith('/api/') ||
     path.startsWith('/join/') ||
@@ -41,9 +42,10 @@ export async function proxy(request: NextRequest) {
     return NextResponse.redirect(url)
   }
 
-  if (user && path === '/login') {
+  // Authenticated users: skip the marketing page and login, go straight to the display
+  if (user && (path === '/' || path === '/login')) {
     const url = request.nextUrl.clone()
-    url.pathname = '/'
+    url.pathname = '/display'
     return NextResponse.redirect(url)
   }
 


### PR DESCRIPTION
Closes #11

## What's in this PR

### Marketing page (`/`)
Full SaaS landing page targeting new families. Public route — no auth required. Authenticated users are redirected straight to `/display` by the middleware.

**Sections:**
- **Nav**: sticky glass bar with logo, section links, gold CTA
- **Hero**: full-viewport with StarField, animated gradient headline "Turn chores into Legendary Quests", static app mockup showing two kid columns with real quest card states (approved/pending/todo), two CTAs
- **How It Works**: 3-step grid (Create quests → Kids complete → Earn & redeem)
- **Features**: 6-card grid — Live Wall Display, Quest Tiers, Streak Multipliers, Family Bounty Board, Custom Reward Store, PIN Protection — each color-coded to the design system
- **For Parents / For Kids**: side-by-side benefit lists
- **Pricing**: Free forever tier (all current features) + Family Pro stub ($5/mo, coming soon)
- **CTA banner**: shimmer animation, "Create your realm" link
- **Footer**: tagline, sign in/up links

### Route changes
- Wall display moved: `/` → `/display` (identical component, new path)
- `proxy.ts`: `/` added to public routes; authenticated users on `/` or `/login` now redirect to `/display`
- "← Realm" links in parent dashboard, kid view, and pin lock screen updated to `/display`

## Test plan
- [ ] Unauthenticated: `chorequest.dresponda.com` shows marketing page
- [ ] Authenticated: `chorequest.dresponda.com` redirects to `/display`
- [ ] Authenticated: `/login` redirects to `/display`
- [ ] Unauthenticated: `/display` redirects to `/login`
- [ ] All existing "← Realm" links in app now point to `/display`
- [ ] CI: lint, typecheck, unit tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)