### PR TITLE
feat: inline reward editing in parent dashboard

### DIFF
--- a/src/app/parent/rewards-tab.tsx
+++ b/src/app/parent/rewards-tab.tsx
@@ -1,11 +1,134 @@
 'use client'
 
 import { useState } from 'react'
-import { motion } from 'framer-motion'
+import { motion, AnimatePresence } from 'framer-motion'
 import type { Plan, Reward } from '@/lib/types'
 import { PLAN_LABELS, PLAN_LIMITS } from '@/lib/plans'
 import { ActionButton, Empty, FormInput, Section, fadeSlide } from './_ui'
 import type { ParentActions } from './use-parent-actions'
+
+const REWARD_ICONS = ['🎁', '🎮', '📱', '🍕', '🎬', '🎡', '🎪', '🛒', '💤', '🎯', '🎨', '🎵']
+
+interface RewardRowProps {
+  reward: Reward
+  onSave: ParentActions['saveReward']
+  onDelete: ParentActions['deleteReward']
+}
+
+function RewardRow({ reward, onSave, onDelete }: RewardRowProps) {
+  const [editing, setEditing] = useState(false)
+  const [title, setTitle] = useState(reward.title)
+  const [desc, setDesc] = useState(reward.description ?? '')
+  const [icon, setIcon] = useState(reward.icon)
+  const [cost, setCost] = useState(reward.cost)
+
+  const handleSave = async () => {
+    await onSave(reward.id, { title, description: desc, icon, cost })
+    setEditing(false)
+  }
+
+  const handleCancel = () => {
+    setTitle(reward.title)
+    setDesc(reward.description ?? '')
+    setIcon(reward.icon)
+    setCost(reward.cost)
+    setEditing(false)
+  }
+
+  return (
+    <div
+      className="rounded-xl overflow-hidden"
+      style={{ background: 'rgba(255,255,255,0.04)', border: `1px solid ${editing ? 'rgba(251,191,36,0.2)' : 'rgba(255,255,255,0.08)'}` }}
+    >
+      <div className="flex items-center gap-3 p-3">
+        <span className="text-2xl">{reward.icon}</span>
+        <div className="flex-1">
+          <p className="text-white/90 text-sm font-semibold">{reward.title}</p>
+          {reward.description && <p className="text-white/40 text-xs">{reward.description}</p>}
+        </div>
+        <span className="text-cq-gold text-sm font-bold font-heading">🪙 {reward.cost}</span>
+        <button
+          onClick={() => setEditing((e) => !e)}
+          className="text-xs px-2.5 py-1 rounded-lg transition-all"
+          style={{
+            background: editing ? 'rgba(251,191,36,0.12)' : 'rgba(255,255,255,0.05)',
+            color: editing ? '#fbbf24' : 'rgba(255,255,255,0.4)',
+          }}
+        >
+          ✏️
+        </button>
+        <button
+          onClick={() => onDelete(reward.id)}
+          className="text-white/20 hover:text-red-400 transition-all text-xs ml-1"
+        >
+          ✕
+        </button>
+      </div>
+
+      <AnimatePresence>
+        {editing && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            className="overflow-hidden"
+          >
+            <div
+              className="px-3 pb-3 pt-2 flex flex-col gap-3"
+              style={{ borderTop: '1px solid rgba(255,255,255,0.07)' }}
+            >
+              <div className="flex gap-2 flex-wrap">
+                {REWARD_ICONS.map((ic) => (
+                  <button
+                    key={ic}
+                    onClick={() => setIcon(ic)}
+                    className="text-xl w-9 h-9 rounded-xl transition-all"
+                    style={{
+                      background: icon === ic ? 'rgba(251,191,36,0.2)' : 'rgba(255,255,255,0.05)',
+                      border: `1px solid ${icon === ic ? 'rgba(251,191,36,0.4)' : 'rgba(255,255,255,0.08)'}`,
+                    }}
+                  >
+                    {ic}
+                  </button>
+                ))}
+              </div>
+              <FormInput placeholder="Reward title..." value={title} onChange={setTitle} />
+              <FormInput placeholder="Description (optional)" value={desc} onChange={setDesc} />
+              <div>
+                <label className="text-xs text-white/40 mb-1 block">Coin cost</label>
+                <input
+                  type="number"
+                  min={1}
+                  value={cost}
+                  onChange={(e) => setCost(Number(e.target.value))}
+                  className="w-full px-3 py-2.5 rounded-xl text-sm text-white/90 outline-none"
+                  style={{ background: 'rgba(255,255,255,0.06)', border: '1px solid rgba(255,255,255,0.1)' }}
+                />
+              </div>
+              <div className="flex gap-2">
+                <button
+                  onClick={handleSave}
+                  className="flex-1 py-2 rounded-xl text-sm font-bold transition-all"
+                  style={{ background: 'rgba(74,222,128,0.14)', border: '1px solid rgba(74,222,128,0.3)', color: '#4ade80' }}
+                >
+                  Save Changes
+                </button>
+                <button
+                  onClick={handleCancel}
+                  className="px-4 py-2 rounded-xl text-sm transition-all"
+                  style={{ background: 'rgba(255,255,255,0.05)', border: '1px solid rgba(255,255,255,0.08)', color: 'rgba(255,255,255,0.4)' }}
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  )
+}
 
 interface Props {
   rewards: Reward[]
@@ -75,24 +198,7 @@ export function RewardsTab({ rewards, actions, plan }: Props) {
         ) : (
           <div className="flex flex-col gap-2">
             {rewards.map((r) => (
-              <div
-                key={r.id}
-                className="flex items-center gap-3 p-3 rounded-xl"
-                style={{ background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.08)' }}
-              >
-                <span className="text-2xl">{r.icon}</span>
-                <div className="flex-1">
-                  <p className="text-white/90 text-sm font-semibold">{r.title}</p>
-                  {r.description && <p className="text-white/40 text-xs">{r.description}</p>}
-                </div>
-                <span className="text-cq-gold text-sm font-bold font-heading">🪙 {r.cost}</span>
-                <button
-                  onClick={() => actions.deleteReward(r.id)}
-                  className="text-white/20 hover:text-red-400 transition-all text-xs ml-1"
-                >
-                  ✕
-                </button>
-              </div>
+              <RewardRow key={r.id} reward={r} onSave={actions.saveReward} onDelete={actions.deleteReward} />
             ))}
           </div>
         )}

--- a/src/app/parent/use-parent-actions.ts
+++ b/src/app/parent/use-parent-actions.ts
@@ -38,6 +38,7 @@ export interface ParentActions {
   seedDefaultQuests: () => Promise<void>
   addReward: (data: { title: string; description: string; icon: string; cost: number }) => Promise<void>
   deleteReward: (id: string) => Promise<void>
+  saveReward: (id: string, updates: { title: string; description: string; icon: string; cost: number }) => Promise<void>
   saveResetHour: (hour: number) => Promise<void>
   saveFamilyName: (name: string) => Promise<void>
   saveCoins: (kidId: string, value: number) => Promise<void>
@@ -311,6 +312,20 @@ export function useParentActions(deps: Deps): ParentActions {
     await refetch()
   }, [refetch, supabase])
 
+  const saveReward = useCallback(async (id: string, updates: { title: string; description: string; icon: string; cost: number }) => {
+    if (!updates.title.trim()) return
+    const { error } = await supabase.from('rewards').update({
+      title: updates.title.trim(),
+      description: updates.description.trim() || null,
+      icon: updates.icon,
+      cost: updates.cost,
+    }).eq('id', id)
+    if (!error) {
+      toast.success('Reward updated!')
+      await refetch()
+    }
+  }, [refetch, supabase])
+
   const saveResetHour = useCallback(async (hour: number) => {
     if (!family) return
     await supabase.from('families').update({ daily_reset_hour: hour }).eq('id', family.id)
@@ -448,7 +463,7 @@ export function useParentActions(deps: Deps): ParentActions {
     fulfillRedemption, denyRedemption,
     addKid,
     addQuest, toggleQuest, deleteQuest, saveQuest, seedDefaultQuests,
-    addReward, deleteReward,
+    addReward, deleteReward, saveReward,
     saveResetHour, saveFamilyName, saveCoins,
     setParentPin, removeParentPin,
     regenerateApiKey, regenerateInviteToken,


### PR DESCRIPTION
## Summary

- Each reward row in the Rewards tab now has an ✏️ edit button
- Clicking it expands an inline form (same icon picker, title, description, coin cost fields as Add Reward)
- Border highlights gold while editing so it's clear which row is active
- Cancel restores the original values without saving
- Adds `saveReward` to `ParentActions` / `useParentActions`

Follows the same collapsible-row pattern as `QuestRow`.

## Test plan

- [ ] Open Rewards tab → click ✏️ on a reward → edit fields → Save Changes → values update
- [ ] Click Cancel → original values restored, form closes
- [ ] Edit icon → save → icon updates in the row
- [ ] Empty title → save does nothing (guarded in action)

🤖 Generated with [Claude Code](https://claude.com/claude-code)