### PR TITLE
feat: quick-cast ad hoc curses without a template

### DIFF
--- a/src/app/parent/curses-tab.tsx
+++ b/src/app/parent/curses-tab.tsx
@@ -23,6 +23,11 @@ export function CursesTab({ kids, curses, activeCurseInstances, actions, plan }:
   const [penalty, setPenalty] = useState(10)
   const [castingCurseId, setCastingCurseId] = useState<string | null>(null)
 
+  // Quick cast state
+  const [qcTitle, setQcTitle] = useState('')
+  const [qcIcon, setQcIcon] = useState('😈')
+  const [qcPenalty, setQcPenalty] = useState(10)
+
   if (!PLAN_LIMITS[plan].curses) {
     return (
       <motion.div key="curses" {...fadeSlide} className="flex flex-col gap-6">
@@ -51,9 +56,67 @@ export function CursesTab({ kids, curses, activeCurseInstances, actions, plan }:
     setCastingCurseId(null)
   }
 
+  const handleQuickCast = async (kidId: string) => {
+    if (!qcTitle.trim()) return
+    await actions.castAdHocCurse({ title: qcTitle, icon: qcIcon, penalty: qcPenalty, kidId })
+    setQcTitle('')
+    setQcPenalty(10)
+  }
+
   return (
     <motion.div key="curses" {...fadeSlide} className="flex flex-col gap-6">
-      <Section title="Define Curses">
+      <Section title="⚡ Quick Cast">
+        <div className="flex flex-col gap-3">
+          <p className="text-white/40 text-xs">Cast a one-off curse instantly — no template needed.</p>
+          <div className="flex gap-2 flex-wrap">
+            {CURSE_ICONS.map((ic) => (
+              <button
+                key={ic}
+                onClick={() => setQcIcon(ic)}
+                className="text-xl w-10 h-10 rounded-xl transition-all"
+                style={{
+                  background: qcIcon === ic ? 'rgba(239,68,68,0.2)' : 'rgba(255,255,255,0.05)',
+                  border: `1px solid ${qcIcon === ic ? 'rgba(239,68,68,0.4)' : 'rgba(255,255,255,0.08)'}`,
+                }}
+              >
+                {ic}
+              </button>
+            ))}
+          </div>
+          <FormInput placeholder="What happened? (e.g. Whining, Hit sibling...)" value={qcTitle} onChange={setQcTitle} />
+          <div>
+            <label className="text-xs text-white/40 mb-1 block">Coin penalty</label>
+            <input
+              type="number"
+              min={1}
+              max={200}
+              value={qcPenalty}
+              onChange={(e) => setQcPenalty(Number(e.target.value))}
+              className="w-full px-3 py-2.5 rounded-xl text-sm text-white/90 outline-none"
+              style={{ background: 'rgba(255,255,255,0.06)', border: '1px solid rgba(255,255,255,0.1)' }}
+            />
+          </div>
+          {kids.length > 0 && (
+            <div className="flex gap-2 flex-wrap">
+              {kids.map(k => (
+                <motion.button
+                  key={k.id}
+                  onClick={() => handleQuickCast(k.id)}
+                  disabled={!qcTitle.trim()}
+                  className="flex-1 py-2.5 rounded-xl text-sm font-bold transition-all disabled:opacity-30"
+                  style={{ background: 'rgba(239,68,68,0.15)', border: '1px solid rgba(239,68,68,0.35)', color: '#f87171' }}
+                  whileHover={{ background: 'rgba(239,68,68,0.22)' }}
+                  whileTap={{ scale: 0.97 }}
+                >
+                  {k.avatar} Cast on {k.name}
+                </motion.button>
+              ))}
+            </div>
+          )}
+        </div>
+      </Section>
+
+      <Section title="Saved Curses">
         <div className="flex flex-col gap-3">
           <p className="text-white/45 text-xs">
             Create named penalties you can cast instantly when bad behavior happens.

--- a/src/app/parent/use-parent-actions.ts
+++ b/src/app/parent/use-parent-actions.ts
@@ -49,6 +49,7 @@ export interface ParentActions {
   addCurse: (data: { title: string; icon: string; penalty: number }) => Promise<void>
   deleteCurse: (id: string) => Promise<void>
   castCurse: (curseId: string, kidId: string) => Promise<void>
+  castAdHocCurse: (data: { title: string; icon: string; penalty: number; kidId: string }) => Promise<void>
   resolveCurse: (instanceId: string, refund: boolean) => Promise<void>
   signOut: () => Promise<void>
 }
@@ -427,6 +428,41 @@ export function useParentActions(deps: Deps): ParentActions {
     await refetch()
   }, [curses, kids, refetch, supabase])
 
+  const castAdHocCurse = useCallback(async (data: { title: string; icon: string; penalty: number; kidId: string }) => {
+    if (!data.title.trim() || !family) return
+    const plan = family.plan ?? 'free'
+    if (!PLAN_LIMITS[plan].curses) {
+      toast.error(`Curses require Family plan or higher. ${PLAN_UPGRADE_HINT[plan]}`)
+      return
+    }
+    const kid = kids.find(k => k.id === data.kidId)
+    if (!kid) return
+
+    const { data: curse, error: curseError } = await supabase.from('curses').insert({
+      family_id: family.id,
+      title: data.title.trim(),
+      icon: data.icon,
+      penalty: data.penalty,
+    }).select('id').single()
+    if (curseError || !curse) { toast.error('Failed to cast curse'); return }
+
+    const { error: instanceError } = await supabase.from('curse_instances').insert({
+      curse_id: curse.id,
+      kid_id: data.kidId,
+      coins_deducted: data.penalty,
+      status: 'active',
+    })
+    if (instanceError) { toast.error('Curse created but failed to cast'); return }
+
+    const { data: freshKid } = await supabase.from('kids').select('coins').eq('id', data.kidId).single()
+    await supabase.from('kids')
+      .update({ coins: Math.max(0, (freshKid?.coins ?? kid.coins) - data.penalty) })
+      .eq('id', data.kidId)
+
+    toast.success(`${data.icon} ${data.title.trim()} cast on ${kid.name}! −${data.penalty} coins`)
+    await refetch()
+  }, [family, kids, refetch, supabase])
+
   const resolveCurse = useCallback(async (instanceId: string, refund: boolean) => {
     const instance = activeCurseInstances.find(ci => ci.id === instanceId)
     const kid = instance?.kid as Kid | undefined
@@ -467,7 +503,7 @@ export function useParentActions(deps: Deps): ParentActions {
     saveResetHour, saveFamilyName, saveCoins,
     setParentPin, removeParentPin,
     regenerateApiKey, regenerateInviteToken,
-    addCurse, deleteCurse, castCurse, resolveCurse,
+    addCurse, deleteCurse, castCurse, castAdHocCurse, resolveCurse,
     signOut,
   }
 }


### PR DESCRIPTION
## Summary

- New **⚡ Quick Cast** section at the top of the Curses tab
- Pick icon → describe what happened → set penalty → tap kid button → instant cast
- No template creation step required; the curse also saves to Saved Curses for reuse
- Adds `castAdHocCurse` to `useParentActions`: inserts curse + instance in one go, deducts coins with a fresh-fetch guard
- Renamed "Define Curses" → "Saved Curses" for clarity

## Test plan

- [ ] Curses tab → fill Quick Cast (icon, description, penalty) → tap kid → curse appears in Active Afflictions, coins deducted
- [ ] Empty description keeps kid buttons disabled
- [ ] Saved Curses cast/delete flow still works
- [ ] Forgive/Resolve in Active Afflictions still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)