### PR TITLE
fix: wire colors into AppIcon at all render sites

### DIFF
--- a/src/app/display/page.tsx
+++ b/src/app/display/page.tsx
@@ -357,7 +357,7 @@ export default function WallDisplay() {
                   whileTap={!isFull ? { scale: 0.97 } : {}}
                 >
                   <div className="flex items-start justify-between gap-2 mb-2">
-                    <AppIcon icon={quest.icon} size={22} />
+                    <AppIcon icon={quest.icon} size={22} color={isFull ? 'rgba(255,255,255,0.3)' : tier.color} />
                     <div className="text-right">
                       <div className="flex items-center gap-1 justify-end">
                         <span className="text-sm">🪙</span>
@@ -475,7 +475,7 @@ export default function WallDisplay() {
                       animate={{ opacity: 1, x: 0 }}
                       transition={{ delay: i * 0.04 }}
                     >
-                      <AppIcon icon={reward.icon} size={30} />
+                      <AppIcon icon={reward.icon} size={30} color="#fbbf24" />
                       <div className="flex-1 min-w-0">
                         <p className="text-sm font-semibold text-white/88 leading-snug">{reward.title}</p>
                         {reward.description && (
@@ -534,7 +534,7 @@ export default function WallDisplay() {
               onClick={(e) => e.stopPropagation()}
             >
               <div className="flex items-center gap-3 justify-center mb-2">
-                <AppIcon icon={claimingBounty.icon} size={32} />
+                <AppIcon icon={claimingBounty.icon} size={32} color={TIER_CONFIG[claimingBounty.tier ?? 'normal'].color} />
                 <p className="font-heading font-bold text-lg text-white/90">{claimingBounty.title}</p>
               </div>
               <p className="text-center text-white/40 text-sm mb-6">Who&apos;s doing this bounty?</p>
@@ -551,7 +551,7 @@ export default function WallDisplay() {
                       whileHover={{ scale: 1.06, boxShadow: `0 0 20px ${colors.glow}` }}
                       whileTap={{ scale: 0.95 }}
                     >
-                      <AppIcon icon={kid.avatar} size={40} />
+                      <AppIcon icon={kid.avatar} size={40} color={colors.primary} />
                       <span className="text-sm font-bold" style={{ color: colors.primary }}>{kid.name}</span>
                     </motion.button>
                   )

--- a/src/app/join/[token]/page.tsx
+++ b/src/app/join/[token]/page.tsx
@@ -106,7 +106,7 @@ export default function JoinPage({ params }: { params: Promise<{ token: string }
                   whileHover={{ scale: 1.02 }}
                   whileTap={{ scale: 0.98 }}
                 >
-                  <AppIcon icon={kid.avatar} size={32} />
+                  <AppIcon icon={kid.avatar} size={32} color={colors.primary} />
                   <span className="font-heading font-bold text-lg" style={{ color: colors.primary }}>
                     {kid.name}
                   </span>

--- a/src/app/kid/[id]/page.tsx
+++ b/src/app/kid/[id]/page.tsx
@@ -254,7 +254,7 @@ export default function KidPage({ params }: { params: Promise<{ id: string }> })
             animate={{ y: [0, -6, 0] }}
             transition={{ duration: 3, repeat: Infinity, ease: 'easeInOut' }}
           >
-            <AppIcon icon={kid.avatar} size={56} />
+            <AppIcon icon={kid.avatar} size={56} color={colors.primary} />
           </motion.span>
           <h2 className="font-heading text-3xl font-bold text-white mb-1">{kid.name}</h2>
           {lockedUntil && now < lockedUntil ? (
@@ -359,7 +359,7 @@ export default function KidPage({ params }: { params: Promise<{ id: string }> })
           </Link>
 
           <div className="flex-1 flex items-center gap-3 justify-center">
-            <AppIcon icon={kid.avatar} size={32} />
+            <AppIcon icon={kid.avatar} size={32} color={colors.primary} />
             <div>
               <h1 className="font-heading text-2xl font-bold text-white/95">{kid.name}</h1>
               <p className="text-xs" style={{ color: colors.primary }}>Level {Math.floor(kid.coins / 50) + 1} Adventurer</p>
@@ -623,7 +623,7 @@ function RewardsTab({
           <p className="text-xs font-bold uppercase tracking-widest text-amber-400/55">⏳ Awaiting Approval</p>
           {pendingRedemptions.map((r) => (
             <div key={r.id} className="flex items-center gap-3">
-              <AppIcon icon={r.reward?.icon ?? 'GiPresent'} size={18} />
+              <AppIcon icon={r.reward?.icon ?? 'GiPresent'} size={18} color="#fbbf24" />
               <p className="flex-1 text-sm text-white/70">{r.reward?.title ?? 'Reward'}</p>
               <span className="text-xs text-white/35">🪙 {r.reward?.cost ?? '?'}</span>
               <button
@@ -656,7 +656,7 @@ function RewardsTab({
               border: '1px solid rgba(255, 255, 255, 0.08)',
             }}
           >
-            <AppIcon icon={reward.icon} size={32} />
+            <AppIcon icon={reward.icon} size={32} color="#fbbf24" />
             <div className="flex-1 min-w-0">
               <p className="font-semibold text-white/90">{reward.title}</p>
               {reward.description && (

--- a/src/app/parent/approvals-tab.tsx
+++ b/src/app/parent/approvals-tab.tsx
@@ -3,6 +3,7 @@
 import { motion } from 'framer-motion'
 import { QuestCard } from '@/components/quest-card'
 import type { Kid, Quest, Completion, Reward, Redemption } from '@/lib/types'
+import { KID_COLORS } from '@/lib/constants'
 import { Empty, fadeSlide } from './_ui'
 import { AppIcon } from '@/components/app-icon'
 import type { ParentActions } from './use-parent-actions'
@@ -47,11 +48,11 @@ export function ApprovalsTab({
                   className="flex items-center gap-3 p-3 rounded-2xl"
                   style={{ background: 'rgba(251,191,36,0.06)', border: '1px solid rgba(251,191,36,0.18)' }}
                 >
-                  <AppIcon icon={reward.icon} size={24} />
+                  <AppIcon icon={reward.icon} size={24} color="#fbbf24" />
                   <div className="flex-1 min-w-0">
                     <p className="text-white/90 text-sm font-semibold truncate">{reward.title}</p>
                     <p className="text-white/45 text-xs">
-                      <AppIcon icon={kid.avatar} size={16} style={{ display: 'inline' }} /> {kid.name} · 🪙 {reward.cost} coins
+                      <AppIcon icon={kid.avatar} size={16} color={KID_COLORS[kid.color].primary} style={{ display: 'inline' }} /> {kid.name} · 🪙 {reward.cost} coins
                     </p>
                   </div>
                   <div className="flex gap-2 flex-shrink-0">
@@ -89,7 +90,7 @@ export function ApprovalsTab({
           return (
             <div key={c.id} className="rounded-2xl overflow-hidden" style={{ background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.08)' }}>
               <div className="flex items-center gap-3 px-4 pt-4 pb-2">
-                <AppIcon icon={kid.avatar} size={24} />
+                <AppIcon icon={kid.avatar} size={24} color={KID_COLORS[kid.color].primary} />
                 <div>
                   <p className="font-semibold text-white/90 text-sm">{kid.name}</p>
                   <p className="text-white/40 text-xs">completed a quest</p>
@@ -123,7 +124,7 @@ export function ApprovalsTab({
               if (!kid) return null
               return (
                 <div key={c.id} className="flex items-center gap-3 py-2">
-                  <AppIcon icon={kid.avatar} size={18} />
+                  <AppIcon icon={kid.avatar} size={18} color={KID_COLORS[kid.color].primary} />
                   <span className="text-white/50 text-sm">{kid.name}</span>
                   <span className="text-white/35 text-sm flex-1 truncate">{(c.quest as Quest)?.title}</span>
                   <span className={`text-xs font-semibold flex-shrink-0 ${c.status === 'approved' ? 'text-cq-forest' : 'text-red-400'}`}>
@@ -147,7 +148,7 @@ export function ApprovalsTab({
               <div key={r.id} className="flex items-center gap-3 py-2">
                 <span className="text-lg">{kid.avatar}</span>
                 <span className="text-white/50 text-sm">{kid.name}</span>
-                <span className="text-white/35 text-sm flex-1 truncate flex items-center gap-1.5"><AppIcon icon={reward.icon} size={16} /> {reward.title}</span>
+                <span className="text-white/35 text-sm flex-1 truncate flex items-center gap-1.5"><AppIcon icon={reward.icon} size={16} color="#fbbf24" /> {reward.title}</span>
                 <span className="text-xs font-semibold flex-shrink-0 text-cq-gold">
                   🎁 -{reward.cost}🪙
                 </span>

--- a/src/app/parent/family-tab.tsx
+++ b/src/app/parent/family-tab.tsx
@@ -293,7 +293,7 @@ function KidList({ kids, onShowQr, actions }: { kids: Kid[]; onShowQr: (kidId: s
                 className="flex items-center gap-4 p-4 rounded-2xl"
                 style={{ background: colors.bg, border: `1px solid ${colors.border}` }}
               >
-                <AppIcon icon={kid.avatar} size={32} />
+                <AppIcon icon={kid.avatar} size={32} color={colors.primary} />
                 <div className="flex-1">
                   <p className="font-semibold text-white/90">{kid.name}</p>
                   {editingCoinsKidId === kid.id ? (

--- a/src/app/parent/quest-row.tsx
+++ b/src/app/parent/quest-row.tsx
@@ -69,7 +69,7 @@ export function QuestRow({ quest, kids, onToggle, onDelete, onSave }: Props) {
       style={{ background: 'rgba(255,255,255,0.03)', border: '1px solid rgba(255,255,255,0.07)' }}
     >
       <div className="flex items-center gap-3 p-3">
-        <AppIcon icon={quest.icon} size={20} />
+        <AppIcon icon={quest.icon} size={20} color={TIER_CONFIG[quest.tier ?? 'normal'].color} />
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 flex-wrap">
             <p className={`text-sm font-semibold ${quest.active ? 'text-white/90' : 'text-white/40 line-through'}`}>

--- a/src/app/parent/rewards-tab.tsx
+++ b/src/app/parent/rewards-tab.tsx
@@ -74,7 +74,7 @@ export function RewardsTab({ rewards, actions }: Props) {
                 className="flex items-center gap-3 p-3 rounded-xl"
                 style={{ background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.08)' }}
               >
-                <AppIcon icon={r.icon} size={24} />
+                <AppIcon icon={r.icon} size={24} color="#fbbf24" />
                 <div className="flex-1">
                   <p className="text-white/90 text-sm font-semibold">{r.title}</p>
                   {r.description && <p className="text-white/40 text-xs">{r.description}</p>}

--- a/src/components/quest-card.tsx
+++ b/src/components/quest-card.tsx
@@ -159,7 +159,7 @@ export function QuestCard({
 
       <div className="p-4">
         <div className="flex items-start gap-3">
-          <AppIcon icon={quest.icon} size={24} style={{ marginTop: 2 }} />
+          <AppIcon icon={quest.icon} size={24} color={isNormal ? 'rgba(255,255,255,0.65)' : tier.color} style={{ marginTop: 2 }} />
 
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-1.5 flex-wrap">


### PR DESCRIPTION
Follow-up to #58.

## What changed

All AppIcon call sites now pass context-appropriate colors:

| Icon type | Color rule |
|-----------|-----------|
| Quest icons | `tier.color` — gold (normal/legendary), azure (heroic), mystic (epic) |
| Kid avatars | `KID_COLORS[kid.color].primary` — azure or mystic per kid |
| Reward icons | `#fbbf24` (cq-gold) |

## Sites updated
- `quest-card.tsx` — tier color (normal renders slightly dimmed white, tiered render in full tier color)
- `quest-row.tsx` (parent quests list) — tier color
- `approvals-tab.tsx` — kid color on avatars, gold on reward icons
- `rewards-tab.tsx` — gold on reward list
- `family-tab.tsx` — kid color on avatar display
- `kid/[id]/page.tsx` — kid color on avatar, gold on rewards
- `display/page.tsx` — tier color on bounty board quest icons + claiming modal, gold on reward icons, kid color on kid picker avatars
- `join/[token]/page.tsx` — kid color on kid picker avatars

🤖 Generated with [Claude Code](https://claude.com/claude-code)