### PR TITLE
feat: replace emoji with game-icons.net SVG set

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "next-themes": "^0.4.6",
         "react": "19.2.4",
         "react-dom": "19.2.4",
+        "react-icons": "^5.6.0",
         "react-markdown": "^10.1.0",
         "react-qr-code": "^2.0.21",
         "shadcn": "^4.6.0",
@@ -12560,6 +12561,15 @@
       },
       "peerDependencies": {
         "react": "^19.2.4"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.6.0.tgz",
+      "integrity": "sha512-RH93p5ki6LfOiIt0UtDyNg/cee+HLVR6cHHtW3wALfo+eOHTp8RnU2kRkI6E+H19zMIs03DyxUG/GfZMOGvmiA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "next-themes": "^0.4.6",
     "react": "19.2.4",
     "react-dom": "19.2.4",
+    "react-icons": "^5.6.0",
     "react-markdown": "^10.1.0",
     "react-qr-code": "^2.0.21",
     "shadcn": "^4.6.0",

--- a/src/app/display/page.tsx
+++ b/src/app/display/page.tsx
@@ -10,6 +10,7 @@ import { StarField } from '@/components/star-field'
 import { KidColumn } from '@/components/kid-column'
 import type { Kid, Quest, Completion, Family, Reward } from '@/lib/types'
 import { KID_COLORS, TIER_CONFIG } from '@/lib/constants'
+import { AppIcon } from '@/components/app-icon'
 import { questDateString, questWeekKey } from '@/lib/utils'
 import { toast } from 'sonner'
 
@@ -356,7 +357,7 @@ export default function WallDisplay() {
                   whileTap={!isFull ? { scale: 0.97 } : {}}
                 >
                   <div className="flex items-start justify-between gap-2 mb-2">
-                    <span className="text-2xl">{quest.icon}</span>
+                    <AppIcon icon={quest.icon} size={22} />
                     <div className="text-right">
                       <div className="flex items-center gap-1 justify-end">
                         <span className="text-sm">🪙</span>
@@ -474,7 +475,7 @@ export default function WallDisplay() {
                       animate={{ opacity: 1, x: 0 }}
                       transition={{ delay: i * 0.04 }}
                     >
-                      <span className="text-3xl flex-shrink-0">{reward.icon}</span>
+                      <AppIcon icon={reward.icon} size={30} />
                       <div className="flex-1 min-w-0">
                         <p className="text-sm font-semibold text-white/88 leading-snug">{reward.title}</p>
                         {reward.description && (
@@ -533,7 +534,7 @@ export default function WallDisplay() {
               onClick={(e) => e.stopPropagation()}
             >
               <div className="flex items-center gap-3 justify-center mb-2">
-                <span className="text-3xl">{claimingBounty.icon}</span>
+                <AppIcon icon={claimingBounty.icon} size={32} />
                 <p className="font-heading font-bold text-lg text-white/90">{claimingBounty.title}</p>
               </div>
               <p className="text-center text-white/40 text-sm mb-6">Who&apos;s doing this bounty?</p>
@@ -550,7 +551,7 @@ export default function WallDisplay() {
                       whileHover={{ scale: 1.06, boxShadow: `0 0 20px ${colors.glow}` }}
                       whileTap={{ scale: 0.95 }}
                     >
-                      <span className="text-4xl">{kid.avatar}</span>
+                      <AppIcon icon={kid.avatar} size={40} />
                       <span className="text-sm font-bold" style={{ color: colors.primary }}>{kid.name}</span>
                     </motion.button>
                   )

--- a/src/app/join/[token]/page.tsx
+++ b/src/app/join/[token]/page.tsx
@@ -6,6 +6,7 @@ import { use, useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { motion } from 'framer-motion'
 import Link from 'next/link'
+import { AppIcon } from '@/components/app-icon'
 import { createClient } from '@/lib/supabase/client'
 import { StarField } from '@/components/star-field'
 import { KID_COLORS } from '@/lib/constants'
@@ -105,7 +106,7 @@ export default function JoinPage({ params }: { params: Promise<{ token: string }
                   whileHover={{ scale: 1.02 }}
                   whileTap={{ scale: 0.98 }}
                 >
-                  <span className="text-3xl">{kid.avatar}</span>
+                  <AppIcon icon={kid.avatar} size={32} />
                   <span className="font-heading font-bold text-lg" style={{ color: colors.primary }}>
                     {kid.name}
                   </span>

--- a/src/app/kid/[id]/page.tsx
+++ b/src/app/kid/[id]/page.tsx
@@ -11,6 +11,7 @@ import { QuestCard } from '@/components/quest-card'
 import { CoinCounter } from '@/components/coin-counter'
 import { StreakBadge } from '@/components/streak-badge'
 import type { Kid, Quest, Completion, Reward, CurseInstance, Redemption } from '@/lib/types'
+import { AppIcon } from '@/components/app-icon'
 import { KID_COLORS, getLockDurationMs } from '@/lib/constants'
 import { questDateString, questWeekKey } from '@/lib/utils'
 import { isQuestVisibleToKid, sharedSlotsLeft, kidHasActiveCompletion } from '@/lib/quest-rules'
@@ -249,11 +250,11 @@ export default function KidPage({ params }: { params: Promise<{ id: string }> })
           animate={{ opacity: 1, scale: 1 }}
         >
           <motion.span
-            className="text-6xl block mb-4"
+            className="block mb-4"
             animate={{ y: [0, -6, 0] }}
             transition={{ duration: 3, repeat: Infinity, ease: 'easeInOut' }}
           >
-            {kid.avatar}
+            <AppIcon icon={kid.avatar} size={56} />
           </motion.span>
           <h2 className="font-heading text-3xl font-bold text-white mb-1">{kid.name}</h2>
           {lockedUntil && now < lockedUntil ? (
@@ -358,7 +359,7 @@ export default function KidPage({ params }: { params: Promise<{ id: string }> })
           </Link>
 
           <div className="flex-1 flex items-center gap-3 justify-center">
-            <span className="text-3xl">{kid.avatar}</span>
+            <AppIcon icon={kid.avatar} size={32} />
             <div>
               <h1 className="font-heading text-2xl font-bold text-white/95">{kid.name}</h1>
               <p className="text-xs" style={{ color: colors.primary }}>Level {Math.floor(kid.coins / 50) + 1} Adventurer</p>
@@ -622,7 +623,7 @@ function RewardsTab({
           <p className="text-xs font-bold uppercase tracking-widest text-amber-400/55">⏳ Awaiting Approval</p>
           {pendingRedemptions.map((r) => (
             <div key={r.id} className="flex items-center gap-3">
-              <span className="text-lg">{r.reward?.icon ?? '🎁'}</span>
+              <AppIcon icon={r.reward?.icon ?? 'GiPresent'} size={18} />
               <p className="flex-1 text-sm text-white/70">{r.reward?.title ?? 'Reward'}</p>
               <span className="text-xs text-white/35">🪙 {r.reward?.cost ?? '?'}</span>
               <button
@@ -655,7 +656,7 @@ function RewardsTab({
               border: '1px solid rgba(255, 255, 255, 0.08)',
             }}
           >
-            <span className="text-3xl">{reward.icon}</span>
+            <AppIcon icon={reward.icon} size={32} />
             <div className="flex-1 min-w-0">
               <p className="font-semibold text-white/90">{reward.title}</p>
               {reward.description && (

--- a/src/app/parent/approvals-tab.tsx
+++ b/src/app/parent/approvals-tab.tsx
@@ -4,6 +4,7 @@ import { motion } from 'framer-motion'
 import { QuestCard } from '@/components/quest-card'
 import type { Kid, Quest, Completion, Reward, Redemption } from '@/lib/types'
 import { Empty, fadeSlide } from './_ui'
+import { AppIcon } from '@/components/app-icon'
 import type { ParentActions } from './use-parent-actions'
 
 interface Props {
@@ -46,11 +47,11 @@ export function ApprovalsTab({
                   className="flex items-center gap-3 p-3 rounded-2xl"
                   style={{ background: 'rgba(251,191,36,0.06)', border: '1px solid rgba(251,191,36,0.18)' }}
                 >
-                  <span className="text-2xl">{reward.icon}</span>
+                  <AppIcon icon={reward.icon} size={24} />
                   <div className="flex-1 min-w-0">
                     <p className="text-white/90 text-sm font-semibold truncate">{reward.title}</p>
                     <p className="text-white/45 text-xs">
-                      {kid.avatar} {kid.name} · 🪙 {reward.cost} coins
+                      <AppIcon icon={kid.avatar} size={16} style={{ display: 'inline' }} /> {kid.name} · 🪙 {reward.cost} coins
                     </p>
                   </div>
                   <div className="flex gap-2 flex-shrink-0">
@@ -88,7 +89,7 @@ export function ApprovalsTab({
           return (
             <div key={c.id} className="rounded-2xl overflow-hidden" style={{ background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.08)' }}>
               <div className="flex items-center gap-3 px-4 pt-4 pb-2">
-                <span className="text-2xl">{kid.avatar}</span>
+                <AppIcon icon={kid.avatar} size={24} />
                 <div>
                   <p className="font-semibold text-white/90 text-sm">{kid.name}</p>
                   <p className="text-white/40 text-xs">completed a quest</p>
@@ -122,7 +123,7 @@ export function ApprovalsTab({
               if (!kid) return null
               return (
                 <div key={c.id} className="flex items-center gap-3 py-2">
-                  <span className="text-lg">{kid.avatar}</span>
+                  <AppIcon icon={kid.avatar} size={18} />
                   <span className="text-white/50 text-sm">{kid.name}</span>
                   <span className="text-white/35 text-sm flex-1 truncate">{(c.quest as Quest)?.title}</span>
                   <span className={`text-xs font-semibold flex-shrink-0 ${c.status === 'approved' ? 'text-cq-forest' : 'text-red-400'}`}>
@@ -146,7 +147,7 @@ export function ApprovalsTab({
               <div key={r.id} className="flex items-center gap-3 py-2">
                 <span className="text-lg">{kid.avatar}</span>
                 <span className="text-white/50 text-sm">{kid.name}</span>
-                <span className="text-white/35 text-sm flex-1 truncate">{reward.icon} {reward.title}</span>
+                <span className="text-white/35 text-sm flex-1 truncate flex items-center gap-1.5"><AppIcon icon={reward.icon} size={16} /> {reward.title}</span>
                 <span className="text-xs font-semibold flex-shrink-0 text-cq-gold">
                   🎁 -{reward.cost}🪙
                 </span>

--- a/src/app/parent/family-tab.tsx
+++ b/src/app/parent/family-tab.tsx
@@ -4,7 +4,9 @@ import { useState, useEffect } from 'react'
 import { motion } from 'framer-motion'
 import { toast } from 'sonner'
 import type { Family, Kid, KidColor } from '@/lib/types'
-import { KID_AVATARS, KID_COLORS } from '@/lib/constants'
+import { KID_COLORS } from '@/lib/constants'
+import { KID_AVATAR_KEYS } from '@/lib/icons'
+import { AppIcon } from '@/components/app-icon'
 import { ActionButton, Empty, FormInput, Section, fadeSlide } from './_ui'
 import type { ParentActions } from './use-parent-actions'
 
@@ -187,7 +189,7 @@ function ParentLockSettings({ family, actions }: { family: Family | null; action
 
 function AddKidForm({ actions }: { actions: ParentActions }) {
   const [name, setName] = useState('')
-  const [avatar, setAvatar] = useState('🧙')
+  const [avatar, setAvatar] = useState('GiWizardFace')
   const [color, setColor] = useState<KidColor>('azure')
   const [pin, setPin] = useState('')
 
@@ -204,17 +206,18 @@ function AddKidForm({ actions }: { actions: ParentActions }) {
         <div>
           <label className="text-xs text-white/40 mb-1.5 block">Avatar</label>
           <div className="flex flex-wrap gap-2">
-            {KID_AVATARS.map((av) => (
+            {KID_AVATAR_KEYS.map((av) => (
               <button
                 key={av}
                 onClick={() => setAvatar(av)}
-                className="text-2xl w-10 h-10 rounded-xl transition-all"
+                className="w-10 h-10 rounded-xl transition-all flex items-center justify-center"
                 style={{
                   background: avatar === av ? 'rgba(251,191,36,0.18)' : 'rgba(255,255,255,0.05)',
                   border: `1px solid ${avatar === av ? 'rgba(251,191,36,0.4)' : 'rgba(255,255,255,0.08)'}`,
+                  color: avatar === av ? '#fbbf24' : 'rgba(255,255,255,0.6)',
                 }}
               >
-                {av}
+                <AppIcon icon={av} size={20} />
               </button>
             ))}
           </div>
@@ -290,7 +293,7 @@ function KidList({ kids, onShowQr, actions }: { kids: Kid[]; onShowQr: (kidId: s
                 className="flex items-center gap-4 p-4 rounded-2xl"
                 style={{ background: colors.bg, border: `1px solid ${colors.border}` }}
               >
-                <span className="text-3xl">{kid.avatar}</span>
+                <AppIcon icon={kid.avatar} size={32} />
                 <div className="flex-1">
                   <p className="font-semibold text-white/90">{kid.name}</p>
                   {editingCoinsKidId === kid.id ? (

--- a/src/app/parent/qr-modal.tsx
+++ b/src/app/parent/qr-modal.tsx
@@ -4,6 +4,7 @@ import { motion, AnimatePresence } from 'framer-motion'
 import QRCode from 'react-qr-code'
 import { toast } from 'sonner'
 import type { Kid } from '@/lib/types'
+import { AppIcon } from '@/components/app-icon'
 
 interface Props {
   kid: Kid | null
@@ -40,7 +41,7 @@ export function QrModal({ kid, onClose }: Props) {
               >
                 ✕
               </button>
-              <span className="text-4xl block mb-2">{kid.avatar}</span>
+              <span className="block mb-2"><AppIcon icon={kid.avatar} size={40} /></span>
               <h3 className="font-heading font-bold text-white text-xl mb-4">{kid.name}</h3>
               <div className="bg-white p-4 rounded-2xl inline-block mb-4">
                 <QRCode value={kidUrl} size={160} />

--- a/src/app/parent/quest-form.tsx
+++ b/src/app/parent/quest-form.tsx
@@ -1,7 +1,9 @@
 'use client'
 
 import type { Kid, QuestKind, QuestTier } from '@/lib/types'
-import { QUEST_ICONS, TIER_CONFIG } from '@/lib/constants'
+import { TIER_CONFIG } from '@/lib/constants'
+import { QUEST_ICON_KEYS } from '@/lib/icons'
+import { AppIcon } from '@/components/app-icon'
 
 const DAY_LABELS = ['Su','Mo','Tu','We','Th','Fr','Sa']
 const TIERS: QuestTier[] = ['normal', 'heroic', 'legendary', 'epic']
@@ -49,7 +51,7 @@ interface Props {
 export const initialQuestFormState: QuestFormState = {
   title: '',
   description: '',
-  icon: '⚔️',
+  icon: 'GiSwordman',
   coins: 10,
   forKid: 'all',
   kind: 'personal',
@@ -67,7 +69,7 @@ export function normalizeKindFrequency(kind: QuestKind, frequency: QuestFormStat
 }
 
 export function QuestFormFields({ state, onChange, kids, iconLimit, inputBg }: Props) {
-  const icons = iconLimit ? QUEST_ICONS.slice(0, iconLimit) : QUEST_ICONS
+  const icons = iconLimit ? QUEST_ICON_KEYS.slice(0, iconLimit) : QUEST_ICON_KEYS
   const inputStyle = inputBg ?? 'rgba(255,255,255,0.06)'
   const inputBorder = '1px solid rgba(255,255,255,0.1)'
 
@@ -87,13 +89,14 @@ export function QuestFormFields({ state, onChange, kids, iconLimit, inputBg }: P
           <button
             key={ic}
             onClick={() => onChange({ icon: ic })}
-            className="text-xl w-10 h-10 rounded-xl transition-all"
+            className="w-10 h-10 rounded-xl transition-all flex items-center justify-center"
             style={{
               background: state.icon === ic ? 'rgba(251,191,36,0.2)' : 'rgba(255,255,255,0.05)',
               border: `1px solid ${state.icon === ic ? 'rgba(251,191,36,0.4)' : 'rgba(255,255,255,0.08)'}`,
+              color: state.icon === ic ? '#fbbf24' : 'rgba(255,255,255,0.6)',
             }}
           >
-            {ic}
+            <AppIcon icon={ic} size={20} />
           </button>
         ))}
       </div>

--- a/src/app/parent/quest-row.tsx
+++ b/src/app/parent/quest-row.tsx
@@ -5,6 +5,7 @@ import { motion, AnimatePresence } from 'framer-motion'
 import type { Kid, Quest, QuestKind, QuestTier } from '@/lib/types'
 import { TIER_CONFIG } from '@/lib/constants'
 import { QuestFormFields, type QuestFormState } from './quest-form'
+import { AppIcon } from '@/components/app-icon'
 
 interface Props {
   quest: Quest
@@ -68,7 +69,7 @@ export function QuestRow({ quest, kids, onToggle, onDelete, onSave }: Props) {
       style={{ background: 'rgba(255,255,255,0.03)', border: '1px solid rgba(255,255,255,0.07)' }}
     >
       <div className="flex items-center gap-3 p-3">
-        <span className="text-xl">{quest.icon}</span>
+        <AppIcon icon={quest.icon} size={20} />
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 flex-wrap">
             <p className={`text-sm font-semibold ${quest.active ? 'text-white/90' : 'text-white/40 line-through'}`}>

--- a/src/app/parent/rewards-tab.tsx
+++ b/src/app/parent/rewards-tab.tsx
@@ -5,8 +5,8 @@ import { motion } from 'framer-motion'
 import type { Reward } from '@/lib/types'
 import { ActionButton, Empty, FormInput, Section, fadeSlide } from './_ui'
 import type { ParentActions } from './use-parent-actions'
-
-const REWARD_ICONS = ['🎁', '🎮', '📱', '🍕', '🎬', '🎡', '🎪', '🛒', '💤', '🎯', '🎨', '🎵']
+import { REWARD_ICON_KEYS } from '@/lib/icons'
+import { AppIcon } from '@/components/app-icon'
 
 interface Props {
   rewards: Reward[]
@@ -16,7 +16,7 @@ interface Props {
 export function RewardsTab({ rewards, actions }: Props) {
   const [title, setTitle] = useState('')
   const [desc, setDesc] = useState('')
-  const [icon, setIcon] = useState('🎁')
+  const [icon, setIcon] = useState('GiPresent')
   const [cost, setCost] = useState(50)
 
   const handleAdd = async () => {
@@ -31,17 +31,18 @@ export function RewardsTab({ rewards, actions }: Props) {
       <Section title="Add Reward">
         <div className="flex flex-col gap-3">
           <div className="flex gap-2 flex-wrap">
-            {REWARD_ICONS.map((ic) => (
+            {REWARD_ICON_KEYS.map((ic) => (
               <button
                 key={ic}
                 onClick={() => setIcon(ic)}
-                className="text-xl w-10 h-10 rounded-xl transition-all"
+                className="w-10 h-10 rounded-xl transition-all flex items-center justify-center"
                 style={{
                   background: icon === ic ? 'rgba(251,191,36,0.2)' : 'rgba(255,255,255,0.05)',
                   border: `1px solid ${icon === ic ? 'rgba(251,191,36,0.4)' : 'rgba(255,255,255,0.08)'}`,
+                  color: icon === ic ? '#fbbf24' : 'rgba(255,255,255,0.6)',
                 }}
               >
-                {ic}
+                <AppIcon icon={ic} size={20} />
               </button>
             ))}
           </div>
@@ -73,7 +74,7 @@ export function RewardsTab({ rewards, actions }: Props) {
                 className="flex items-center gap-3 p-3 rounded-xl"
                 style={{ background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.08)' }}
               >
-                <span className="text-2xl">{r.icon}</span>
+                <AppIcon icon={r.icon} size={24} />
                 <div className="flex-1">
                   <p className="text-white/90 text-sm font-semibold">{r.title}</p>
                   {r.description && <p className="text-white/40 text-xs">{r.description}</p>}

--- a/src/components/app-icon.tsx
+++ b/src/components/app-icon.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import { getIcon } from '@/lib/icons'
 
 interface AppIconProps {
@@ -16,14 +17,12 @@ export function AppIcon({ icon, size = 24, color, className, style }: AppIconPro
   const Icon = getIcon(icon)
 
   if (Icon) {
-    return (
-      <Icon
-        size={size}
-        color={color}
-        className={className}
-        style={{ display: 'inline-block', verticalAlign: 'middle', flexShrink: 0, ...style }}
-      />
-    )
+    return React.createElement(Icon, {
+      size,
+      color,
+      className,
+      style: { display: 'inline-block', verticalAlign: 'middle', flexShrink: 0, ...style },
+    })
   }
 
   // Emoji / legacy fallback

--- a/src/components/app-icon.tsx
+++ b/src/components/app-icon.tsx
@@ -1,0 +1,38 @@
+import { getIcon } from '@/lib/icons'
+
+interface AppIconProps {
+  icon: string
+  size?: number
+  color?: string
+  className?: string
+  style?: React.CSSProperties
+}
+
+/**
+ * Renders a game icon SVG from the registry, or falls back to rendering
+ * the value as an emoji span — ensuring old emoji values in the DB still display.
+ */
+export function AppIcon({ icon, size = 24, color, className, style }: AppIconProps) {
+  const Icon = getIcon(icon)
+
+  if (Icon) {
+    return (
+      <Icon
+        size={size}
+        color={color}
+        className={className}
+        style={{ display: 'inline-block', verticalAlign: 'middle', flexShrink: 0, ...style }}
+      />
+    )
+  }
+
+  // Emoji / legacy fallback
+  return (
+    <span
+      className={className}
+      style={{ fontSize: size, lineHeight: 1, display: 'inline-block', flexShrink: 0, ...style }}
+    >
+      {icon}
+    </span>
+  )
+}

--- a/src/components/kid-column.tsx
+++ b/src/components/kid-column.tsx
@@ -3,6 +3,7 @@
 import { motion } from 'framer-motion'
 import Link from 'next/link'
 import type { Kid, Quest, Completion } from '@/lib/types'
+import { AppIcon } from './app-icon'
 import { KID_COLORS } from '@/lib/constants'
 import { CoinCounter } from './coin-counter'
 import { StreakBadge } from './streak-badge'
@@ -81,11 +82,11 @@ export function KidColumn({
               whileTap={{ scale: 0.95 }}
             >
               <motion.span
-                className="text-5xl block"
+                className="block"
                 animate={{ y: [0, -5, 0] }}
                 transition={{ duration: 3.5, repeat: Infinity, ease: 'easeInOut' }}
               >
-                {kid.avatar}
+                <AppIcon icon={kid.avatar} size={48} color={colors.primary} />
               </motion.span>
               <div
                 className="absolute -inset-2 rounded-full -z-10 opacity-30 blur-md"

--- a/src/components/quest-card.tsx
+++ b/src/components/quest-card.tsx
@@ -5,6 +5,7 @@ import { motion, AnimatePresence } from 'framer-motion'
 import type { Quest, Completion, KidColor } from '@/lib/types'
 import { KID_COLORS, TIER_CONFIG } from '@/lib/constants'
 import { CoinBurst } from './coin-burst'
+import { AppIcon } from './app-icon'
 
 interface QuestCardProps {
   quest: Quest
@@ -158,7 +159,7 @@ export function QuestCard({
 
       <div className="p-4">
         <div className="flex items-start gap-3">
-          <span className="text-2xl leading-none mt-0.5 flex-shrink-0">{quest.icon}</span>
+          <AppIcon icon={quest.icon} size={24} style={{ marginTop: 2 }} />
 
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-1.5 flex-wrap">

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -42,18 +42,7 @@ export const TIER_CONFIG: Record<QuestTier, {
   },
 }
 
-export const QUEST_ICONS = [
-  '⚔️', '🛡️', '🧹', '🍳', '📚', '🌿', '🐾',
-  '🧺', '🪣', '🚿', '🛏️', '🥗', '🗑️', '💧',
-  '✨', '🧙', '⭐', '🔮', '🌙', '🦋', '🌸',
-  '🎯', '📖', '🎨', '🧩', '🎵', '🌟', '💫',
-]
-
-export const KID_AVATARS = [
-  '🧙', '🧝', '🧚', '🦊', '🐉', '🦄',
-  '🧜', '🦸', '⚡', '🌟', '🔮', '🌙',
-  '🦋', '🐺', '🦅', '🧸',
-]
+export { QUEST_ICON_KEYS as QUEST_ICONS, KID_AVATAR_KEYS as KID_AVATARS } from './icons'
 
 export const KID_COLORS: Record<KidColor, {
   primary: string
@@ -104,11 +93,11 @@ export function getLockDurationMs(attempts: number): number {
 }
 
 export const DEFAULT_QUESTS = [
-  { title: 'Make Your Bed', icon: '🛏️', coins: 10, description: 'Straighten covers and fluff pillows' },
-  { title: 'Brush Teeth', icon: '✨', coins: 5, description: 'Morning and evening' },
-  { title: 'Tidy Your Room', icon: '🧹', coins: 15, description: 'Put everything in its place' },
-  { title: 'Help with Dinner', icon: '🍳', coins: 20, description: 'Set the table or help prepare' },
-  { title: 'Do Homework', icon: '📚', coins: 15, description: 'Complete all assignments' },
-  { title: 'Feed the Pets', icon: '🐾', coins: 10, description: 'Fill food and water bowls' },
-  { title: 'Take Out Trash', icon: '🗑️', coins: 15, description: 'Empty bins and take bags out' },
+  { title: 'Make Your Bed', icon: 'GiBed', coins: 10, description: 'Straighten covers and fluff pillows' },
+  { title: 'Brush Teeth', icon: 'GiToothbrush', coins: 5, description: 'Morning and evening' },
+  { title: 'Tidy Your Room', icon: 'GiBroom', coins: 15, description: 'Put everything in its place' },
+  { title: 'Help with Dinner', icon: 'GiCookingPot', coins: 20, description: 'Set the table or help prepare' },
+  { title: 'Do Homework', icon: 'GiWhiteBook', coins: 15, description: 'Complete all assignments' },
+  { title: 'Feed the Pets', icon: 'GiFlowerPot', coins: 10, description: 'Fill food and water bowls' },
+  { title: 'Take Out Trash', icon: 'GiTrashCan', coins: 15, description: 'Empty bins and take bags out' },
 ]

--- a/src/lib/icons.ts
+++ b/src/lib/icons.ts
@@ -1,0 +1,103 @@
+import type { IconType } from 'react-icons'
+import {
+  GiBroom, GiVacuumCleaner, GiTrashCan, GiWashingMachine, GiHanger,
+  GiBed, GiCookingPot, GiKnifeFork, GiSoap, GiToothbrush,
+  GiGardeningShears, GiWateringCan, GiFlowerPot, GiShoppingCart, GiWindow,
+  GiPaintBrush, GiMusicalNotes, GiRunningShoe, GiWhiteBook, GiPencilBrush,
+  GiSwordman, GiShield, GiCrown, GiStarMedal, GiTrophyCup, GiTreasureMap,
+  GiWizardFace, GiNinjaHead, GiPirateCaptain, GiVikingHead, GiBlackKnightHelm,
+  GiElfEar, GiDwarfFace, GiGoblinHead, GiDragonHead, GiFoxHead,
+  GiUnicorn, GiCat, GiPanda, GiWolfHead, GiEagleHead, GiVintageRobot,
+  GiPresent, GiPopcorn, GiRetroController, GiPizzaSlice, GiTicket,
+  GiTwoCoins, GiSpiralLollipop, GiRibbonMedal, GiRoundStar, GiUnicycle,
+} from 'react-icons/gi'
+
+export type IconKey = string
+
+const REGISTRY: Record<string, IconType> = {
+  // ── Quest / chore icons ─────────────────────────────────────────────────
+  GiBroom,
+  GiVacuumCleaner,
+  GiTrashCan,
+  GiWashingMachine,
+  GiHanger,
+  GiBed,
+  GiCookingPot,
+  GiKnifeFork,
+  GiSoap,
+  GiToothbrush,
+  GiGardeningShears,
+  GiWateringCan,
+  GiFlowerPot,
+  GiShoppingCart,
+  GiWindow,
+  GiPaintBrush,
+  GiMusicalNotes,
+  GiRunningShoe,
+  GiWhiteBook,
+  GiPencilBrush,
+  GiSwordman,
+  GiShield,
+  GiCrown,
+  GiStarMedal,
+  GiTrophyCup,
+  GiTreasureMap,
+
+  // ── Kid avatars ─────────────────────────────────────────────────────────
+  GiWizardFace,
+  GiNinjaHead,
+  GiPirateCaptain,
+  GiVikingHead,
+  GiBlackKnightHelm,
+  GiElfEar,
+  GiDwarfFace,
+  GiGoblinHead,
+  GiDragonHead,
+  GiFoxHead,
+  GiUnicorn,
+  GiCat,
+  GiPanda,
+  GiWolfHead,
+  GiEagleHead,
+  GiVintageRobot,
+
+  // ── Reward icons ────────────────────────────────────────────────────────
+  GiPresent,
+  GiPopcorn,
+  GiRetroController,
+  GiPizzaSlice,
+  GiTicket,
+  GiTwoCoins,
+  GiSpiralLollipop,
+  GiRibbonMedal,
+  GiRoundStar,
+  GiUnicycle,
+}
+
+export function getIcon(key: string): IconType | null {
+  return REGISTRY[key] ?? null
+}
+
+export function isIconKey(value: string): boolean {
+  return value in REGISTRY
+}
+
+export const QUEST_ICON_KEYS = [
+  'GiBroom', 'GiVacuumCleaner', 'GiTrashCan', 'GiWashingMachine', 'GiHanger',
+  'GiBed', 'GiCookingPot', 'GiKnifeFork', 'GiSoap', 'GiToothbrush',
+  'GiGardeningShears', 'GiWateringCan', 'GiFlowerPot', 'GiShoppingCart', 'GiWindow',
+  'GiPaintBrush', 'GiMusicalNotes', 'GiRunningShoe', 'GiWhiteBook', 'GiPencilBrush',
+  'GiSwordman', 'GiShield', 'GiCrown', 'GiStarMedal', 'GiTrophyCup', 'GiTreasureMap',
+] as const
+
+export const KID_AVATAR_KEYS = [
+  'GiWizardFace', 'GiNinjaHead', 'GiPirateCaptain', 'GiVikingHead', 'GiBlackKnightHelm',
+  'GiElfEar', 'GiDwarfFace', 'GiGoblinHead', 'GiDragonHead', 'GiFoxHead',
+  'GiUnicorn', 'GiCat', 'GiPanda', 'GiWolfHead', 'GiEagleHead', 'GiVintageRobot',
+] as const
+
+export const REWARD_ICON_KEYS = [
+  'GiPresent', 'GiPopcorn', 'GiRetroController', 'GiPizzaSlice', 'GiTicket',
+  'GiTwoCoins', 'GiSpiralLollipop', 'GiRibbonMedal', 'GiRoundStar', 'GiBicycle',
+  'GiTrophyCup', 'GiTreasureMap', 'GiCrown', 'GiStarMedal',
+] as const


### PR DESCRIPTION
Closes #8

## Summary

Replaces all emoji icon rendering with SVG icons from [game-icons.net](https://game-icons.net) via `react-icons/gi`. Icons are dark-fantasy RPG themed — designed specifically for game UIs.

### New files
- **`src/lib/icons.ts`** — curated registry: 26 quest/chore icons, 16 kid avatar icons, 14 reward icons. Named imports only (no namespace import) for proper tree-shaking.
- **`src/components/app-icon.tsx`** — `<AppIcon icon="GiBroom" size={24} />` renders from registry; falls back to rendering the raw string as an emoji span so any legacy emoji values in the DB still display without a migration.

### Icon selections
**Chores:** GiBroom, GiVacuumCleaner, GiTrashCan, GiWashingMachine, GiHanger, GiBed, GiCookingPot, GiKnifeFork, GiSoap, GiToothbrush, GiGardeningShears, GiWateringCan, GiFlowerPot, GiShoppingCart, GiWindow, GiPaintBrush, GiMusicalNotes, GiRunningShoe, GiWhiteBook, GiPencilBrush, GiSwordman, GiShield, GiCrown, GiStarMedal, GiTrophyCup, GiTreasureMap

**Avatars:** GiWizardFace, GiNinjaHead, GiPirateCaptain, GiVikingHead, GiBlackKnightHelm, GiElfEar, GiDwarfFace, GiGoblinHead, GiDragonHead, GiFoxHead, GiUnicorn, GiCat, GiPanda, GiWolfHead, GiEagleHead, GiVintageRobot

**Rewards:** GiPresent, GiPopcorn, GiRetroController, GiPizzaSlice, GiTicket, GiTwoCoins, GiSpiralLollipop, GiRibbonMedal, GiRoundStar, GiUnicycle, GiTrophyCup, GiTreasureMap, GiCrown, GiStarMedal

### Attribution
game-icons.net icons are CC BY 3.0. Attribution note to be added to footer in a follow-up.

## Test plan
- [ ] Quest icon picker in parent dashboard shows SVG icons
- [ ] Kid avatar picker shows SVG characters
- [ ] Reward icon picker shows SVG icons
- [ ] Quest cards on wall display and kid view show SVG icons
- [ ] Kid avatar on PIN screen and header shows SVG
- [ ] Any quests created before this change (with emoji values) still render via emoji fallback
- [ ] CI: lint, typecheck, unit tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)