### PR TITLE
rename: quest tier Heroic -> Rare (WoW progression)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -55,7 +55,7 @@ function AppMockup() {
           coins={340} streak={7}
           quests={[
             { title: 'Make your bed', icon: '🛏️', coins: 15, status: 'approved' },
-            { title: 'Feed the cat', icon: '🐱', coins: 20, status: 'pending', tier: 'heroic' },
+            { title: 'Feed the cat', icon: '🐱', coins: 20, status: 'pending', tier: 'rare' },
             { title: 'Clean desk', icon: '📚', coins: 25, status: 'todo' },
           ]}
         />
@@ -64,7 +64,7 @@ function AppMockup() {
           name="Liam" avatar="🧝‍♂️" color="mystic"
           coins={210} streak={3}
           quests={[
-            { title: 'Take out trash', icon: '🗑️', coins: 30, status: 'approved', tier: 'heroic' },
+            { title: 'Take out trash', icon: '🗑️', coins: 30, status: 'approved', tier: 'rare' },
             { title: 'Unload dishwasher', icon: '🍽️', coins: 20, status: 'todo' },
             { title: 'Vacuum living room', icon: '🧹', coins: 50, status: 'todo', tier: 'legendary' },
           ]}
@@ -91,13 +91,13 @@ function AppMockup() {
 }
 
 type QuestStatus = 'todo' | 'pending' | 'approved'
-type QuestTier = 'normal' | 'heroic' | 'legendary' | 'epic'
+type QuestTier = 'normal' | 'rare' | 'epic' | 'legendary'
 
 const TIER_COLORS: Record<QuestTier, string> = {
   normal: '#fbbf24',
-  heroic: '#38bdf8',
-  legendary: '#fbbf24',
+  rare: '#38bdf8',
   epic: '#a78bfa',
+  legendary: '#fbbf24',
 }
 
 function MockKidColumn({ name, avatar, color, coins, streak, quests }: {

--- a/src/app/parent/quest-form.tsx
+++ b/src/app/parent/quest-form.tsx
@@ -4,7 +4,7 @@ import type { Kid, QuestKind, QuestTier } from '@/lib/types'
 import { QUEST_ICONS, TIER_CONFIG } from '@/lib/constants'
 
 const DAY_LABELS = ['Su','Mo','Tu','We','Th','Fr','Sa']
-const TIERS: QuestTier[] = ['normal', 'heroic', 'legendary', 'epic']
+const TIERS: QuestTier[] = ['normal', 'rare', 'epic', 'legendary']
 
 const KIND_LABELS: Record<QuestKind, { title: string; subtitle: string; emoji: string }> = {
   personal: {

--- a/src/lib/__tests__/constants.test.ts
+++ b/src/lib/__tests__/constants.test.ts
@@ -52,7 +52,7 @@ describe('getStreakLabel', () => {
 })
 
 describe('TIER_CONFIG', () => {
-  const tiers = ['normal', 'heroic', 'legendary', 'epic'] as const
+  const tiers = ['normal', 'rare', 'epic', 'legendary'] as const
 
   it('has all four tiers', () => {
     tiers.forEach((tier) => {
@@ -72,7 +72,7 @@ describe('TIER_CONFIG', () => {
 
   it('non-normal tiers have glows; normal does not', () => {
     expect(TIER_CONFIG.normal.glow).toBeNull()
-    expect(TIER_CONFIG.heroic.glow).toBeTruthy()
+    expect(TIER_CONFIG.rare.glow).toBeTruthy()
     expect(TIER_CONFIG.legendary.glow).toBeTruthy()
     expect(TIER_CONFIG.epic.glow).toBeTruthy()
   })

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -16,8 +16,8 @@ export const TIER_CONFIG: Record<QuestTier, {
     border: 'rgba(255,255,255,0.1)',
     glow: null,
   },
-  heroic: {
-    label: 'Heroic',
+  rare: {
+    label: 'Rare',
     icon: '🔵',
     color: '#38bdf8',
     bg: 'linear-gradient(135deg, rgba(56,189,248,0.14) 0%, rgba(56,189,248,0.05) 100%)',

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,7 +1,7 @@
 export type KidColor = 'azure' | 'mystic'
 export type QuestFrequency = 'daily' | 'weekly' | 'once'
 export type QuestKind = 'personal' | 'shared' | 'oneoff'
-export type QuestTier = 'normal' | 'heroic' | 'legendary' | 'epic'
+export type QuestTier = 'normal' | 'rare' | 'epic' | 'legendary'
 export type CompletionStatus = 'pending' | 'approved' | 'rejected'
 
 export interface Family {

--- a/supabase/migrations/20260504000001_rename_heroic_to_rare.sql
+++ b/supabase/migrations/20260504000001_rename_heroic_to_rare.sql
@@ -1,0 +1,6 @@
+-- Rename quest tier 'heroic' -> 'rare' to match WoW quality progression:
+-- Common (normal) -> Rare -> Epic -> Legendary
+ALTER TABLE quests DROP CONSTRAINT IF EXISTS quests_tier_check;
+UPDATE quests SET tier = 'rare' WHERE tier = 'heroic';
+ALTER TABLE quests ADD CONSTRAINT quests_tier_check
+  CHECK (tier IN ('normal', 'rare', 'epic', 'legendary'));

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -43,7 +43,7 @@ create table quests (
   assigned_to uuid references kids(id) on delete set null,
   kind text not null default 'personal' check (kind in ('personal', 'shared', 'oneoff')),
   frequency text not null default 'daily' check (frequency in ('daily', 'weekly', 'once')),
-  tier text not null default 'normal' check (tier in ('normal', 'heroic', 'legendary', 'epic')),
+  tier text not null default 'normal' check (tier in ('normal', 'rare', 'epic', 'legendary')),
   slots integer not null default 1 check (slots >= 1),
   active_days integer[],
   active boolean not null default true,


### PR DESCRIPTION
## Summary

- Renames `'heroic'` → `'rare'` everywhere to match WoW quality ladder: Common → Rare → Epic → Legendary
- Fixes tier display order in the quest form (was normal/heroic/legendary/epic)
- DB migration drops and recreates the `quests.tier` CHECK constraint, backfills existing `heroic` rows to `rare`

## Files changed

- `src/lib/types.ts` — `QuestTier` union
- `src/lib/constants.ts` — `TIER_CONFIG` key + label
- `src/app/parent/quest-form.tsx` — `TIERS` display order
- `src/app/page.tsx` — local type + mock data
- `src/lib/__tests__/constants.test.ts` — test fixtures
- `supabase/schema.sql` + new migration

## Test plan

- [ ] 83 unit tests pass
- [ ] Build passes
- [ ] Quest form shows: Common → Rare → Epic → Legendary in order
- [ ] Existing quests with `tier = 'heroic'` in DB are migrated to `'rare'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)