### PR TITLE
feat: XP system, levels, and weekly completion goal bonuses

### DIFF
--- a/src/app/display/page.tsx
+++ b/src/app/display/page.tsx
@@ -37,7 +37,7 @@ export default function WallDisplay() {
 
     const [familyRes, kidsRes, questsRes, rewardsRes] = await Promise.all([
       supabase.from('families').select('id, name, invite_token, daily_reset_hour, created_at, plan').eq('id', profile.family_id).single(),
-      supabase.from('kids').select('id, name, avatar, color, coins, streak, last_completed_date, family_id, created_at').eq('family_id', profile.family_id).order('created_at'),
+      supabase.from('kids').select('id, name, avatar, color, coins, streak, last_completed_date, xp, level, weekly_goal, weekly_goal_paid_week, family_id, created_at').eq('family_id', profile.family_id).order('created_at'),
       supabase.from('quests').select('*').eq('family_id', profile.family_id).eq('active', true).order('created_at'),
       supabase.from('rewards').select('*').eq('available', true).order('cost'),
     ])

--- a/src/app/parent/use-parent-actions.ts
+++ b/src/app/parent/use-parent-actions.ts
@@ -8,7 +8,8 @@ import type { Family, Kid, Quest, QuestKind, QuestFrequency, QuestTier, Completi
 import { DEFAULT_QUESTS } from '@/lib/constants'
 import { PLAN_LIMITS, PLAN_LABELS, PLAN_UPGRADE_HINT } from '@/lib/plans'
 import { questDateString } from '@/lib/utils'
-import { getStreakBonus, yesterday } from './_streak'
+import { yesterday } from './_streak'
+import { getLevelFromXP, getWeekMonday } from '@/lib/xp'
 
 interface Deps {
   supabase: SupabaseClient
@@ -75,8 +76,7 @@ export function useParentActions(deps: Deps): ParentActions {
     const completion = completions.find((c) => c.id === completionId)
     if (!completion) return
 
-    const bonus = getStreakBonus(completion.kid?.streak ?? 0)
-    const coinsAwarded = Math.round((completion.quest?.coins ?? 0) * bonus)
+    const coinsAwarded = completion.quest?.coins ?? 0
 
     const { data: updated, error } = await supabase
       .from('completions')
@@ -91,19 +91,55 @@ export function useParentActions(deps: Deps): ParentActions {
       return
     }
 
-    await supabase.from('kids').update({ coins: (completion.kid?.coins ?? 0) + coinsAwarded }).eq('id', completion.kid_id)
+    const { data: freshKid } = await supabase
+      .from('kids')
+      .select('coins, xp, level, streak, last_completed_date, weekly_goal, weekly_goal_paid_week')
+      .eq('id', completion.kid_id)
+      .single()
 
+    const newXP = (freshKid?.xp ?? 0) + coinsAwarded
+    const newLevel = getLevelFromXP(newXP)
     const today = questDateString(family?.daily_reset_hour ?? 0)
-    const lastDate = completion.kid?.last_completed_date
-    const newStreak = lastDate === yesterday() ? (completion.kid?.streak ?? 0) + 1 : 1
+    const newStreak = freshKid?.last_completed_date === yesterday() ? (freshKid?.streak ?? 0) + 1 : 1
 
-    await supabase.from('kids').update({ streak: newStreak, last_completed_date: today }).eq('id', completion.kid_id)
+    // Check weekly goal payout
+    const monday = getWeekMonday()
+    const { data: weeklyData } = await supabase
+      .from('completions')
+      .select('coins_awarded')
+      .eq('kid_id', completion.kid_id)
+      .eq('status', 'approved')
+      .gte('date', monday)
+
+    const weeklyCount = weeklyData?.length ?? 0
+    const weeklyCoinsTotal = weeklyData?.reduce((s, c) => s + (c.coins_awarded ?? 0), 0) ?? 0
+    const goalHit = weeklyCount >= (freshKid?.weekly_goal ?? 5)
+    const alreadyPaid = freshKid?.weekly_goal_paid_week === monday
+    const bonusCoins = goalHit && !alreadyPaid ? Math.ceil(weeklyCoinsTotal * 0.2) : 0
+
+    await supabase.from('kids').update({
+      coins: (freshKid?.coins ?? 0) + coinsAwarded + bonusCoins,
+      xp: newXP + bonusCoins,
+      level: getLevelFromXP(newXP + bonusCoins),
+      streak: newStreak,
+      last_completed_date: today,
+      ...(goalHit && !alreadyPaid ? { weekly_goal_paid_week: monday } : {}),
+    }).eq('id', completion.kid_id)
 
     if (completion.quest?.kind === 'oneoff') {
       await supabase.from('quests').update({ active: false }).eq('id', completion.quest.id)
     }
 
-    toast.success(`Quest approved! +${coinsAwarded} coins awarded ✨`)
+    if (bonusCoins > 0) {
+      toast.success(`🎯 Weekly goal hit! +${coinsAwarded} coins + ${bonusCoins} bonus for ${completion.kid?.name ?? 'adventurer'}!`)
+    } else {
+      toast.success(`Quest approved! +${coinsAwarded} coins awarded ✨`)
+    }
+
+    if (newLevel > (freshKid?.level ?? 1)) {
+      setTimeout(() => toast.success(`⬆️ ${completion.kid?.name ?? 'Level up'}! Reached Level ${newLevel}!`), 600)
+    }
+
     await refetch()
   }, [completions, family?.daily_reset_hour, refetch, supabase])
 
@@ -116,7 +152,6 @@ export function useParentActions(deps: Deps): ParentActions {
   const undoApproval = useCallback(async (completionId: string) => {
     const completion = completions.find((c) => c.id === completionId)
     if (!completion) return
-    const kid = completion.kid as Kid | undefined
     const coinsToRemove = completion.coins_awarded ?? 0
 
     await supabase
@@ -124,8 +159,15 @@ export function useParentActions(deps: Deps): ParentActions {
       .update({ status: 'pending', approved_at: null, coins_awarded: null })
       .eq('id', completionId)
 
-    if (kid && coinsToRemove > 0) {
-      await supabase.from('kids').update({ coins: Math.max(0, (kid.coins ?? 0) - coinsToRemove) }).eq('id', kid.id)
+    if (coinsToRemove > 0) {
+      const { data: freshKid } = await supabase
+        .from('kids').select('coins, xp').eq('id', completion.kid_id).single()
+      const newXP = Math.max(0, (freshKid?.xp ?? 0) - coinsToRemove)
+      await supabase.from('kids').update({
+        coins: Math.max(0, (freshKid?.coins ?? 0) - coinsToRemove),
+        xp: newXP,
+        level: getLevelFromXP(newXP),
+      }).eq('id', completion.kid_id)
     }
     toast.success('Approval undone — back to pending')
     await refetch()

--- a/src/app/parent/use-parent-data.ts
+++ b/src/app/parent/use-parent-data.ts
@@ -20,7 +20,7 @@ export interface ParentData {
   refetch: () => Promise<void>
 }
 
-const KID_COLS = 'id, name, avatar, color, coins, streak, last_completed_date, family_id, created_at'
+const KID_COLS = 'id, name, avatar, color, coins, streak, last_completed_date, xp, level, weekly_goal, weekly_goal_paid_week, family_id, created_at'
 
 export function useParentData(): ParentData {
   const [supabase] = useState(createClient)

--- a/src/components/kid-column.tsx
+++ b/src/components/kid-column.tsx
@@ -4,6 +4,7 @@ import { motion } from 'framer-motion'
 import Link from 'next/link'
 import type { Kid, Quest, Completion } from '@/lib/types'
 import { KID_COLORS } from '@/lib/constants'
+import { getXPProgress, getLevelTitle } from '@/lib/xp'
 import { CoinCounter } from './coin-counter'
 import { StreakBadge } from './streak-badge'
 import { QuestCard } from './quest-card'
@@ -37,6 +38,7 @@ export function KidColumn({
   linkToKidView = true,
 }: KidColumnProps) {
   const colors = KID_COLORS[kid.color]
+  const xpInfo = getXPProgress(kid.xp ?? 0)
 
   const getCompletion = (quest: Quest): Completion | undefined => {
     if (quest.frequency === 'weekly') {
@@ -108,11 +110,28 @@ export function KidColumn({
             {kid.name}
           </h2>
           <p className="text-xs mt-0.5 font-medium" style={{ color: colors.primary }}>
-            Adventurer · Level {Math.floor(kid.coins / 50) + 1}
+            {getLevelTitle(kid.level ?? 1)} · Lv {kid.level ?? 1}
           </p>
         </div>
 
         <CoinCounter value={kid.coins} size="md" />
+
+        {/* XP bar */}
+        <div className="w-full">
+          <div className="flex justify-between text-xs text-white/25 mb-1">
+            <span>XP</span>
+            <span>{xpInfo.currentXP}/{xpInfo.neededXP}</span>
+          </div>
+          <div className="h-1 rounded-full overflow-hidden" style={{ background: 'rgba(255,255,255,0.06)' }}>
+            <motion.div
+              className="h-full rounded-full"
+              style={{ background: `linear-gradient(90deg, ${colors.primary}, #fbbf24)` }}
+              initial={{ width: 0 }}
+              animate={{ width: `${xpInfo.pct}%` }}
+              transition={{ duration: 0.8, ease: 'easeOut' }}
+            />
+          </div>
+        </div>
 
         <div className="flex items-center gap-2">
           {kid.streak > 1 && <StreakBadge streak={kid.streak} />}

--- a/src/lib/__tests__/xp.test.ts
+++ b/src/lib/__tests__/xp.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest'
+import { getLevelFromXP, getXPForLevel, getXPProgress, getLevelTitle, getWeekMonday, LEVEL_TITLES } from '../xp'
+
+describe('getLevelFromXP', () => {
+  it('starts at level 1 with 0 XP', () => {
+    expect(getLevelFromXP(0)).toBe(1)
+    expect(getLevelFromXP(99)).toBe(1)
+  })
+
+  it('reaches level 2 at 100 XP', () => {
+    expect(getLevelFromXP(100)).toBe(2)
+    expect(getLevelFromXP(249)).toBe(2)
+  })
+
+  it('handles thresholds for levels 3–10', () => {
+    expect(getLevelFromXP(250)).toBe(3)
+    expect(getLevelFromXP(500)).toBe(4)
+    expect(getLevelFromXP(900)).toBe(5)
+    expect(getLevelFromXP(1400)).toBe(6)
+    expect(getLevelFromXP(2100)).toBe(7)
+    expect(getLevelFromXP(3000)).toBe(8)
+    expect(getLevelFromXP(4200)).toBe(9)
+    expect(getLevelFromXP(6000)).toBe(10)
+  })
+
+  it('returns level 10 for XP just below level 11 threshold', () => {
+    // Level 11 needs 6000 + (11 * 800) = 14800
+    expect(getLevelFromXP(14799)).toBe(10)
+    expect(getLevelFromXP(14800)).toBe(11)
+  })
+
+  it('keeps climbing past level 10', () => {
+    expect(getLevelFromXP(100_000)).toBeGreaterThan(10)
+  })
+})
+
+describe('getXPForLevel', () => {
+  it('returns 0 for level 1', () => {
+    expect(getXPForLevel(1)).toBe(0)
+  })
+
+  it('matches known thresholds', () => {
+    expect(getXPForLevel(2)).toBe(100)
+    expect(getXPForLevel(5)).toBe(900)
+    expect(getXPForLevel(10)).toBe(6000)
+  })
+
+  it('is consistent with getLevelFromXP', () => {
+    for (let lv = 1; lv <= 12; lv++) {
+      const xp = getXPForLevel(lv)
+      expect(getLevelFromXP(xp)).toBe(lv)
+    }
+  })
+})
+
+describe('getXPProgress', () => {
+  it('shows 0% at level start', () => {
+    const p = getXPProgress(0)
+    expect(p.level).toBe(1)
+    expect(p.pct).toBe(0)
+    expect(p.currentXP).toBe(0)
+  })
+
+  it('shows 50% halfway through a level', () => {
+    // Level 1 spans 0–99 (neededXP = 100). 50 XP = 50%.
+    const p = getXPProgress(50)
+    expect(p.level).toBe(1)
+    expect(p.pct).toBe(50)
+  })
+
+  it('caps pct at 100', () => {
+    // Level 10 threshold is 6000, level 11 threshold is 14800.
+    // At exactly level 11 threshold, pct should be 0 for level 11 (or 100 capped for level 10).
+    const p = getXPProgress(6000)
+    expect(p.pct).toBeGreaterThanOrEqual(0)
+    expect(p.pct).toBeLessThanOrEqual(100)
+  })
+})
+
+describe('getLevelTitle', () => {
+  it('returns correct titles for levels 1-10', () => {
+    expect(getLevelTitle(1)).toBe('Apprentice')
+    expect(getLevelTitle(6)).toBe('Hero')
+    expect(getLevelTitle(10)).toBe('Mythic')
+  })
+
+  it('returns Mythic N for levels beyond 10', () => {
+    expect(getLevelTitle(11)).toBe('Mythic 2')
+    expect(getLevelTitle(15)).toBe('Mythic 6')
+  })
+
+  it('has 10 base titles defined', () => {
+    expect(LEVEL_TITLES).toHaveLength(10)
+  })
+})
+
+describe('getWeekMonday', () => {
+  it('returns a valid YYYY-MM-DD string', () => {
+    const monday = getWeekMonday()
+    expect(monday).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+  })
+
+  it('always returns a Monday', () => {
+    const monday = getWeekMonday()
+    const d = new Date(monday + 'T00:00:00')
+    expect(d.getDay()).toBe(1) // 1 = Monday
+  })
+})

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -31,6 +31,10 @@ export interface Kid {
   coins: number
   streak: number
   last_completed_date: string | null
+  xp: number
+  level: number
+  weekly_goal: number
+  weekly_goal_paid_week: string | null
   pin?: string
   created_at: string
 }

--- a/src/lib/xp.ts
+++ b/src/lib/xp.ts
@@ -1,0 +1,70 @@
+// XP thresholds for levels 1–10 (index = level - 1)
+const THRESHOLDS = [0, 100, 250, 500, 900, 1400, 2100, 3000, 4200, 6000]
+
+export const LEVEL_TITLES = [
+  'Apprentice', 'Squire', 'Scout', 'Warrior', 'Champion',
+  'Hero', 'Veteran', 'Guardian', 'Legend', 'Mythic',
+]
+
+export function getLevelTitle(level: number): string {
+  if (level <= LEVEL_TITLES.length) return LEVEL_TITLES[level - 1]
+  return `Mythic ${level - 9}`
+}
+
+export function getXPForLevel(level: number): number {
+  if (level <= THRESHOLDS.length) return THRESHOLDS[level - 1]
+  let xp = THRESHOLDS[THRESHOLDS.length - 1]
+  for (let lv = THRESHOLDS.length; lv < level; lv++) {
+    xp += (lv + 1) * 800
+  }
+  return xp
+}
+
+export function getLevelFromXP(xp: number): number {
+  let level = 1
+  // Levels 1-10: check fixed thresholds
+  for (let i = 0; i < THRESHOLDS.length; i++) {
+    if (xp >= THRESHOLDS[i]) level = i + 1
+    else break
+  }
+  if (level < THRESHOLDS.length) return level
+
+  // Levels 11+: formula-based
+  let remaining = xp - THRESHOLDS[THRESHOLDS.length - 1]
+  let lv = THRESHOLDS.length
+  while (true) {
+    const needed = (lv + 1) * 800
+    if (remaining < needed) break
+    remaining -= needed
+    lv++
+  }
+  return lv
+}
+
+export function getXPProgress(xp: number): {
+  level: number
+  currentXP: number
+  neededXP: number
+  pct: number
+} {
+  const level = getLevelFromXP(xp)
+  const levelStart = getXPForLevel(level)
+  const levelEnd = getXPForLevel(level + 1)
+  const currentXP = xp - levelStart
+  const neededXP = levelEnd - levelStart
+  return {
+    level,
+    currentXP,
+    neededXP,
+    pct: Math.min(100, Math.round((currentXP / neededXP) * 100)),
+  }
+}
+
+/** Returns the Monday of the current week as 'YYYY-MM-DD'. */
+export function getWeekMonday(): string {
+  const d = new Date()
+  const day = d.getDay() // 0=Sun
+  const diff = day === 0 ? -6 : 1 - day
+  d.setDate(d.getDate() + diff)
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}

--- a/supabase/migrations/20260505000000_add_xp_weekly_goals.sql
+++ b/supabase/migrations/20260505000000_add_xp_weekly_goals.sql
@@ -1,0 +1,6 @@
+-- XP, level, and weekly goal tracking per kid
+
+ALTER TABLE kids ADD COLUMN xp integer NOT NULL DEFAULT 0;
+ALTER TABLE kids ADD COLUMN level integer NOT NULL DEFAULT 1;
+ALTER TABLE kids ADD COLUMN weekly_goal integer NOT NULL DEFAULT 5;
+ALTER TABLE kids ADD COLUMN weekly_goal_paid_week date;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -30,6 +30,10 @@ create table kids (
   coins integer not null default 0,
   streak integer not null default 0,
   last_completed_date date,
+  xp integer not null default 0,
+  level integer not null default 1,
+  weekly_goal integer not null default 5,
+  weekly_goal_paid_week date,
   pin text not null, -- 4-digit PIN (stored plaintext, protected by RLS)
   created_at timestamptz default now()
 );


### PR DESCRIPTION
## Summary

- Replaces streak coin multipliers with flat coin awards + a new XP/level system
- Adds weekly completion goal: when a kid hits their weekly quest target, they earn 20% bonus coins for the week
- Real level titles (Apprentice → Squire → ... → Mythic) replace the fake coin-derived level on kid cards
- XP progress bar added to the display wall kid cards

## Changes

**Schema** (`supabase/migrations/20260505000000_add_xp_weekly_goals.sql`)
- `kids.xp` — accumulated XP, never decreases, awards = quest coin value
- `kids.level` — denormalized for fast reads, recomputed on every XP change
- `kids.weekly_goal` — target quest completions per week (default 5)
- `kids.weekly_goal_paid_week` — prevents double-paying the weekly bonus

**`src/lib/xp.ts`** (new)
- `getLevelFromXP` — levels 1–10 use fixed thresholds; 11+ use formula
- `getXPProgress` — current/needed XP + pct for progress bars
- `getLevelTitle` — Apprentice through Mythic, then Mythic N for 11+
- `getWeekMonday` — returns current week's Monday as YYYY-MM-DD

**Approval flow** (`use-parent-actions.ts`)
- Removed `getStreakBonus` multiplier — coins = flat quest value
- Awards XP = coins_awarded on every approval
- On approval that hits weekly_goal for the first time this week: awards +20% bonus coins + XP
- Level-up toast fires when level increases
- `undoApproval` now also reverses XP and recomputes level

**Display wall** (`kid-column.tsx`)
- Real level title + Lv N from `kid.level` (was `Math.floor(kid.coins/50)+1`)
- XP bar below coin counter, gradient from kid color → gold

## Test plan
- [ ] Approve a quest → kid gains coins and XP
- [ ] Approve enough quests to hit weekly_goal → bonus coins toast fires; next approval that week does not double-pay
- [ ] Undo approval → XP is reversed and level recalculates
- [ ] Kid card on display wall shows level title and XP bar progressing

🤖 Generated with [Claude Code](https://claude.com/claude-code)