### PR TITLE
feat: plan tier backbone (Free/Family/Legendary limits)

### DIFF
--- a/src/app/api/curses/route.ts
+++ b/src/app/api/curses/route.ts
@@ -1,5 +1,7 @@
 import { authenticate, isAuthError, cors } from '@/lib/api-auth'
 import { createServiceClient } from '@/lib/supabase/service'
+import type { Plan } from '@/lib/types'
+import { PLAN_LIMITS } from '@/lib/plans'
 
 export async function OPTIONS() {
   return new Response(null, { status: 204, headers: cors() })
@@ -30,6 +32,13 @@ export async function POST(req: Request) {
   }
 
   const supabase = createServiceClient()
+
+  const { data: familyData } = await supabase.from('families').select('plan').eq('id', auth.familyId).single()
+  const plan = ((familyData?.plan ?? 'free') as Plan)
+  if (!PLAN_LIMITS[plan].curses) {
+    return Response.json({ error: 'Curses require Family plan or higher' }, { status: 402, headers: cors() })
+  }
+
   const { data, error } = await supabase
     .from('curses')
     .insert({

--- a/src/app/api/quests/route.ts
+++ b/src/app/api/quests/route.ts
@@ -1,5 +1,7 @@
 import { authenticate, isAuthError, cors } from '@/lib/api-auth'
 import { createServiceClient } from '@/lib/supabase/service'
+import type { Plan } from '@/lib/types'
+import { PLAN_LIMITS, PLAN_LABELS } from '@/lib/plans'
 
 export async function OPTIONS() {
   return new Response(null, { status: 204, headers: cors() })
@@ -37,6 +39,24 @@ export async function POST(req: Request) {
   }
 
   const supabase = createServiceClient()
+
+  const [familyRes, countRes] = await Promise.all([
+    supabase.from('families').select('plan').eq('id', auth.familyId).single(),
+    supabase.from('quests').select('id', { count: 'exact', head: true }).eq('family_id', auth.familyId).eq('active', true),
+  ])
+  const plan = ((familyRes.data?.plan ?? 'free') as Plan)
+  const limits = PLAN_LIMITS[plan]
+
+  if (limits.maxQuests < Infinity && (countRes.count ?? 0) >= limits.maxQuests) {
+    return Response.json({ error: `Quest limit reached for ${PLAN_LABELS[plan]} plan (max ${limits.maxQuests})` }, { status: 402, headers: cors() })
+  }
+  if (body.tier && body.tier !== 'normal' && !limits.questTiers) {
+    return Response.json({ error: 'Quest tiers (Heroic/Epic/Legendary) require Legendary plan' }, { status: 402, headers: cors() })
+  }
+  if (body.active_days?.length && !limits.activeDays) {
+    return Response.json({ error: 'Active day scheduling requires Legendary plan' }, { status: 402, headers: cors() })
+  }
+
   const { data, error } = await supabase
     .from('quests')
     .insert({

--- a/src/app/api/rewards/route.ts
+++ b/src/app/api/rewards/route.ts
@@ -1,5 +1,7 @@
 import { authenticate, isAuthError, cors } from '@/lib/api-auth'
 import { createServiceClient } from '@/lib/supabase/service'
+import type { Plan } from '@/lib/types'
+import { PLAN_LIMITS, PLAN_LABELS } from '@/lib/plans'
 
 export async function OPTIONS() {
   return new Response(null, { status: 204, headers: cors() })
@@ -31,6 +33,18 @@ export async function POST(req: Request) {
   }
 
   const supabase = createServiceClient()
+
+  const [familyRes, countRes] = await Promise.all([
+    supabase.from('families').select('plan').eq('id', auth.familyId).single(),
+    supabase.from('rewards').select('id', { count: 'exact', head: true }).eq('family_id', auth.familyId),
+  ])
+  const plan = ((familyRes.data?.plan ?? 'free') as Plan)
+  const limits = PLAN_LIMITS[plan]
+
+  if (limits.maxRewards < Infinity && (countRes.count ?? 0) >= limits.maxRewards) {
+    return Response.json({ error: `Reward limit reached for ${PLAN_LABELS[plan]} plan (max ${limits.maxRewards})` }, { status: 402, headers: cors() })
+  }
+
   const { data, error } = await supabase
     .from('rewards')
     .insert({

--- a/src/app/display/page.tsx
+++ b/src/app/display/page.tsx
@@ -36,7 +36,7 @@ export default function WallDisplay() {
     if (!profile) return
 
     const [familyRes, kidsRes, questsRes, rewardsRes] = await Promise.all([
-      supabase.from('families').select('id, name, invite_token, daily_reset_hour, created_at').eq('id', profile.family_id).single(),
+      supabase.from('families').select('id, name, invite_token, daily_reset_hour, created_at, plan').eq('id', profile.family_id).single(),
       supabase.from('kids').select('id, name, avatar, color, coins, streak, last_completed_date, family_id, created_at').eq('family_id', profile.family_id).order('created_at'),
       supabase.from('quests').select('*').eq('family_id', profile.family_id).eq('active', true).order('created_at'),
       supabase.from('rewards').select('*').eq('available', true).order('cost'),
@@ -51,7 +51,7 @@ export default function WallDisplay() {
       supabase.from('curse_instances').select('kid_id').eq('status', 'active'),
     ])
 
-    if (familyRes.data) setFamily({ ...familyRes.data, has_parent_pin: false })
+    if (familyRes.data) setFamily({ ...familyRes.data, has_parent_pin: false, plan: (familyRes.data.plan as import('@/lib/types').Plan) ?? 'free' })
     if (kidsRes.data) setKids(kidsRes.data)
     if (questsRes.data) setQuests(questsRes.data)
     if (rewardsRes.data) setRewards(rewardsRes.data)

--- a/src/app/parent/curses-tab.tsx
+++ b/src/app/parent/curses-tab.tsx
@@ -18,6 +18,11 @@ interface Props {
 }
 
 export function CursesTab({ kids, curses, activeCurseInstances, actions, plan }: Props) {
+  const [title, setTitle] = useState('')
+  const [icon, setIcon] = useState('☠️')
+  const [penalty, setPenalty] = useState(10)
+  const [castingCurseId, setCastingCurseId] = useState<string | null>(null)
+
   if (!PLAN_LIMITS[plan].curses) {
     return (
       <motion.div key="curses" {...fadeSlide} className="flex flex-col gap-6">
@@ -34,10 +39,6 @@ export function CursesTab({ kids, curses, activeCurseInstances, actions, plan }:
       </motion.div>
     )
   }
-  const [title, setTitle] = useState('')
-  const [icon, setIcon] = useState('☠️')
-  const [penalty, setPenalty] = useState(10)
-  const [castingCurseId, setCastingCurseId] = useState<string | null>(null)
 
   const handleAdd = async () => {
     if (!title.trim()) return

--- a/src/app/parent/curses-tab.tsx
+++ b/src/app/parent/curses-tab.tsx
@@ -2,7 +2,8 @@
 
 import { useState } from 'react'
 import { motion } from 'framer-motion'
-import type { Kid, Curse, CurseInstance } from '@/lib/types'
+import type { Kid, Plan, Curse, CurseInstance } from '@/lib/types'
+import { PLAN_LIMITS } from '@/lib/plans'
 import { Empty, FormInput, Section, fadeSlide } from './_ui'
 import type { ParentActions } from './use-parent-actions'
 
@@ -13,9 +14,26 @@ interface Props {
   curses: Curse[]
   activeCurseInstances: CurseInstance[]
   actions: ParentActions
+  plan: Plan
 }
 
-export function CursesTab({ kids, curses, activeCurseInstances, actions }: Props) {
+export function CursesTab({ kids, curses, activeCurseInstances, actions, plan }: Props) {
+  if (!PLAN_LIMITS[plan].curses) {
+    return (
+      <motion.div key="curses" {...fadeSlide} className="flex flex-col gap-6">
+        <div
+          className="rounded-2xl p-10 text-center flex flex-col items-center gap-3"
+          style={{ background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.08)' }}
+        >
+          <p className="text-5xl">🔒</p>
+          <p className="font-heading text-white/60 font-bold text-lg">Curses · Family Plan</p>
+          <p className="text-white/35 text-sm max-w-xs">
+            Curses let you instantly deduct coins for bad behavior. Available on Family and Legendary plans.
+          </p>
+        </div>
+      </motion.div>
+    )
+  }
   const [title, setTitle] = useState('')
   const [icon, setIcon] = useState('☠️')
   const [penalty, setPenalty] = useState(10)

--- a/src/app/parent/family-tab.tsx
+++ b/src/app/parent/family-tab.tsx
@@ -5,6 +5,7 @@ import { motion } from 'framer-motion'
 import { toast } from 'sonner'
 import type { Family, Kid, KidColor } from '@/lib/types'
 import { KID_AVATARS, KID_COLORS } from '@/lib/constants'
+import { PLAN_LABELS, PLAN_LIMITS } from '@/lib/plans'
 import { ActionButton, Empty, FormInput, Section, fadeSlide } from './_ui'
 import type { ParentActions } from './use-parent-actions'
 
@@ -23,7 +24,7 @@ export function FamilyTab({ family, kids, onShowQr, actions }: Props) {
       <RealmName family={family} actions={actions} />
       <DailyResetSettings family={family} actions={actions} />
       <ParentLockSettings family={family} actions={actions} />
-      <AddKidForm actions={actions} />
+      <AddKidForm family={family} kidCount={kids.length} actions={actions} />
       <KidList kids={kids} onShowQr={onShowQr} actions={actions} />
       {family && <InviteLink family={family} actions={actions} />}
       {family?.api_key && <ApiKey family={family} actions={actions} />}
@@ -185,11 +186,14 @@ function ParentLockSettings({ family, actions }: { family: Family | null; action
   )
 }
 
-function AddKidForm({ actions }: { actions: ParentActions }) {
+function AddKidForm({ family, kidCount, actions }: { family: Family | null; kidCount: number; actions: ParentActions }) {
   const [name, setName] = useState('')
   const [avatar, setAvatar] = useState('🧙')
   const [color, setColor] = useState<KidColor>('azure')
   const [pin, setPin] = useState('')
+  const plan = family?.plan ?? 'free'
+  const limits = PLAN_LIMITS[plan]
+  const atLimit = limits.maxKids < Infinity && kidCount >= limits.maxKids
 
   const handleAdd = async () => {
     await actions.addKid({ name, avatar, color, pin })
@@ -255,10 +259,15 @@ function AddKidForm({ actions }: { actions: ParentActions }) {
           />
         </div>
 
+        {limits.maxKids < Infinity && (
+          <p className="text-xs text-center" style={{ color: atLimit ? '#fb923c' : 'rgba(255,255,255,0.3)' }}>
+            {kidCount} / {limits.maxKids} adventurers · {PLAN_LABELS[plan]} plan
+          </p>
+        )}
         <ActionButton
           onClick={handleAdd}
-          label="+ Add Adventurer"
-          disabled={!name.trim() || pin.length !== 4}
+          label={atLimit ? 'Adventurer limit reached' : '+ Add Adventurer'}
+          disabled={atLimit || !name.trim() || pin.length !== 4}
         />
       </div>
     </Section>

--- a/src/app/parent/page.tsx
+++ b/src/app/parent/page.tsx
@@ -147,10 +147,10 @@ export default function ParentDashboard() {
               />
             )}
             {tab === 'quests' && (
-              <QuestsTab kids={data.kids} quests={data.quests} actions={actions} />
+              <QuestsTab kids={data.kids} quests={data.quests} actions={actions} plan={data.family?.plan ?? 'free'} />
             )}
             {tab === 'rewards' && (
-              <RewardsTab rewards={data.rewards} actions={actions} />
+              <RewardsTab rewards={data.rewards} actions={actions} plan={data.family?.plan ?? 'free'} />
             )}
             {tab === 'curses' && (
               <CursesTab
@@ -158,6 +158,7 @@ export default function ParentDashboard() {
                 curses={data.curses}
                 activeCurseInstances={data.activeCurseInstances}
                 actions={actions}
+                plan={data.family?.plan ?? 'free'}
               />
             )}
             {tab === 'family' && (

--- a/src/app/parent/quest-form.tsx
+++ b/src/app/parent/quest-form.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import type { Kid, QuestKind, QuestTier } from '@/lib/types'
+import type { Kid, Plan, QuestKind, QuestTier } from '@/lib/types'
 import { QUEST_ICONS, TIER_CONFIG } from '@/lib/constants'
+import { PLAN_LIMITS } from '@/lib/plans'
 
 const DAY_LABELS = ['Su','Mo','Tu','We','Th','Fr','Sa']
 const TIERS: QuestTier[] = ['normal', 'rare', 'epic', 'legendary']
@@ -44,6 +45,8 @@ interface Props {
   /** Edit mode shows all icons; create mode shows the first 14. */
   iconLimit?: number
   inputBg?: string
+  /** Omit to allow all features (edit mode in QuestRow doesn't need plan gating). */
+  plan?: Plan
 }
 
 export const initialQuestFormState: QuestFormState = {
@@ -66,10 +69,11 @@ export function normalizeKindFrequency(kind: QuestKind, frequency: QuestFormStat
   return frequency
 }
 
-export function QuestFormFields({ state, onChange, kids, iconLimit, inputBg }: Props) {
+export function QuestFormFields({ state, onChange, kids, iconLimit, inputBg, plan }: Props) {
   const icons = iconLimit ? QUEST_ICONS.slice(0, iconLimit) : QUEST_ICONS
   const inputStyle = inputBg ?? 'rgba(255,255,255,0.06)'
   const inputBorder = '1px solid rgba(255,255,255,0.1)'
+  const limits = plan ? PLAN_LIMITS[plan] : PLAN_LIMITS['legendary']
 
   const setKind = (kind: QuestKind) => {
     onChange({
@@ -210,10 +214,13 @@ export function QuestFormFields({ state, onChange, kids, iconLimit, inputBg }: P
 
       {state.kind === 'personal' && state.frequency === 'daily' && (
         <div>
-          <label className="text-xs text-white/40 mb-1.5 block">
+          <label className="text-xs text-white/40 mb-1.5 flex items-center gap-2">
             Active Days <span className="text-white/20 font-normal">(none = every day)</span>
+            {!limits.activeDays && (
+              <span className="text-white/25 text-xs">🔒 Legendary plan</span>
+            )}
           </label>
-          <div className="flex gap-1">
+          <div className={`flex gap-1 ${!limits.activeDays ? 'opacity-30 pointer-events-none' : ''}`}>
             {DAY_LABELS.map((day, i) => {
               const on = state.activeDays.includes(i)
               return (
@@ -240,24 +247,32 @@ export function QuestFormFields({ state, onChange, kids, iconLimit, inputBg }: P
       )}
 
       <div>
-        <label className="text-xs text-white/40 mb-1.5 block">Tier</label>
+        <label className="text-xs text-white/40 mb-1.5 flex items-center gap-2">
+          Tier
+          {!limits.questTiers && (
+            <span className="text-white/25 font-normal text-xs">🔒 Legendary plan</span>
+          )}
+        </label>
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-1.5">
           {TIERS.map((t) => {
             const tc = TIER_CONFIG[t]
             const selected = state.tier === t
+            const locked = t !== 'normal' && !limits.questTiers
             return (
               <button
                 key={t}
-                onClick={() => onChange({ tier: t })}
+                onClick={() => !locked && onChange({ tier: t })}
+                disabled={locked}
                 className="py-2 rounded-xl text-xs font-semibold transition-all"
                 style={{
-                  background: selected ? tc.bg : 'rgba(255,255,255,0.04)',
-                  border: `1px solid ${selected ? tc.border : 'rgba(255,255,255,0.08)'}`,
-                  color: selected ? tc.color : 'rgba(255,255,255,0.4)',
-                  boxShadow: selected && tc.glow ? tc.glow : 'none',
+                  background: selected && !locked ? tc.bg : 'rgba(255,255,255,0.04)',
+                  border: `1px solid ${selected && !locked ? tc.border : 'rgba(255,255,255,0.08)'}`,
+                  color: locked ? 'rgba(255,255,255,0.18)' : selected ? tc.color : 'rgba(255,255,255,0.4)',
+                  boxShadow: selected && !locked && tc.glow ? tc.glow : 'none',
+                  cursor: locked ? 'not-allowed' : 'pointer',
                 }}
               >
-                {tc.label}
+                {locked ? '🔒 ' : ''}{tc.label}
               </button>
             )
           })}

--- a/src/app/parent/quests-tab.tsx
+++ b/src/app/parent/quests-tab.tsx
@@ -2,7 +2,8 @@
 
 import { useState } from 'react'
 import { motion } from 'framer-motion'
-import type { Kid, Quest } from '@/lib/types'
+import type { Kid, Plan, Quest } from '@/lib/types'
+import { PLAN_LABELS, PLAN_LIMITS } from '@/lib/plans'
 import { ActionButton, Empty, Section, fadeSlide } from './_ui'
 import { QuestFormFields, initialQuestFormState, type QuestFormState } from './quest-form'
 import { QuestRow } from './quest-row'
@@ -12,10 +13,14 @@ interface Props {
   kids: Kid[]
   quests: Quest[]
   actions: ParentActions
+  plan: Plan
 }
 
-export function QuestsTab({ kids, quests, actions }: Props) {
+export function QuestsTab({ kids, quests, actions, plan }: Props) {
   const [state, setState] = useState<QuestFormState>(initialQuestFormState)
+  const limits = PLAN_LIMITS[plan]
+  const activeCount = quests.filter((q) => q.active).length
+  const atLimit = limits.maxQuests < Infinity && activeCount >= limits.maxQuests
 
   const update = (patch: Partial<QuestFormState>) => setState((s) => ({ ...s, ...patch }))
 
@@ -52,8 +57,13 @@ export function QuestsTab({ kids, quests, actions }: Props) {
     <motion.div key="quests" {...fadeSlide} className="flex flex-col gap-6">
       <Section title="Add New Quest">
         <div className="flex flex-col gap-3">
-          <QuestFormFields state={state} onChange={update} kids={kids} iconLimit={14} />
-          <ActionButton onClick={handleAdd} label="+ Add Quest" />
+          <QuestFormFields state={state} onChange={update} kids={kids} iconLimit={14} plan={plan} />
+          {limits.maxQuests < Infinity && (
+            <p className="text-xs text-center" style={{ color: atLimit ? '#fb923c' : 'rgba(255,255,255,0.3)' }}>
+              {activeCount} / {limits.maxQuests} active quests · {PLAN_LABELS[plan]} plan
+            </p>
+          )}
+          <ActionButton onClick={handleAdd} label={atLimit ? 'Quest limit reached' : '+ Add Quest'} disabled={atLimit} />
         </div>
       </Section>
 

--- a/src/app/parent/rewards-tab.tsx
+++ b/src/app/parent/rewards-tab.tsx
@@ -2,20 +2,24 @@
 
 import { useState } from 'react'
 import { motion } from 'framer-motion'
-import type { Reward } from '@/lib/types'
+import type { Plan, Reward } from '@/lib/types'
+import { PLAN_LABELS, PLAN_LIMITS } from '@/lib/plans'
 import { ActionButton, Empty, FormInput, Section, fadeSlide } from './_ui'
 import type { ParentActions } from './use-parent-actions'
 
 interface Props {
   rewards: Reward[]
   actions: ParentActions
+  plan: Plan
 }
 
-export function RewardsTab({ rewards, actions }: Props) {
+export function RewardsTab({ rewards, actions, plan }: Props) {
   const [title, setTitle] = useState('')
   const [desc, setDesc] = useState('')
   const [icon, setIcon] = useState('🎁')
   const [cost, setCost] = useState(50)
+  const limits = PLAN_LIMITS[plan]
+  const atLimit = limits.maxRewards < Infinity && rewards.length >= limits.maxRewards
 
   const handleAdd = async () => {
     if (!title.trim()) return
@@ -56,7 +60,12 @@ export function RewardsTab({ rewards, actions }: Props) {
               style={{ background: 'rgba(255,255,255,0.06)', border: '1px solid rgba(255,255,255,0.1)' }}
             />
           </div>
-          <ActionButton onClick={handleAdd} label="+ Add Reward" />
+          {limits.maxRewards < Infinity && (
+            <p className="text-xs text-center" style={{ color: atLimit ? '#fb923c' : 'rgba(255,255,255,0.3)' }}>
+              {rewards.length} / {limits.maxRewards} rewards · {PLAN_LABELS[plan]} plan
+            </p>
+          )}
+          <ActionButton onClick={handleAdd} label={atLimit ? 'Reward limit reached' : '+ Add Reward'} disabled={atLimit} />
         </div>
       </Section>
 

--- a/src/app/parent/use-parent-actions.ts
+++ b/src/app/parent/use-parent-actions.ts
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation'
 import type { SupabaseClient } from '@supabase/supabase-js'
 import type { Family, Kid, Quest, QuestKind, QuestFrequency, QuestTier, Completion, Reward, Redemption, Curse, CurseInstance } from '@/lib/types'
 import { DEFAULT_QUESTS } from '@/lib/constants'
+import { PLAN_LIMITS, PLAN_LABELS, PLAN_UPGRADE_HINT } from '@/lib/plans'
 import { questDateString } from '@/lib/utils'
 import { getStreakBonus, yesterday } from './_streak'
 
@@ -15,6 +16,8 @@ interface Deps {
   completions: Completion[]
   redemptions: Redemption[]
   kids: Kid[]
+  quests: Quest[]
+  rewards: Reward[]
   curses: Curse[]
   activeCurseInstances: CurseInstance[]
   refetch: () => Promise<void>
@@ -63,7 +66,7 @@ export interface AddQuestInput {
 }
 
 export function useParentActions(deps: Deps): ParentActions {
-  const { supabase, family, completions, redemptions, kids, curses, activeCurseInstances, refetch } = deps
+  const { supabase, family, completions, redemptions, kids, quests, rewards, curses, activeCurseInstances, refetch } = deps
   const router = useRouter()
 
   const approve = useCallback(async (completionId: string) => {
@@ -169,6 +172,12 @@ export function useParentActions(deps: Deps): ParentActions {
 
   const addKid = useCallback(async (data: { name: string; avatar: string; color: 'azure' | 'mystic'; pin: string }) => {
     if (!data.name.trim() || data.pin.length !== 4 || !family) return
+    const plan = family.plan ?? 'free'
+    const limits = PLAN_LIMITS[plan]
+    if (limits.maxKids < Infinity && kids.length >= limits.maxKids) {
+      toast.error(`Kid limit reached (${limits.maxKids} max on ${PLAN_LABELS[plan]} plan). ${PLAN_UPGRADE_HINT[plan]}`)
+      return
+    }
     const { error } = await supabase.from('kids').insert({
       family_id: family.id,
       name: data.name.trim(),
@@ -182,10 +191,25 @@ export function useParentActions(deps: Deps): ParentActions {
     } else {
       toast.error('Failed to add adventurer')
     }
-  }, [family, refetch, supabase])
+  }, [family, kids, refetch, supabase])
 
   const addQuest = useCallback(async (data: AddQuestInput) => {
     if (!data.title.trim() || !family) return
+    const plan = family.plan ?? 'free'
+    const limits = PLAN_LIMITS[plan]
+    const activeQuestCount = quests.filter((q) => q.active).length
+    if (limits.maxQuests < Infinity && activeQuestCount >= limits.maxQuests) {
+      toast.error(`Quest limit reached (${limits.maxQuests} max on ${PLAN_LABELS[plan]} plan). ${PLAN_UPGRADE_HINT[plan]}`)
+      return
+    }
+    if (data.tier !== 'normal' && !limits.questTiers) {
+      toast.error(`Quest tiers require Legendary plan. ${PLAN_UPGRADE_HINT[plan]}`)
+      return
+    }
+    if (data.activeDays.length > 0 && !limits.activeDays) {
+      toast.error(`Active day scheduling requires Legendary plan. ${PLAN_UPGRADE_HINT[plan]}`)
+      return
+    }
     const { error } = await supabase.from('quests').insert({
       family_id: family.id,
       title: data.title.trim(),
@@ -211,7 +235,7 @@ export function useParentActions(deps: Deps): ParentActions {
     } else {
       toast.error('Failed to add quest')
     }
-  }, [family, refetch, supabase])
+  }, [family, quests, refetch, supabase])
 
   const toggleQuest = useCallback(async (id: string, active: boolean) => {
     await supabase.from('quests').update({ active: !active }).eq('id', id)
@@ -234,8 +258,17 @@ export function useParentActions(deps: Deps): ParentActions {
 
   const seedDefaultQuests = useCallback(async () => {
     if (!family) return
+    const plan = family.plan ?? 'free'
+    const limits = PLAN_LIMITS[plan]
+    const activeCount = quests.filter((q) => q.active).length
+    const slots = limits.maxQuests === Infinity ? DEFAULT_QUESTS.length : Math.max(0, limits.maxQuests - activeCount)
+    const toSeed = DEFAULT_QUESTS.slice(0, slots)
+    if (toSeed.length === 0) {
+      toast.error(`Quest limit reached (${limits.maxQuests} on ${PLAN_LABELS[plan]} plan). ${PLAN_UPGRADE_HINT[plan]}`)
+      return
+    }
     await supabase.from('quests').insert(
-      DEFAULT_QUESTS.map((q) => ({
+      toSeed.map((q) => ({
         ...q,
         family_id: family.id,
         kind: 'personal' as const,
@@ -244,12 +277,21 @@ export function useParentActions(deps: Deps): ParentActions {
         active: true,
       }))
     )
-    toast.success('Default quests added! ✨')
+    const msg = toSeed.length < DEFAULT_QUESTS.length
+      ? `Added ${toSeed.length}/${DEFAULT_QUESTS.length} starter quests (${PLAN_LABELS[plan]} plan limit) ✨`
+      : 'Default quests added! ✨'
+    toast.success(msg)
     await refetch()
-  }, [family, refetch, supabase])
+  }, [family, quests, refetch, supabase])
 
   const addReward = useCallback(async (data: { title: string; description: string; icon: string; cost: number }) => {
     if (!data.title.trim() || !family) return
+    const plan = family.plan ?? 'free'
+    const limits = PLAN_LIMITS[plan]
+    if (limits.maxRewards < Infinity && rewards.length >= limits.maxRewards) {
+      toast.error(`Reward limit reached (${limits.maxRewards} max on ${PLAN_LABELS[plan]} plan). ${PLAN_UPGRADE_HINT[plan]}`)
+      return
+    }
     const { error } = await supabase.from('rewards').insert({
       family_id: family.id,
       title: data.title.trim(),
@@ -262,7 +304,7 @@ export function useParentActions(deps: Deps): ParentActions {
       toast.success('Reward added to the store! 🎁')
       await refetch()
     }
-  }, [family, refetch, supabase])
+  }, [family, rewards, refetch, supabase])
 
   const deleteReward = useCallback(async (id: string) => {
     await supabase.from('rewards').delete().eq('id', id)
@@ -325,6 +367,11 @@ export function useParentActions(deps: Deps): ParentActions {
 
   const addCurse = useCallback(async (data: { title: string; icon: string; penalty: number }) => {
     if (!data.title.trim() || !family) return
+    const plan = family.plan ?? 'free'
+    if (!PLAN_LIMITS[plan].curses) {
+      toast.error(`Curses require Family plan or higher. ${PLAN_UPGRADE_HINT[plan]}`)
+      return
+    }
     const { error } = await supabase.from('curses').insert({
       family_id: family.id,
       title: data.title.trim(),

--- a/src/app/parent/use-parent-data.ts
+++ b/src/app/parent/use-parent-data.ts
@@ -49,7 +49,7 @@ export function useParentData(): ParentData {
       familyRes, kidsRes, questsRes, completionsRes, rewardsRes,
       pendingRedemptionsRes, approvedRedemptionsRes, cursesRes, curseInstancesRes,
     ] = await Promise.all([
-      supabase.from('families').select('id, name, invite_token, api_key, daily_reset_hour, created_at, parent_pin').eq('id', profile.family_id).single(),
+      supabase.from('families').select('id, name, invite_token, api_key, daily_reset_hour, created_at, parent_pin, plan').eq('id', profile.family_id).single(),
       supabase.from('kids').select(KID_COLS).eq('family_id', profile.family_id).order('created_at'),
       supabase.from('quests').select('*').eq('family_id', profile.family_id).order('created_at'),
       supabase.from('completions').select(`*, quest:quests(*), kid:kids(${KID_COLS})`).eq('date', today).order('completed_at', { ascending: false }),
@@ -67,6 +67,7 @@ export function useParentData(): ParentData {
         has_parent_pin: parent_pin !== null,
         api_key: rest.api_key ?? undefined,
         daily_reset_hour: rest.daily_reset_hour ?? 0,
+        plan: (rest.plan as import('@/lib/types').Plan) ?? 'free',
       })
     }
     if (kidsRes.data) setKids(kidsRes.data as Kid[])

--- a/src/lib/plans.ts
+++ b/src/lib/plans.ts
@@ -1,0 +1,49 @@
+import type { Plan } from './types'
+
+export interface PlanLimits {
+  maxKids: number
+  maxQuests: number
+  maxRewards: number
+  curses: boolean
+  questTiers: boolean
+  activeDays: boolean
+}
+
+export const PLAN_LIMITS: Record<Plan, PlanLimits> = {
+  free: {
+    maxKids: 2,
+    maxQuests: 5,
+    maxRewards: 3,
+    curses: false,
+    questTiers: false,
+    activeDays: false,
+  },
+  family: {
+    maxKids: Infinity,
+    maxQuests: Infinity,
+    maxRewards: Infinity,
+    curses: true,
+    questTiers: false,
+    activeDays: false,
+  },
+  legendary: {
+    maxKids: Infinity,
+    maxQuests: Infinity,
+    maxRewards: Infinity,
+    curses: true,
+    questTiers: true,
+    activeDays: true,
+  },
+}
+
+export const PLAN_LABELS: Record<Plan, string> = {
+  free: 'Free',
+  family: 'Family',
+  legendary: 'Legendary',
+}
+
+export const PLAN_UPGRADE_HINT: Record<Plan, string> = {
+  free: 'Upgrade to Family to unlock',
+  family: 'Upgrade to Legendary to unlock',
+  legendary: '',
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,5 @@
 export type KidColor = 'azure' | 'mystic'
+export type Plan = 'free' | 'family' | 'legendary'
 export type QuestFrequency = 'daily' | 'weekly' | 'once'
 export type QuestKind = 'personal' | 'shared' | 'oneoff'
 export type QuestTier = 'normal' | 'rare' | 'epic' | 'legendary'
@@ -11,6 +12,7 @@ export interface Family {
   invite_token: string
   api_key?: string
   daily_reset_hour: number
+  plan: Plan
   created_at: string
 }
 

--- a/supabase/migrations/20260504000000_add_plan_column.sql
+++ b/supabase/migrations/20260504000000_add_plan_column.sql
@@ -1,0 +1,5 @@
+-- Add subscription plan tier to families.
+-- Defaults to 'free'. Stripe webhooks will update this when paid plans land.
+ALTER TABLE families
+  ADD COLUMN plan text NOT NULL DEFAULT 'free'
+  CHECK (plan IN ('free', 'family', 'legendary'));

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -10,6 +10,7 @@ create table families (
   invite_token uuid not null default gen_random_uuid() unique,
   api_key uuid not null default gen_random_uuid() unique,
   daily_reset_hour integer not null default 0 check (daily_reset_hour >= 0 and daily_reset_hour <= 23),
+  plan text not null default 'free' check (plan in ('free', 'family', 'legendary')),
   created_at timestamptz default now()
 );
 


### PR DESCRIPTION
## Summary

- New `src/lib/plans.ts` — single source of truth for all tier limits and feature flags. Changing a limit or adding a tier is a one-line edit here.
- DB migration adds `families.plan TEXT DEFAULT 'free'` with a CHECK constraint. All existing rows become Free plan automatically.
- 3-layer enforcement: API routes (server, authoritative) + `use-parent-actions` (client guard) + UI hints (usage meters, lock icons, disabled buttons).

## Tier definitions

| | Free | Family | Legendary |
|---|---|---|---|
| Kids | 2 | ∞ | ∞ |
| Quests | 5 | ∞ | ∞ |
| Rewards | 3 | ∞ | ∞ |
| Curses | ✗ | ✓ | ✓ |
| Quest tiers (Heroic/Epic) | ✗ | ✗ | ✓ |
| Active-day scheduling | ✗ | ✗ | ✓ |

## What's intentionally NOT included

- No Stripe, no payment flows, no upgrade modals
- To "upgrade" for testing: `UPDATE families SET plan = 'family' WHERE id = '...'` in Supabase dashboard

## When Stripe lands later

A single webhook handler that does `UPDATE families SET plan = 'family'` is the only new code needed. Every enforcement layer already reads from that column.

## Test plan

- [ ] `npm test` passes (83 unit tests)
- [ ] `npm run build` compiles clean
- [ ] On Free plan: adding 3rd kid / 6th quest / 4th reward shows upgrade toast
- [ ] On Free plan: Curses tab shows feature-gate panel
- [ ] On Free plan: Quest form tier buttons show 🔒 for Heroic/Epic/Legendary; active-days greyed out
- [ ] API: `POST /api/quests` with `tier: 'heroic'` on Free plan returns 402
- [ ] Manual DB upgrade to 'family' removes all locks

🤖 Generated with [Claude Code](https://claude.com/claude-code)