### PR TITLE
feat: Weekly Dungeon + Raid Boss cooperative RPG challenges

### DIFF
--- a/src/app/display/page.tsx
+++ b/src/app/display/page.tsx
@@ -37,7 +37,7 @@ export default function WallDisplay() {
 
     const [familyRes, kidsRes, questsRes, rewardsRes] = await Promise.all([
       supabase.from('families').select('id, name, invite_token, daily_reset_hour, created_at, plan').eq('id', profile.family_id).single(),
-      supabase.from('kids').select('id, name, avatar, color, coins, streak, last_completed_date, xp, level, weekly_goal, weekly_goal_paid_week, family_id, created_at').eq('family_id', profile.family_id).order('created_at'),
+      supabase.from('kids').select('id, name, avatar, color, coins, streak, last_completed_date, xp, level, family_id, created_at').eq('family_id', profile.family_id).order('created_at'),
       supabase.from('quests').select('*').eq('family_id', profile.family_id).eq('active', true).order('created_at'),
       supabase.from('rewards').select('*').eq('available', true).order('cost'),
     ])

--- a/src/app/parent/dungeons-tab.tsx
+++ b/src/app/parent/dungeons-tab.tsx
@@ -1,0 +1,276 @@
+'use client'
+
+import { useState } from 'react'
+import { motion } from 'framer-motion'
+import type { DungeonRun, RaidBoss } from '@/lib/types'
+import { Section, FormInput, Empty, fadeSlide } from './_ui'
+import type { ParentActions } from './use-parent-actions'
+
+const DUNGEON_ICONS = ['🏰', '⚔️', '🗡️', '🛡️', '🔮', '🌋', '🕳️', '🐲']
+const BOSS_ICONS = ['🐉', '👾', '💀', '🦂', '👹', '🔥', '🌩️', '🦇']
+
+interface Props {
+  activeDungeon: DungeonRun | null
+  activeBoss: RaidBoss | null
+  pastDungeons: DungeonRun[]
+  defeatedBosses: RaidBoss[]
+  kidCount: number
+  actions: ParentActions
+}
+
+function HpBar({ current, max, color }: { current: number; max: number; color: string }) {
+  const pct = max > 0 ? Math.min(100, Math.round((current / max) * 100)) : 0
+  return (
+    <div className="w-full">
+      <div className="flex justify-between text-xs text-white/35 mb-1">
+        <span>{current.toLocaleString()} / {max.toLocaleString()}</span>
+        <span>{pct}%</span>
+      </div>
+      <div className="h-2.5 rounded-full overflow-hidden" style={{ background: 'rgba(255,255,255,0.07)' }}>
+        <motion.div
+          className="h-full rounded-full"
+          style={{ background: color }}
+          initial={{ width: 0 }}
+          animate={{ width: `${pct}%` }}
+          transition={{ duration: 0.9, ease: 'easeOut' }}
+        />
+      </div>
+    </div>
+  )
+}
+
+export function DungeonsTab({ activeDungeon, activeBoss, pastDungeons, defeatedBosses, kidCount, actions }: Props) {
+  // Dungeon form state
+  const [dTitle, setDTitle] = useState('')
+  const [dIcon, setDIcon] = useState('🏰')
+  const [dHp, setDHp] = useState(200)
+  const [dRewardCoins, setDRewardCoins] = useState(50)
+  const [dRewardXp, setDRewardXp] = useState(100)
+
+  // Raid boss form state
+  const [bTitle, setBTitle] = useState('')
+  const [bIcon, setBIcon] = useState('🐉')
+  const [bHpPerKid, setBHpPerKid] = useState(200)
+  const [bBounty, setBBounty] = useState(150)
+
+  const handleAddDungeon = async () => {
+    await actions.addDungeonRun({ title: dTitle, icon: dIcon, hp: dHp, rewardCoins: dRewardCoins, rewardXp: dRewardXp })
+    setDTitle('')
+  }
+
+  const handleAddBoss = async () => {
+    await actions.addRaidBoss({ title: bTitle, icon: bIcon, hpPerKid: bHpPerKid, bountyCoins: bBounty })
+    setBTitle('')
+  }
+
+  return (
+    <motion.div key="dungeons" {...fadeSlide} className="flex flex-col gap-6">
+
+      {/* ── Active Dungeon ─────────────────────────────── */}
+      <Section title="Weekly Dungeon">
+        {activeDungeon ? (
+          <div className="flex flex-col gap-3">
+            <div className="flex items-center gap-3">
+              <span className="text-3xl">{activeDungeon.icon}</span>
+              <div className="flex-1">
+                <p className="text-white/90 font-semibold">{activeDungeon.title}</p>
+                <p className="text-white/40 text-xs">Loot: +{activeDungeon.reward_coins} coins · +{activeDungeon.reward_xp} XP per kid</p>
+              </div>
+              <button
+                onClick={() => actions.deleteDungeonRun(activeDungeon.id)}
+                className="text-white/20 hover:text-red-400 transition-all text-xs"
+                title="Cancel dungeon"
+              >
+                ✕
+              </button>
+            </div>
+            <HpBar
+              current={activeDungeon.current_damage}
+              max={activeDungeon.hp}
+              color="linear-gradient(90deg, #38bdf8, #a78bfa)"
+            />
+            <p className="text-xs text-white/30 text-center">
+              Every approved quest deals damage · {activeDungeon.hp - activeDungeon.current_damage} coins of damage remaining
+            </p>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-3">
+            <p className="text-white/40 text-xs">
+              Create a weekly cooperative challenge. All kids contribute damage by completing quests. When cleared, everyone earns the loot.
+            </p>
+            <div className="flex gap-2 flex-wrap">
+              {DUNGEON_ICONS.map((ic) => (
+                <button
+                  key={ic}
+                  onClick={() => setDIcon(ic)}
+                  className="text-xl w-10 h-10 rounded-xl transition-all"
+                  style={{
+                    background: dIcon === ic ? 'rgba(56,189,248,0.2)' : 'rgba(255,255,255,0.05)',
+                    border: `1px solid ${dIcon === ic ? 'rgba(56,189,248,0.4)' : 'rgba(255,255,255,0.08)'}`,
+                  }}
+                >
+                  {ic}
+                </button>
+              ))}
+            </div>
+            <FormInput placeholder="Dungeon name (e.g. Cave of Chaos)" value={dTitle} onChange={setDTitle} />
+            <div className="grid grid-cols-3 gap-2">
+              <div>
+                <label className="text-xs text-white/40 mb-1 block">HP (damage needed)</label>
+                <input type="number" min={50} max={5000} value={dHp}
+                  onChange={(e) => setDHp(Number(e.target.value))}
+                  className="w-full px-3 py-2.5 rounded-xl text-sm text-white/90 outline-none"
+                  style={{ background: 'rgba(255,255,255,0.06)', border: '1px solid rgba(255,255,255,0.1)' }} />
+              </div>
+              <div>
+                <label className="text-xs text-white/40 mb-1 block">Reward coins (per kid)</label>
+                <input type="number" min={10} max={500} value={dRewardCoins}
+                  onChange={(e) => setDRewardCoins(Number(e.target.value))}
+                  className="w-full px-3 py-2.5 rounded-xl text-sm text-white/90 outline-none"
+                  style={{ background: 'rgba(255,255,255,0.06)', border: '1px solid rgba(255,255,255,0.1)' }} />
+              </div>
+              <div>
+                <label className="text-xs text-white/40 mb-1 block">Reward XP (per kid)</label>
+                <input type="number" min={10} max={1000} value={dRewardXp}
+                  onChange={(e) => setDRewardXp(Number(e.target.value))}
+                  className="w-full px-3 py-2.5 rounded-xl text-sm text-white/90 outline-none"
+                  style={{ background: 'rgba(255,255,255,0.06)', border: '1px solid rgba(255,255,255,0.1)' }} />
+              </div>
+            </div>
+            <motion.button
+              onClick={handleAddDungeon}
+              disabled={!dTitle.trim()}
+              className="w-full py-2.5 rounded-xl text-sm font-bold transition-all disabled:opacity-40"
+              style={{ background: 'rgba(56,189,248,0.15)', border: '1px solid rgba(56,189,248,0.35)', color: '#38bdf8' }}
+              whileHover={{ background: 'rgba(56,189,248,0.22)' }}
+              whileTap={{ scale: 0.98 }}
+            >
+              🏰 Open This Week&apos;s Dungeon
+            </motion.button>
+          </div>
+        )}
+      </Section>
+
+      {/* ── Active Raid Boss ───────────────────────────── */}
+      <Section title="Raid Boss">
+        {activeBoss ? (
+          <div className="flex flex-col gap-3">
+            <div className="flex items-center gap-3">
+              <motion.span
+                className="text-4xl"
+                animate={{ scale: [1, 1.06, 1] }}
+                transition={{ duration: 2.5, repeat: Infinity }}
+              >
+                {activeBoss.icon}
+              </motion.span>
+              <div className="flex-1">
+                <p className="text-white/90 font-semibold font-heading">{activeBoss.title}</p>
+                <p className="text-white/40 text-xs">Bounty: {activeBoss.bounty_coins} coins split among all kids</p>
+              </div>
+              <button
+                onClick={() => actions.deleteRaidBoss(activeBoss.id)}
+                className="text-white/20 hover:text-red-400 transition-all text-xs"
+                title="Dismiss boss"
+              >
+                ✕
+              </button>
+            </div>
+            <HpBar
+              current={activeBoss.current_hp}
+              max={activeBoss.max_hp}
+              color="linear-gradient(90deg, #fb923c, #ef4444)"
+            />
+            <p className="text-xs text-white/30 text-center">
+              {activeBoss.current_hp.toLocaleString()} HP remaining · {Math.floor(activeBoss.bounty_coins / Math.max(1, kidCount))} coins per kid on defeat
+            </p>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-3">
+            <p className="text-white/40 text-xs">
+              Summon a persistent boss. HP scales with the number of kids. Every approved quest deals damage. Defeat splits the coin bounty equally.
+            </p>
+            <div className="flex gap-2 flex-wrap">
+              {BOSS_ICONS.map((ic) => (
+                <button
+                  key={ic}
+                  onClick={() => setBIcon(ic)}
+                  className="text-xl w-10 h-10 rounded-xl transition-all"
+                  style={{
+                    background: bIcon === ic ? 'rgba(251,146,60,0.2)' : 'rgba(255,255,255,0.05)',
+                    border: `1px solid ${bIcon === ic ? 'rgba(251,146,60,0.4)' : 'rgba(255,255,255,0.08)'}`,
+                  }}
+                >
+                  {ic}
+                </button>
+              ))}
+            </div>
+            <FormInput placeholder="Boss name (e.g. The Great Laziness)" value={bTitle} onChange={setBTitle} />
+            <div className="grid grid-cols-2 gap-2">
+              <div>
+                <label className="text-xs text-white/40 mb-1 block">HP per kid · total: {bHpPerKid * Math.max(1, kidCount)}</label>
+                <input type="number" min={100} max={5000} value={bHpPerKid}
+                  onChange={(e) => setBHpPerKid(Number(e.target.value))}
+                  className="w-full px-3 py-2.5 rounded-xl text-sm text-white/90 outline-none"
+                  style={{ background: 'rgba(255,255,255,0.06)', border: '1px solid rgba(255,255,255,0.1)' }} />
+              </div>
+              <div>
+                <label className="text-xs text-white/40 mb-1 block">Total coin bounty</label>
+                <input type="number" min={50} max={2000} value={bBounty}
+                  onChange={(e) => setBBounty(Number(e.target.value))}
+                  className="w-full px-3 py-2.5 rounded-xl text-sm text-white/90 outline-none"
+                  style={{ background: 'rgba(255,255,255,0.06)', border: '1px solid rgba(255,255,255,0.1)' }} />
+              </div>
+            </div>
+            <p className="text-xs text-white/30 text-center">
+              {kidCount > 0 ? `${Math.floor(bBounty / kidCount)} coins per kid on defeat` : 'Add kids first'}
+            </p>
+            <motion.button
+              onClick={handleAddBoss}
+              disabled={!bTitle.trim() || kidCount === 0}
+              className="w-full py-2.5 rounded-xl text-sm font-bold transition-all disabled:opacity-40"
+              style={{ background: 'rgba(251,146,60,0.15)', border: '1px solid rgba(251,146,60,0.35)', color: '#fb923c' }}
+              whileHover={{ background: 'rgba(251,146,60,0.22)' }}
+              whileTap={{ scale: 0.98 }}
+            >
+              🐉 Summon Raid Boss
+            </motion.button>
+          </div>
+        )}
+      </Section>
+
+      {/* ── History ───────────────────────────────────── */}
+      {(pastDungeons.length > 0 || defeatedBosses.length > 0) && (
+        <Section title="Hall of Victories">
+          <div className="flex flex-col gap-2">
+            {defeatedBosses.map(boss => (
+              <div key={boss.id} className="flex items-center gap-3 p-2.5 rounded-xl"
+                style={{ background: 'rgba(251,146,60,0.06)', border: '1px solid rgba(251,146,60,0.15)' }}>
+                <span className="text-xl">{boss.icon}</span>
+                <div className="flex-1 min-w-0">
+                  <p className="text-white/80 text-sm font-semibold truncate">{boss.title}</p>
+                  <p className="text-white/35 text-xs">Raid boss · {boss.bounty_coins} coin bounty</p>
+                </div>
+                <span className="text-xs text-cq-ember font-bold">Defeated ⚔️</span>
+              </div>
+            ))}
+            {pastDungeons.map(d => (
+              <div key={d.id} className="flex items-center gap-3 p-2.5 rounded-xl"
+                style={{ background: 'rgba(56,189,248,0.06)', border: '1px solid rgba(56,189,248,0.15)' }}>
+                <span className="text-xl">{d.icon}</span>
+                <div className="flex-1 min-w-0">
+                  <p className="text-white/80 text-sm font-semibold truncate">{d.title}</p>
+                  <p className="text-white/35 text-xs">Dungeon · +{d.reward_coins} coins each</p>
+                </div>
+                <span className="text-xs text-cq-azure font-bold">Cleared 🏆</span>
+              </div>
+            ))}
+          </div>
+        </Section>
+      )}
+
+      {pastDungeons.length === 0 && defeatedBosses.length === 0 && (
+        <Empty icon="🏆" message="No victories yet — the realm awaits!" />
+      )}
+    </motion.div>
+  )
+}

--- a/src/app/parent/page.tsx
+++ b/src/app/parent/page.tsx
@@ -17,12 +17,13 @@ import { QuestsTab } from './quests-tab'
 import { RewardsTab } from './rewards-tab'
 import { CursesTab } from './curses-tab'
 import { FamilyTab } from './family-tab'
+import { DungeonsTab } from './dungeons-tab'
 
-type Tab = 'approvals' | 'quests' | 'family' | 'rewards' | 'curses'
+type Tab = 'approvals' | 'quests' | 'family' | 'rewards' | 'curses' | 'dungeons'
 
 export default function ParentDashboard() {
   const data = useParentData()
-  const actions = useParentActions(data)
+  const actions = useParentActions({ ...data, activeDungeon: data.activeDungeon, activeBoss: data.activeBoss })
   const lock = useParentPinLock(data.family)
 
   const [tab, setTab] = useState<Tab>('approvals')
@@ -69,6 +70,7 @@ export default function ParentDashboard() {
     { id: 'quests', label: '⚔️ Quests' },
     { id: 'rewards', label: '🎁 Rewards' },
     { id: 'curses', label: '☠️ Curses', badge: data.activeCurseInstances.length || undefined },
+    { id: 'dungeons', label: '🏰 Dungeons' },
     { id: 'family', label: '👨‍👩‍👧 Family' },
   ]
 
@@ -159,6 +161,16 @@ export default function ParentDashboard() {
                 activeCurseInstances={data.activeCurseInstances}
                 actions={actions}
                 plan={data.family?.plan ?? 'free'}
+              />
+            )}
+            {tab === 'dungeons' && (
+              <DungeonsTab
+                activeDungeon={data.activeDungeon}
+                activeBoss={data.activeBoss}
+                pastDungeons={data.pastDungeons}
+                defeatedBosses={data.defeatedBosses}
+                kidCount={data.kids.length}
+                actions={actions}
               />
             )}
             {tab === 'family' && (

--- a/src/app/parent/use-parent-actions.ts
+++ b/src/app/parent/use-parent-actions.ts
@@ -10,6 +10,7 @@ import { PLAN_LIMITS, PLAN_LABELS, PLAN_UPGRADE_HINT } from '@/lib/plans'
 import { questDateString } from '@/lib/utils'
 import { yesterday } from './_streak'
 import { getLevelFromXP, getWeekMonday } from '@/lib/xp'
+import type { DungeonRun, RaidBoss } from '@/lib/types'
 
 interface Deps {
   supabase: SupabaseClient
@@ -21,6 +22,8 @@ interface Deps {
   rewards: Reward[]
   curses: Curse[]
   activeCurseInstances: CurseInstance[]
+  activeDungeon: DungeonRun | null
+  activeBoss: RaidBoss | null
   refetch: () => Promise<void>
 }
 
@@ -52,6 +55,10 @@ export interface ParentActions {
   castCurse: (curseId: string, kidId: string) => Promise<void>
   castAdHocCurse: (data: { title: string; icon: string; penalty: number; kidId: string }) => Promise<void>
   resolveCurse: (instanceId: string, refund: boolean) => Promise<void>
+  addDungeonRun: (data: { title: string; icon: string; hp: number; rewardCoins: number; rewardXp: number }) => Promise<void>
+  deleteDungeonRun: (id: string) => Promise<void>
+  addRaidBoss: (data: { title: string; icon: string; hpPerKid: number; bountyCoins: number }) => Promise<void>
+  deleteRaidBoss: (id: string) => Promise<void>
   signOut: () => Promise<void>
 }
 
@@ -69,7 +76,7 @@ export interface AddQuestInput {
 }
 
 export function useParentActions(deps: Deps): ParentActions {
-  const { supabase, family, completions, redemptions, kids, quests, rewards, curses, activeCurseInstances, refetch } = deps
+  const { supabase, family, completions, redemptions, kids, quests, rewards, curses, activeCurseInstances, activeDungeon, activeBoss, refetch } = deps
   const router = useRouter()
 
   const approve = useCallback(async (completionId: string) => {
@@ -91,9 +98,10 @@ export function useParentActions(deps: Deps): ParentActions {
       return
     }
 
+    // Award coins + XP to the completing kid
     const { data: freshKid } = await supabase
       .from('kids')
-      .select('coins, xp, level, streak, last_completed_date, weekly_goal, weekly_goal_paid_week')
+      .select('coins, xp, level, streak, last_completed_date')
       .eq('id', completion.kid_id)
       .single()
 
@@ -102,46 +110,85 @@ export function useParentActions(deps: Deps): ParentActions {
     const today = questDateString(family?.daily_reset_hour ?? 0)
     const newStreak = freshKid?.last_completed_date === yesterday() ? (freshKid?.streak ?? 0) + 1 : 1
 
-    // Check weekly goal payout
-    const monday = getWeekMonday()
-    const { data: weeklyData } = await supabase
-      .from('completions')
-      .select('coins_awarded')
-      .eq('kid_id', completion.kid_id)
-      .eq('status', 'approved')
-      .gte('date', monday)
-
-    const weeklyCount = weeklyData?.length ?? 0
-    const weeklyCoinsTotal = weeklyData?.reduce((s, c) => s + (c.coins_awarded ?? 0), 0) ?? 0
-    const goalHit = weeklyCount >= (freshKid?.weekly_goal ?? 5)
-    const alreadyPaid = freshKid?.weekly_goal_paid_week === monday
-    const bonusCoins = goalHit && !alreadyPaid ? Math.ceil(weeklyCoinsTotal * 0.2) : 0
-
     await supabase.from('kids').update({
-      coins: (freshKid?.coins ?? 0) + coinsAwarded + bonusCoins,
-      xp: newXP + bonusCoins,
-      level: getLevelFromXP(newXP + bonusCoins),
+      coins: (freshKid?.coins ?? 0) + coinsAwarded,
+      xp: newXP,
+      level: newLevel,
       streak: newStreak,
       last_completed_date: today,
-      ...(goalHit && !alreadyPaid ? { weekly_goal_paid_week: monday } : {}),
     }).eq('id', completion.kid_id)
 
     if (completion.quest?.kind === 'oneoff') {
       await supabase.from('quests').update({ active: false }).eq('id', completion.quest.id)
     }
 
-    if (bonusCoins > 0) {
-      toast.success(`🎯 Weekly goal hit! +${coinsAwarded} coins + ${bonusCoins} bonus for ${completion.kid?.name ?? 'adventurer'}!`)
-    } else {
-      toast.success(`Quest approved! +${coinsAwarded} coins awarded ✨`)
-    }
+    toast.success(`Quest approved! +${coinsAwarded} coins awarded ✨`)
 
     if (newLevel > (freshKid?.level ?? 1)) {
       setTimeout(() => toast.success(`⬆️ ${completion.kid?.name ?? 'Level up'}! Reached Level ${newLevel}!`), 600)
     }
 
+    // Deal damage to active dungeon run
+    if (activeDungeon && family) {
+      const newDamage = activeDungeon.current_damage + coinsAwarded
+      if (newDamage >= activeDungeon.hp) {
+        await supabase.from('dungeon_runs').update({
+          current_damage: newDamage,
+          status: 'cleared',
+          cleared_at: new Date().toISOString(),
+        }).eq('id', activeDungeon.id)
+
+        const { data: allKids } = await supabase.from('kids').select('id, coins, xp').eq('family_id', family.id)
+        await Promise.all((allKids ?? []).map(async (k) => {
+          const kNewXP = k.xp + activeDungeon.reward_xp
+          return supabase.from('kids').update({
+            coins: k.coins + activeDungeon.reward_coins,
+            xp: kNewXP,
+            level: getLevelFromXP(kNewXP),
+          }).eq('id', k.id)
+        }))
+        setTimeout(() => toast.success(`🏰 Dungeon cleared! +${activeDungeon.reward_coins} coins for everyone!`), 700)
+      } else {
+        await supabase.from('dungeon_runs').update({ current_damage: newDamage }).eq('id', activeDungeon.id)
+      }
+    }
+
+    // Deal damage to active raid boss
+    if (activeBoss && family) {
+      const newHP = Math.max(0, activeBoss.current_hp - coinsAwarded)
+
+      await supabase.from('raid_boss_hits').insert({
+        boss_id: activeBoss.id,
+        completion_id: completionId,
+        kid_id: completion.kid_id,
+        damage_dealt: coinsAwarded,
+      })
+
+      if (newHP === 0) {
+        await supabase.from('raid_bosses').update({
+          current_hp: 0,
+          status: 'defeated',
+          defeated_at: new Date().toISOString(),
+        }).eq('id', activeBoss.id)
+
+        const { data: allKids } = await supabase.from('kids').select('id, coins, xp').eq('family_id', family.id)
+        const perKid = Math.floor(activeBoss.bounty_coins / Math.max(1, allKids?.length ?? 1))
+        await Promise.all((allKids ?? []).map(async (k) => {
+          const kNewXP = k.xp + perKid
+          return supabase.from('kids').update({
+            coins: k.coins + perKid,
+            xp: kNewXP,
+            level: getLevelFromXP(kNewXP),
+          }).eq('id', k.id)
+        }))
+        setTimeout(() => toast.success(`⚔️ Raid boss defeated! ${perKid} coins each!`), 900)
+      } else {
+        await supabase.from('raid_bosses').update({ current_hp: newHP }).eq('id', activeBoss.id)
+      }
+    }
+
     await refetch()
-  }, [completions, family?.daily_reset_hour, refetch, supabase])
+  }, [activeBoss, activeDungeon, completions, family, refetch, supabase])
 
   const reject = useCallback(async (completionId: string) => {
     await supabase.from('completions').update({ status: 'rejected' }).eq('id', completionId)
@@ -530,6 +577,58 @@ export function useParentActions(deps: Deps): ParentActions {
     await refetch()
   }, [activeCurseInstances, refetch, supabase])
 
+  const addDungeonRun = useCallback(async (data: { title: string; icon: string; hp: number; rewardCoins: number; rewardXp: number }) => {
+    if (!family) return
+    const monday = getWeekMonday()
+    const { error } = await supabase.from('dungeon_runs').insert({
+      family_id: family.id,
+      title: data.title.trim() || 'Weekly Dungeon',
+      icon: data.icon,
+      hp: data.hp,
+      reward_coins: data.rewardCoins,
+      reward_xp: data.rewardXp,
+      week_start: monday,
+      status: 'active',
+    })
+    if (error) {
+      if (error.code === '23505') toast.error('A dungeon already exists for this week')
+      else toast.error('Failed to create dungeon')
+    } else {
+      toast.success(`🏰 ${data.title || 'Weekly Dungeon'} awakens!`)
+      await refetch()
+    }
+  }, [family, refetch, supabase])
+
+  const deleteDungeonRun = useCallback(async (id: string) => {
+    await supabase.from('dungeon_runs').delete().eq('id', id)
+    await refetch()
+  }, [refetch, supabase])
+
+  const addRaidBoss = useCallback(async (data: { title: string; icon: string; hpPerKid: number; bountyCoins: number }) => {
+    if (!family || !data.title.trim()) return
+    const totalHP = data.hpPerKid * Math.max(1, kids.length)
+    const { error } = await supabase.from('raid_bosses').insert({
+      family_id: family.id,
+      title: data.title.trim(),
+      icon: data.icon,
+      max_hp: totalHP,
+      current_hp: totalHP,
+      bounty_coins: data.bountyCoins,
+      status: 'active',
+    })
+    if (!error) {
+      toast.success(`🐉 ${data.title} has appeared! ${totalHP} HP · ${data.bountyCoins} coin bounty`)
+      await refetch()
+    } else {
+      toast.error('Failed to summon raid boss')
+    }
+  }, [family, kids, refetch, supabase])
+
+  const deleteRaidBoss = useCallback(async (id: string) => {
+    await supabase.from('raid_bosses').delete().eq('id', id)
+    await refetch()
+  }, [refetch, supabase])
+
   const signOut = useCallback(async () => {
     await supabase.auth.signOut()
     router.push('/login')
@@ -546,6 +645,7 @@ export function useParentActions(deps: Deps): ParentActions {
     setParentPin, removeParentPin,
     regenerateApiKey, regenerateInviteToken,
     addCurse, deleteCurse, castCurse, castAdHocCurse, resolveCurse,
+    addDungeonRun, deleteDungeonRun, addRaidBoss, deleteRaidBoss,
     signOut,
   }
 }

--- a/src/app/parent/use-parent-data.ts
+++ b/src/app/parent/use-parent-data.ts
@@ -3,8 +3,9 @@
 import { useState, useEffect, useCallback } from 'react'
 import type { SupabaseClient } from '@supabase/supabase-js'
 import { createClient } from '@/lib/supabase/client'
-import type { Family, Kid, Quest, Completion, Reward, Redemption, Curse, CurseInstance } from '@/lib/types'
+import type { Family, Kid, Quest, Completion, Reward, Redemption, Curse, CurseInstance, DungeonRun, RaidBoss } from '@/lib/types'
 import { questDateString } from '@/lib/utils'
+import { getWeekMonday } from '@/lib/xp'
 
 export interface ParentData {
   family: Family | null
@@ -15,12 +16,16 @@ export interface ParentData {
   redemptions: Redemption[]
   curses: Curse[]
   activeCurseInstances: CurseInstance[]
+  activeDungeon: DungeonRun | null
+  activeBoss: RaidBoss | null
+  pastDungeons: DungeonRun[]
+  defeatedBosses: RaidBoss[]
   loading: boolean
   supabase: SupabaseClient
   refetch: () => Promise<void>
 }
 
-const KID_COLS = 'id, name, avatar, color, coins, streak, last_completed_date, xp, level, weekly_goal, weekly_goal_paid_week, family_id, created_at'
+const KID_COLS = 'id, name, avatar, color, coins, streak, last_completed_date, xp, level, family_id, created_at'
 
 export function useParentData(): ParentData {
   const [supabase] = useState(createClient)
@@ -32,6 +37,10 @@ export function useParentData(): ParentData {
   const [redemptions, setRedemptions] = useState<Redemption[]>([])
   const [curses, setCurses] = useState<Curse[]>([])
   const [activeCurseInstances, setActiveCurseInstances] = useState<CurseInstance[]>([])
+  const [activeDungeon, setActiveDungeon] = useState<DungeonRun | null>(null)
+  const [activeBoss, setActiveBoss] = useState<RaidBoss | null>(null)
+  const [pastDungeons, setPastDungeons] = useState<DungeonRun[]>([])
+  const [defeatedBosses, setDefeatedBosses] = useState<RaidBoss[]>([])
   const [loading, setLoading] = useState(true)
 
   const refetch = useCallback(async () => {
@@ -44,10 +53,12 @@ export function useParentData(): ParentData {
       .eq('id', profile.family_id)
       .single()
     const today = questDateString(resetData?.daily_reset_hour ?? 0)
+    const monday = getWeekMonday()
 
     const [
       familyRes, kidsRes, questsRes, completionsRes, rewardsRes,
       pendingRedemptionsRes, approvedRedemptionsRes, cursesRes, curseInstancesRes,
+      activeDungeonRes, activeBossRes, pastDungeonsRes, defeatedBossesRes,
     ] = await Promise.all([
       supabase.from('families').select('id, name, invite_token, api_key, daily_reset_hour, created_at, parent_pin, plan').eq('id', profile.family_id).single(),
       supabase.from('kids').select(KID_COLS).eq('family_id', profile.family_id).order('created_at'),
@@ -58,6 +69,10 @@ export function useParentData(): ParentData {
       supabase.from('redemptions').select(`*, reward:rewards(*), kid:kids(${KID_COLS})`).eq('status', 'approved').gte('redeemed_at', today).order('redeemed_at', { ascending: false }),
       supabase.from('curses').select('*').eq('family_id', profile.family_id).order('created_at'),
       supabase.from('curse_instances').select(`*, curse:curses(*), kid:kids(${KID_COLS})`).eq('status', 'active').order('cast_at', { ascending: false }),
+      supabase.from('dungeon_runs').select('*').eq('family_id', profile.family_id).eq('week_start', monday).eq('status', 'active').maybeSingle(),
+      supabase.from('raid_bosses').select('*').eq('family_id', profile.family_id).eq('status', 'active').maybeSingle(),
+      supabase.from('dungeon_runs').select('*').eq('family_id', profile.family_id).eq('status', 'cleared').order('cleared_at', { ascending: false }).limit(5),
+      supabase.from('raid_bosses').select('*').eq('family_id', profile.family_id).eq('status', 'defeated').order('defeated_at', { ascending: false }).limit(5),
     ])
 
     if (familyRes.data) {
@@ -80,6 +95,10 @@ export function useParentData(): ParentData {
     ])
     if (cursesRes.data) setCurses(cursesRes.data as Curse[])
     if (curseInstancesRes.data) setActiveCurseInstances(curseInstancesRes.data as CurseInstance[])
+    setActiveDungeon((activeDungeonRes.data as DungeonRun) ?? null)
+    setActiveBoss((activeBossRes.data as RaidBoss) ?? null)
+    setPastDungeons((pastDungeonsRes.data ?? []) as DungeonRun[])
+    setDefeatedBosses((defeatedBossesRes.data ?? []) as RaidBoss[])
     setLoading(false)
   }, [supabase])
 
@@ -90,9 +109,15 @@ export function useParentData(): ParentData {
       .on('postgres_changes', { event: '*', schema: 'public', table: 'completions' }, refetch)
       .on('postgres_changes', { event: '*', schema: 'public', table: 'redemptions' }, refetch)
       .on('postgres_changes', { event: '*', schema: 'public', table: 'curse_instances' }, refetch)
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'dungeon_runs' }, refetch)
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'raid_bosses' }, refetch)
       .subscribe()
     return () => { supabase.removeChannel(channel) }
   }, [refetch, supabase])
 
-  return { family, kids, quests, completions, rewards, redemptions, curses, activeCurseInstances, loading, supabase, refetch }
+  return {
+    family, kids, quests, completions, rewards, redemptions, curses, activeCurseInstances,
+    activeDungeon, activeBoss, pastDungeons, defeatedBosses,
+    loading, supabase, refetch,
+  }
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -33,8 +33,6 @@ export interface Kid {
   last_completed_date: string | null
   xp: number
   level: number
-  weekly_goal: number
-  weekly_goal_paid_week: string | null
   pin?: string
   created_at: string
 }
@@ -99,6 +97,43 @@ export interface Reward {
   cost: number
   available: boolean
   created_at: string
+}
+
+export interface DungeonRun {
+  id: string
+  family_id: string
+  title: string
+  icon: string
+  hp: number
+  current_damage: number
+  reward_coins: number
+  reward_xp: number
+  week_start: string
+  status: 'active' | 'cleared'
+  cleared_at: string | null
+  created_at: string
+}
+
+export interface RaidBoss {
+  id: string
+  family_id: string
+  title: string
+  icon: string
+  max_hp: number
+  current_hp: number
+  bounty_coins: number
+  status: 'active' | 'defeated'
+  defeated_at: string | null
+  created_at: string
+}
+
+export interface RaidBossHit {
+  id: string
+  boss_id: string
+  completion_id: string
+  kid_id: string
+  damage_dealt: number
+  hit_at: string
 }
 
 export interface Redemption {

--- a/supabase/migrations/20260505120000_add_dungeons_and_raid_bosses.sql
+++ b/supabase/migrations/20260505120000_add_dungeons_and_raid_bosses.sql
@@ -1,0 +1,72 @@
+-- Weekly Dungeon: family-wide cooperative challenge (parent creates manually per week)
+create table dungeon_runs (
+  id uuid primary key default gen_random_uuid(),
+  family_id uuid not null references families(id) on delete cascade,
+  title text not null default 'Weekly Dungeon',
+  icon text not null default '🏰',
+  hp integer not null,
+  current_damage integer not null default 0,
+  reward_coins integer not null default 50,
+  reward_xp integer not null default 100,
+  week_start date not null,
+  status text not null default 'active',
+  cleared_at timestamptz,
+  created_at timestamptz default now(),
+  constraint dungeon_status_check check (status in ('active', 'cleared')),
+  unique(family_id, week_start)
+);
+
+-- Raid Boss: persistent family-wide boss (lives until defeated)
+create table raid_bosses (
+  id uuid primary key default gen_random_uuid(),
+  family_id uuid not null references families(id) on delete cascade,
+  title text not null,
+  icon text not null default '🐉',
+  max_hp integer not null,
+  current_hp integer not null,
+  bounty_coins integer not null,
+  status text not null default 'active',
+  defeated_at timestamptz,
+  created_at timestamptz default now(),
+  constraint raid_boss_status_check check (status in ('active', 'defeated'))
+);
+
+-- Each quest approval that hits an active boss records a hit
+create table raid_boss_hits (
+  id uuid primary key default gen_random_uuid(),
+  boss_id uuid not null references raid_bosses(id) on delete cascade,
+  completion_id uuid not null references completions(id) on delete cascade,
+  kid_id uuid not null references kids(id) on delete cascade,
+  damage_dealt integer not null,
+  hit_at timestamptz default now()
+);
+
+-- RLS
+alter table dungeon_runs enable row level security;
+alter table raid_bosses enable row level security;
+alter table raid_boss_hits enable row level security;
+
+create policy "Family dungeon_runs" on dungeon_runs
+  for all using (family_id = get_user_family_id()) with check (family_id = get_user_family_id());
+
+create policy "Family raid_bosses" on raid_bosses
+  for all using (family_id = get_user_family_id()) with check (family_id = get_user_family_id());
+
+create policy "Family raid_boss_hits" on raid_boss_hits
+  for all
+  using (kid_id in (select id from kids where family_id = get_user_family_id()))
+  with check (kid_id in (select id from kids where family_id = get_user_family_id()));
+
+-- Realtime for live HP bars on display wall
+alter publication supabase_realtime add table dungeon_runs;
+alter publication supabase_realtime add table raid_bosses;
+
+-- Indexes
+create index dungeon_runs_family_id_idx on dungeon_runs(family_id);
+create index raid_bosses_family_id_idx on raid_bosses(family_id);
+create index raid_boss_hits_boss_id_idx on raid_boss_hits(boss_id);
+create index raid_boss_hits_kid_id_idx on raid_boss_hits(kid_id);
+
+-- Drop per-kid weekly_goal payout columns (replaced by dungeon system)
+alter table kids drop column if exists weekly_goal;
+alter table kids drop column if exists weekly_goal_paid_week;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -32,8 +32,6 @@ create table kids (
   last_completed_date date,
   xp integer not null default 0,
   level integer not null default 1,
-  weekly_goal integer not null default 5,
-  weekly_goal_paid_week date,
   pin text not null, -- 4-digit PIN (stored plaintext, protected by RLS)
   created_at timestamptz default now()
 );
@@ -88,6 +86,46 @@ create table redemptions (
   constraint redemptions_status_check check (status in ('pending', 'approved'))
 );
 
+create table dungeon_runs (
+  id uuid primary key default gen_random_uuid(),
+  family_id uuid not null references families(id) on delete cascade,
+  title text not null default 'Weekly Dungeon',
+  icon text not null default '🏰',
+  hp integer not null,
+  current_damage integer not null default 0,
+  reward_coins integer not null default 50,
+  reward_xp integer not null default 100,
+  week_start date not null,
+  status text not null default 'active',
+  cleared_at timestamptz,
+  created_at timestamptz default now(),
+  constraint dungeon_status_check check (status in ('active', 'cleared')),
+  unique(family_id, week_start)
+);
+
+create table raid_bosses (
+  id uuid primary key default gen_random_uuid(),
+  family_id uuid not null references families(id) on delete cascade,
+  title text not null,
+  icon text not null default '🐉',
+  max_hp integer not null,
+  current_hp integer not null,
+  bounty_coins integer not null,
+  status text not null default 'active',
+  defeated_at timestamptz,
+  created_at timestamptz default now(),
+  constraint raid_boss_status_check check (status in ('active', 'defeated'))
+);
+
+create table raid_boss_hits (
+  id uuid primary key default gen_random_uuid(),
+  boss_id uuid not null references raid_bosses(id) on delete cascade,
+  completion_id uuid not null references completions(id) on delete cascade,
+  kid_id uuid not null references kids(id) on delete cascade,
+  damage_dealt integer not null,
+  hit_at timestamptz default now()
+);
+
 -- ─── Row Level Security ───────────────────────────────────────────────────────
 
 alter table families enable row level security;
@@ -97,6 +135,9 @@ alter table quests enable row level security;
 alter table completions enable row level security;
 alter table rewards enable row level security;
 alter table redemptions enable row level security;
+alter table dungeon_runs enable row level security;
+alter table raid_bosses enable row level security;
+alter table raid_boss_hits enable row level security;
 
 -- Helper: get the family_id for the current authenticated user
 create or replace function get_user_family_id()


### PR DESCRIPTION
## Summary

Two cooperative RPG systems that are **fully optional** — families that want to keep it simple ignore this tab entirely. Both live behind a new **Dungeons** tab in the parent dashboard.

## Weekly Dungeon (#70)
Family-wide weekly challenge. Parent creates one manually each week (or skips). Every approved quest contributes damage equal to `coins_awarded`. When `current_damage >= hp`, the dungeon clears and every kid gets flat `reward_coins` + `reward_xp` instantly.

- Parent sets: name, icon, HP (damage threshold), coins per kid, XP per kid
- HP bar updates live via Supabase Realtime
- Cleared dungeons appear in Hall of Victories

## Raid Boss (#71)
Persistent boss that lives until the whole family defeats it. HP scales automatically: `hp_per_kid × kidCount` at creation. Every quest approval deals damage and records a hit. When `current_hp = 0`, the coin bounty splits equally among all kids.

- Parent sets: name, icon, HP per kid (total shown live), total bounty coins
- One active boss at a time
- Defeated bosses in Hall of Victories

## Schema
```
dungeon_runs: family_id, hp, current_damage, reward_coins, reward_xp, week_start, status
raid_bosses: family_id, max_hp, current_hp, bounty_coins, status
raid_boss_hits: boss_id, completion_id, kid_id, damage_dealt
```
Also drops `weekly_goal` + `weekly_goal_paid_week` columns (replaced by this system).

## Approval flow changes
`approve()` in `use-parent-actions.ts` now:
1. Awards flat coins + XP to the kid (no streak multiplier)
2. Hits active dungeon → clears and pays all kids if threshold reached
3. Hits active raid boss → defeats and splits bounty if HP hits 0

## Test plan
- [ ] Create a dungeon with low HP → approve quests → dungeon clears, all kids get coins toast
- [ ] Create a raid boss → approve quests → HP bar drains → boss defeated, bounty split toast
- [ ] If no dungeon/boss active, nothing shows in kid views (no regressions)
- [ ] Hall of Victories shows cleared dungeons and defeated bosses

🤖 Generated with [Claude Code](https://claude.com/claude-code)