### PR TITLE
feat: per-kid dungeon progress + realm display wall panels

### DIFF
--- a/src/app/display/page.tsx
+++ b/src/app/display/page.tsx
@@ -8,9 +8,10 @@ import Link from 'next/link'
 import { createClient } from '@/lib/supabase/client'
 import { StarField } from '@/components/star-field'
 import { KidColumn } from '@/components/kid-column'
-import type { Kid, Quest, Completion, Family, Reward } from '@/lib/types'
+import type { Kid, Quest, Completion, Family, Reward, DungeonRun, DungeonClear, RaidBoss } from '@/lib/types'
 import { KID_COLORS, TIER_CONFIG } from '@/lib/constants'
 import { questDateString, questWeekKey } from '@/lib/utils'
+import { getWeekMonday } from '@/lib/xp'
 import { toast } from 'sonner'
 
 export default function WallDisplay() {
@@ -25,6 +26,10 @@ export default function WallDisplay() {
   const [rewards, setRewards] = useState<Reward[]>([])
   const [showRewards, setShowRewards] = useState(false)
   const [isMobile, setIsMobile] = useState(false)
+  const [activeDungeon, setActiveDungeon] = useState<DungeonRun | null>(null)
+  const [dungeonClears, setDungeonClears] = useState<DungeonClear[]>([])
+  const [weeklyCompletions, setWeeklyCompletions] = useState<Completion[]>([])
+  const [activeBoss, setActiveBoss] = useState<RaidBoss | null>(null)
   const [supabase] = useState(createClient)
 
   const fetchData = useCallback(async () => {
@@ -46,9 +51,14 @@ export default function WallDisplay() {
     const today = questDateString(resetHour)
     const weekStart = questWeekKey(resetHour)
 
-    const [completionsRes, cursesRes] = await Promise.all([
+    const monday = getWeekMonday()
+
+    const [completionsRes, cursesRes, dungeonRes, bossRes, weeklyCompletionsRes] = await Promise.all([
       supabase.from('completions').select('*').gte('date', weekStart).lte('date', today),
       supabase.from('curse_instances').select('kid_id').eq('status', 'active'),
+      supabase.from('dungeon_runs').select('*').eq('family_id', profile.family_id).eq('week_start', monday).maybeSingle(),
+      supabase.from('raid_bosses').select('*').eq('family_id', profile.family_id).eq('status', 'active').maybeSingle(),
+      supabase.from('completions').select('kid_id, coins_awarded').eq('status', 'approved').gte('date', monday),
     ])
 
     if (familyRes.data) setFamily({ ...familyRes.data, has_parent_pin: false, plan: (familyRes.data.plan as import('@/lib/types').Plan) ?? 'free' })
@@ -65,6 +75,17 @@ export default function WallDisplay() {
       counts[ci.kid_id] = (counts[ci.kid_id] ?? 0) + 1
     }
     setActiveCurseCounts(counts)
+
+    const dungeon = (dungeonRes.data as DungeonRun) ?? null
+    setActiveDungeon(dungeon)
+    if (dungeon) {
+      const { data: clears } = await supabase.from('dungeon_clears').select('*').eq('dungeon_run_id', dungeon.id)
+      setDungeonClears((clears ?? []) as DungeonClear[])
+    } else {
+      setDungeonClears([])
+    }
+    setActiveBoss((bossRes.data as RaidBoss) ?? null)
+    setWeeklyCompletions((weeklyCompletionsRes.data ?? []) as Completion[])
 
     setLoading(false)
   }, [supabase])
@@ -84,6 +105,9 @@ export default function WallDisplay() {
       .on('postgres_changes', { event: '*', schema: 'public', table: 'completions' }, fetchData)
       .on('postgres_changes', { event: 'UPDATE', schema: 'public', table: 'kids' }, fetchData)
       .on('postgres_changes', { event: '*', schema: 'public', table: 'curse_instances' }, fetchData)
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'dungeon_runs' }, fetchData)
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'dungeon_clears' }, fetchData)
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'raid_bosses' }, fetchData)
       .subscribe()
 
     return () => { supabase.removeChannel(channel) }
@@ -278,6 +302,92 @@ export default function WallDisplay() {
           </Link>
         </div>
       </motion.header>
+
+      {/* Dungeon + Raid Boss progress bar */}
+      {(activeDungeon || activeBoss) && (
+        <div className="relative z-10 px-4 sm:px-8 pb-2 flex flex-col gap-2">
+          {/* Raid Boss — shared HP bar across full width */}
+          {activeBoss && (
+            <motion.div
+              className="rounded-2xl px-4 py-3 flex items-center gap-4"
+              style={{ background: 'rgba(251,146,60,0.08)', border: '1px solid rgba(251,146,60,0.2)' }}
+              initial={{ opacity: 0, y: -8 }}
+              animate={{ opacity: 1, y: 0 }}
+            >
+              <motion.span
+                className="text-2xl flex-shrink-0"
+                animate={{ scale: [1, 1.08, 1] }}
+                transition={{ duration: 2.5, repeat: Infinity }}
+              >
+                {activeBoss.icon}
+              </motion.span>
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center justify-between mb-1.5">
+                  <p className="font-heading text-sm font-bold text-white/80 truncate">{activeBoss.title}</p>
+                  <p className="text-xs text-white/35 flex-shrink-0 ml-2">{activeBoss.current_hp.toLocaleString()} / {activeBoss.max_hp.toLocaleString()} HP</p>
+                </div>
+                <div className="h-2 rounded-full overflow-hidden" style={{ background: 'rgba(255,255,255,0.07)' }}>
+                  <motion.div
+                    className="h-full rounded-full"
+                    style={{ background: 'linear-gradient(90deg, #fb923c, #ef4444)' }}
+                    initial={{ width: '100%' }}
+                    animate={{ width: `${Math.round((activeBoss.current_hp / activeBoss.max_hp) * 100)}%` }}
+                    transition={{ duration: 0.9, ease: 'easeOut' }}
+                  />
+                </div>
+              </div>
+              <p className="text-xs text-cq-ember font-bold flex-shrink-0">{activeBoss.bounty_coins}⚙ bounty</p>
+            </motion.div>
+          )}
+
+          {/* Dungeon — per-kid progress bars in a row */}
+          {activeDungeon && (
+            <motion.div
+              className="rounded-2xl px-4 py-3"
+              style={{ background: 'rgba(56,189,248,0.06)', border: '1px solid rgba(56,189,248,0.16)' }}
+              initial={{ opacity: 0, y: -8 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.05 }}
+            >
+              <div className="flex items-center gap-2 mb-2.5">
+                <span className="text-lg">{activeDungeon.icon}</span>
+                <p className="font-heading text-xs font-bold text-white/60 tracking-wide">{activeDungeon.title}</p>
+                <p className="text-xs text-white/30 ml-auto">+{activeDungeon.reward_coins}🪙 +{activeDungeon.reward_xp}✨ per adventurer</p>
+              </div>
+              <div className={`grid gap-3`} style={{ gridTemplateColumns: `repeat(${Math.max(1, kids.length)}, 1fr)` }}>
+                {kids.map(kid => {
+                  const damage = weeklyCompletions
+                    .filter(c => c.kid_id === kid.id)
+                    .reduce((s, c) => s + (c.coins_awarded ?? 0), 0)
+                  const cleared = dungeonClears.some(c => c.kid_id === kid.id)
+                  const pct = cleared ? 100 : Math.min(100, Math.round((damage / activeDungeon.hp) * 100))
+                  return (
+                    <div key={kid.id}>
+                      <div className="flex items-center gap-1.5 mb-1">
+                        <span className="text-sm">{kid.avatar}</span>
+                        <span className="text-xs text-white/60 font-semibold flex-1 truncate">{kid.name}</span>
+                        {cleared
+                          ? <span className="text-xs text-cq-forest font-bold">✓</span>
+                          : <span className="text-xs text-white/30">{pct}%</span>
+                        }
+                      </div>
+                      <div className="h-1.5 rounded-full overflow-hidden" style={{ background: 'rgba(255,255,255,0.07)' }}>
+                        <motion.div
+                          className="h-full rounded-full"
+                          style={{ background: cleared ? '#4ade80' : 'linear-gradient(90deg, #38bdf8, #a78bfa)' }}
+                          initial={{ width: 0 }}
+                          animate={{ width: `${pct}%` }}
+                          transition={{ duration: 0.8, ease: 'easeOut' }}
+                        />
+                      </div>
+                    </div>
+                  )
+                })}
+              </div>
+            </motion.div>
+          )}
+        </div>
+      )}
 
       {/* Kid columns */}
       <main

--- a/src/app/parent/dungeons-tab.tsx
+++ b/src/app/parent/dungeons-tab.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 import { motion } from 'framer-motion'
-import type { DungeonRun, RaidBoss } from '@/lib/types'
+import type { DungeonRun, DungeonClear, RaidBoss, Kid, Completion } from '@/lib/types'
 import { Section, FormInput, Empty, fadeSlide } from './_ui'
 import type { ParentActions } from './use-parent-actions'
 
@@ -11,10 +11,12 @@ const BOSS_ICONS = ['🐉', '👾', '💀', '🦂', '👹', '🔥', '🌩️', '
 
 interface Props {
   activeDungeon: DungeonRun | null
+  dungeonClears: DungeonClear[]
+  weeklyCompletions: Completion[]
+  kids: Kid[]
   activeBoss: RaidBoss | null
   pastDungeons: DungeonRun[]
   defeatedBosses: RaidBoss[]
-  kidCount: number
   actions: ParentActions
 }
 
@@ -39,7 +41,15 @@ function HpBar({ current, max, color }: { current: number; max: number; color: s
   )
 }
 
-export function DungeonsTab({ activeDungeon, activeBoss, pastDungeons, defeatedBosses, kidCount, actions }: Props) {
+export function DungeonsTab({ activeDungeon, dungeonClears, weeklyCompletions, kids, activeBoss, pastDungeons, defeatedBosses, actions }: Props) {
+  const kidCount = kids.length
+
+  const getKidDamage = (kidId: string) =>
+    weeklyCompletions
+      .filter(c => c.kid_id === kidId)
+      .reduce((s, c) => s + (c.coins_awarded ?? 0), 0)
+
+  const kidCleared = (kidId: string) => dungeonClears.some(c => c.kid_id === kidId)
   // Dungeon form state
   const [dTitle, setDTitle] = useState('')
   const [dIcon, setDIcon] = useState('🏰')
@@ -74,7 +84,7 @@ export function DungeonsTab({ activeDungeon, activeBoss, pastDungeons, defeatedB
               <span className="text-3xl">{activeDungeon.icon}</span>
               <div className="flex-1">
                 <p className="text-white/90 font-semibold">{activeDungeon.title}</p>
-                <p className="text-white/40 text-xs">Loot: +{activeDungeon.reward_coins} coins · +{activeDungeon.reward_xp} XP per kid</p>
+                <p className="text-white/40 text-xs">Goal: {activeDungeon.hp} coins each · Loot: +{activeDungeon.reward_coins} coins · +{activeDungeon.reward_xp} XP</p>
               </div>
               <button
                 onClick={() => actions.deleteDungeonRun(activeDungeon.id)}
@@ -84,14 +94,30 @@ export function DungeonsTab({ activeDungeon, activeBoss, pastDungeons, defeatedB
                 ✕
               </button>
             </div>
-            <HpBar
-              current={activeDungeon.current_damage}
-              max={activeDungeon.hp}
-              color="linear-gradient(90deg, #38bdf8, #a78bfa)"
-            />
-            <p className="text-xs text-white/30 text-center">
-              Every approved quest deals damage · {activeDungeon.hp - activeDungeon.current_damage} coins of damage remaining
-            </p>
+            {kids.length === 0 && (
+              <p className="text-white/30 text-xs text-center">Add kids to track progress</p>
+            )}
+            {kids.map(kid => {
+              const damage = getKidDamage(kid.id)
+              const cleared = kidCleared(kid.id)
+              return (
+                <div key={kid.id} className="flex flex-col gap-1.5">
+                  <div className="flex items-center gap-2">
+                    <span className="text-base">{kid.avatar}</span>
+                    <span className="text-white/70 text-xs font-semibold flex-1">{kid.name}</span>
+                    {cleared
+                      ? <span className="text-xs font-bold text-cq-forest">Cleared ✓</span>
+                      : <span className="text-xs text-white/30">{damage} / {activeDungeon.hp}</span>
+                    }
+                  </div>
+                  <HpBar
+                    current={cleared ? activeDungeon.hp : damage}
+                    max={activeDungeon.hp}
+                    color={cleared ? '#4ade80' : 'linear-gradient(90deg, #38bdf8, #a78bfa)'}
+                  />
+                </div>
+              )
+            })}
           </div>
         ) : (
           <div className="flex flex-col gap-3">

--- a/src/app/parent/page.tsx
+++ b/src/app/parent/page.tsx
@@ -23,7 +23,7 @@ type Tab = 'approvals' | 'quests' | 'family' | 'rewards' | 'curses' | 'dungeons'
 
 export default function ParentDashboard() {
   const data = useParentData()
-  const actions = useParentActions({ ...data, activeDungeon: data.activeDungeon, activeBoss: data.activeBoss })
+  const actions = useParentActions(data)
   const lock = useParentPinLock(data.family)
 
   const [tab, setTab] = useState<Tab>('approvals')
@@ -166,10 +166,12 @@ export default function ParentDashboard() {
             {tab === 'dungeons' && (
               <DungeonsTab
                 activeDungeon={data.activeDungeon}
+                dungeonClears={data.dungeonClears}
+                weeklyCompletions={data.weeklyCompletions}
+                kids={data.kids}
                 activeBoss={data.activeBoss}
                 pastDungeons={data.pastDungeons}
                 defeatedBosses={data.defeatedBosses}
-                kidCount={data.kids.length}
                 actions={actions}
               />
             )}

--- a/src/app/parent/use-parent-actions.ts
+++ b/src/app/parent/use-parent-actions.ts
@@ -10,7 +10,7 @@ import { PLAN_LIMITS, PLAN_LABELS, PLAN_UPGRADE_HINT } from '@/lib/plans'
 import { questDateString } from '@/lib/utils'
 import { yesterday } from './_streak'
 import { getLevelFromXP, getWeekMonday } from '@/lib/xp'
-import type { DungeonRun, RaidBoss } from '@/lib/types'
+import type { DungeonRun, DungeonClear, RaidBoss } from '@/lib/types'
 
 interface Deps {
   supabase: SupabaseClient
@@ -23,6 +23,7 @@ interface Deps {
   curses: Curse[]
   activeCurseInstances: CurseInstance[]
   activeDungeon: DungeonRun | null
+  dungeonClears: DungeonClear[]
   activeBoss: RaidBoss | null
   refetch: () => Promise<void>
 }
@@ -76,7 +77,7 @@ export interface AddQuestInput {
 }
 
 export function useParentActions(deps: Deps): ParentActions {
-  const { supabase, family, completions, redemptions, kids, quests, rewards, curses, activeCurseInstances, activeDungeon, activeBoss, refetch } = deps
+  const { supabase, family, completions, redemptions, kids, quests, rewards, curses, activeCurseInstances, activeDungeon, dungeonClears, activeBoss, refetch } = deps
   const router = useRouter()
 
   const approve = useCallback(async (completionId: string) => {
@@ -128,28 +129,33 @@ export function useParentActions(deps: Deps): ParentActions {
       setTimeout(() => toast.success(`⬆️ ${completion.kid?.name ?? 'Level up'}! Reached Level ${newLevel}!`), 600)
     }
 
-    // Deal damage to active dungeon run
-    if (activeDungeon && family) {
-      const newDamage = activeDungeon.current_damage + coinsAwarded
-      if (newDamage >= activeDungeon.hp) {
-        await supabase.from('dungeon_runs').update({
-          current_damage: newDamage,
-          status: 'cleared',
-          cleared_at: new Date().toISOString(),
-        }).eq('id', activeDungeon.id)
+    // Per-kid dungeon progress check
+    if (activeDungeon) {
+      const alreadyCleared = dungeonClears.some(c => c.kid_id === completion.kid_id)
+      if (!alreadyCleared) {
+        const { data: weeklyData } = await supabase
+          .from('completions')
+          .select('coins_awarded')
+          .eq('kid_id', completion.kid_id)
+          .eq('status', 'approved')
+          .gte('date', activeDungeon.week_start)
 
-        const { data: allKids } = await supabase.from('kids').select('id, coins, xp').eq('family_id', family.id)
-        await Promise.all((allKids ?? []).map(async (k) => {
-          const kNewXP = k.xp + activeDungeon.reward_xp
-          return supabase.from('kids').update({
-            coins: k.coins + activeDungeon.reward_coins,
-            xp: kNewXP,
-            level: getLevelFromXP(kNewXP),
-          }).eq('id', k.id)
-        }))
-        setTimeout(() => toast.success(`🏰 Dungeon cleared! +${activeDungeon.reward_coins} coins for everyone!`), 700)
-      } else {
-        await supabase.from('dungeon_runs').update({ current_damage: newDamage }).eq('id', activeDungeon.id)
+        const kidDamage = weeklyData?.reduce((s, c) => s + (c.coins_awarded ?? 0), 0) ?? 0
+
+        if (kidDamage >= activeDungeon.hp) {
+          await supabase.from('dungeon_clears').insert({
+            dungeon_run_id: activeDungeon.id,
+            kid_id: completion.kid_id,
+          })
+          const { data: freshKid2 } = await supabase.from('kids').select('coins, xp').eq('id', completion.kid_id).single()
+          const k2XP = (freshKid2?.xp ?? 0) + activeDungeon.reward_xp
+          await supabase.from('kids').update({
+            coins: (freshKid2?.coins ?? 0) + activeDungeon.reward_coins,
+            xp: k2XP,
+            level: getLevelFromXP(k2XP),
+          }).eq('id', completion.kid_id)
+          setTimeout(() => toast.success(`🏰 ${completion.kid?.name ?? 'Dungeon'} cleared the dungeon! +${activeDungeon.reward_coins} coins!`), 700)
+        }
       }
     }
 
@@ -188,7 +194,7 @@ export function useParentActions(deps: Deps): ParentActions {
     }
 
     await refetch()
-  }, [activeBoss, activeDungeon, completions, family, refetch, supabase])
+  }, [activeBoss, activeDungeon, dungeonClears, completions, family, refetch, supabase])
 
   const reject = useCallback(async (completionId: string) => {
     await supabase.from('completions').update({ status: 'rejected' }).eq('id', completionId)
@@ -588,7 +594,6 @@ export function useParentActions(deps: Deps): ParentActions {
       reward_coins: data.rewardCoins,
       reward_xp: data.rewardXp,
       week_start: monday,
-      status: 'active',
     })
     if (error) {
       if (error.code === '23505') toast.error('A dungeon already exists for this week')

--- a/src/app/parent/use-parent-data.ts
+++ b/src/app/parent/use-parent-data.ts
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import type { SupabaseClient } from '@supabase/supabase-js'
 import { createClient } from '@/lib/supabase/client'
-import type { Family, Kid, Quest, Completion, Reward, Redemption, Curse, CurseInstance, DungeonRun, RaidBoss } from '@/lib/types'
+import type { Family, Kid, Quest, Completion, Reward, Redemption, Curse, CurseInstance, DungeonRun, DungeonClear, RaidBoss } from '@/lib/types'
 import { questDateString } from '@/lib/utils'
 import { getWeekMonday } from '@/lib/xp'
 
@@ -17,6 +17,8 @@ export interface ParentData {
   curses: Curse[]
   activeCurseInstances: CurseInstance[]
   activeDungeon: DungeonRun | null
+  dungeonClears: DungeonClear[]
+  weeklyCompletions: Completion[]
   activeBoss: RaidBoss | null
   pastDungeons: DungeonRun[]
   defeatedBosses: RaidBoss[]
@@ -38,6 +40,8 @@ export function useParentData(): ParentData {
   const [curses, setCurses] = useState<Curse[]>([])
   const [activeCurseInstances, setActiveCurseInstances] = useState<CurseInstance[]>([])
   const [activeDungeon, setActiveDungeon] = useState<DungeonRun | null>(null)
+  const [dungeonClears, setDungeonClears] = useState<DungeonClear[]>([])
+  const [weeklyCompletions, setWeeklyCompletions] = useState<Completion[]>([])
   const [activeBoss, setActiveBoss] = useState<RaidBoss | null>(null)
   const [pastDungeons, setPastDungeons] = useState<DungeonRun[]>([])
   const [defeatedBosses, setDefeatedBosses] = useState<RaidBoss[]>([])
@@ -58,7 +62,7 @@ export function useParentData(): ParentData {
     const [
       familyRes, kidsRes, questsRes, completionsRes, rewardsRes,
       pendingRedemptionsRes, approvedRedemptionsRes, cursesRes, curseInstancesRes,
-      activeDungeonRes, activeBossRes, pastDungeonsRes, defeatedBossesRes,
+      activeDungeonRes, activeBossRes, pastDungeonsRes, defeatedBossesRes, weeklyCompletionsRes,
     ] = await Promise.all([
       supabase.from('families').select('id, name, invite_token, api_key, daily_reset_hour, created_at, parent_pin, plan').eq('id', profile.family_id).single(),
       supabase.from('kids').select(KID_COLS).eq('family_id', profile.family_id).order('created_at'),
@@ -69,10 +73,11 @@ export function useParentData(): ParentData {
       supabase.from('redemptions').select(`*, reward:rewards(*), kid:kids(${KID_COLS})`).eq('status', 'approved').gte('redeemed_at', today).order('redeemed_at', { ascending: false }),
       supabase.from('curses').select('*').eq('family_id', profile.family_id).order('created_at'),
       supabase.from('curse_instances').select(`*, curse:curses(*), kid:kids(${KID_COLS})`).eq('status', 'active').order('cast_at', { ascending: false }),
-      supabase.from('dungeon_runs').select('*').eq('family_id', profile.family_id).eq('week_start', monday).eq('status', 'active').maybeSingle(),
+      supabase.from('dungeon_runs').select('*').eq('family_id', profile.family_id).eq('week_start', monday).maybeSingle(),
       supabase.from('raid_bosses').select('*').eq('family_id', profile.family_id).eq('status', 'active').maybeSingle(),
-      supabase.from('dungeon_runs').select('*').eq('family_id', profile.family_id).eq('status', 'cleared').order('cleared_at', { ascending: false }).limit(5),
+      supabase.from('dungeon_runs').select('*').eq('family_id', profile.family_id).lt('week_start', monday).order('week_start', { ascending: false }).limit(5),
       supabase.from('raid_bosses').select('*').eq('family_id', profile.family_id).eq('status', 'defeated').order('defeated_at', { ascending: false }).limit(5),
+      supabase.from('completions').select('kid_id, coins_awarded, status').eq('status', 'approved').gte('date', monday),
     ])
 
     if (familyRes.data) {
@@ -95,10 +100,21 @@ export function useParentData(): ParentData {
     ])
     if (cursesRes.data) setCurses(cursesRes.data as Curse[])
     if (curseInstancesRes.data) setActiveCurseInstances(curseInstancesRes.data as CurseInstance[])
-    setActiveDungeon((activeDungeonRes.data as DungeonRun) ?? null)
+
+    const dungeon = (activeDungeonRes.data as DungeonRun) ?? null
+    setActiveDungeon(dungeon)
+    if (dungeon) {
+      const { data: clears } = await supabase
+        .from('dungeon_clears').select('*').eq('dungeon_run_id', dungeon.id)
+      setDungeonClears((clears ?? []) as DungeonClear[])
+    } else {
+      setDungeonClears([])
+    }
+
     setActiveBoss((activeBossRes.data as RaidBoss) ?? null)
     setPastDungeons((pastDungeonsRes.data ?? []) as DungeonRun[])
     setDefeatedBosses((defeatedBossesRes.data ?? []) as RaidBoss[])
+    setWeeklyCompletions((weeklyCompletionsRes.data ?? []) as Completion[])
     setLoading(false)
   }, [supabase])
 
@@ -110,6 +126,7 @@ export function useParentData(): ParentData {
       .on('postgres_changes', { event: '*', schema: 'public', table: 'redemptions' }, refetch)
       .on('postgres_changes', { event: '*', schema: 'public', table: 'curse_instances' }, refetch)
       .on('postgres_changes', { event: '*', schema: 'public', table: 'dungeon_runs' }, refetch)
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'dungeon_clears' }, refetch)
       .on('postgres_changes', { event: '*', schema: 'public', table: 'raid_bosses' }, refetch)
       .subscribe()
     return () => { supabase.removeChannel(channel) }
@@ -117,7 +134,8 @@ export function useParentData(): ParentData {
 
   return {
     family, kids, quests, completions, rewards, redemptions, curses, activeCurseInstances,
-    activeDungeon, activeBoss, pastDungeons, defeatedBosses,
+    activeDungeon, dungeonClears, weeklyCompletions,
+    activeBoss, pastDungeons, defeatedBosses,
     loading, supabase, refetch,
   }
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -105,13 +105,17 @@ export interface DungeonRun {
   title: string
   icon: string
   hp: number
-  current_damage: number
   reward_coins: number
   reward_xp: number
   week_start: string
-  status: 'active' | 'cleared'
-  cleared_at: string | null
   created_at: string
+}
+
+export interface DungeonClear {
+  id: string
+  dungeon_run_id: string
+  kid_id: string
+  cleared_at: string
 }
 
 export interface RaidBoss {

--- a/supabase/migrations/20260505180000_dungeon_per_kid.sql
+++ b/supabase/migrations/20260505180000_dungeon_per_kid.sql
@@ -1,0 +1,26 @@
+-- Dungeons are per-kid: each kid clears independently
+-- Remove family-aggregate columns from dungeon_runs
+alter table dungeon_runs drop column if exists current_damage;
+alter table dungeon_runs drop column if exists status;
+alter table dungeon_runs drop column if exists cleared_at;
+
+-- Track which kids cleared the dungeon (prevents double-paying)
+create table dungeon_clears (
+  id uuid primary key default gen_random_uuid(),
+  dungeon_run_id uuid not null references dungeon_runs(id) on delete cascade,
+  kid_id uuid not null references kids(id) on delete cascade,
+  cleared_at timestamptz default now(),
+  unique(dungeon_run_id, kid_id)
+);
+
+alter table dungeon_clears enable row level security;
+
+create policy "Family dungeon_clears" on dungeon_clears
+  for all
+  using (kid_id in (select id from kids where family_id = get_user_family_id()))
+  with check (kid_id in (select id from kids where family_id = get_user_family_id()));
+
+alter publication supabase_realtime add table dungeon_clears;
+
+create index dungeon_clears_run_id_idx on dungeon_clears(dungeon_run_id);
+create index dungeon_clears_kid_id_idx on dungeon_clears(kid_id);

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -92,15 +92,19 @@ create table dungeon_runs (
   title text not null default 'Weekly Dungeon',
   icon text not null default '🏰',
   hp integer not null,
-  current_damage integer not null default 0,
   reward_coins integer not null default 50,
   reward_xp integer not null default 100,
   week_start date not null,
-  status text not null default 'active',
-  cleared_at timestamptz,
   created_at timestamptz default now(),
-  constraint dungeon_status_check check (status in ('active', 'cleared')),
   unique(family_id, week_start)
+);
+
+create table dungeon_clears (
+  id uuid primary key default gen_random_uuid(),
+  dungeon_run_id uuid not null references dungeon_runs(id) on delete cascade,
+  kid_id uuid not null references kids(id) on delete cascade,
+  cleared_at timestamptz default now(),
+  unique(dungeon_run_id, kid_id)
 );
 
 create table raid_bosses (
@@ -136,6 +140,7 @@ alter table completions enable row level security;
 alter table rewards enable row level security;
 alter table redemptions enable row level security;
 alter table dungeon_runs enable row level security;
+alter table dungeon_clears enable row level security;
 alter table raid_bosses enable row level security;
 alter table raid_boss_hits enable row level security;
 


### PR DESCRIPTION
## Summary

Two changes in one PR:
1. **Dungeon design fix**: each kid clears the weekly dungeon independently (not a shared pool)
2. **Display wall panels**: Realm shows live progress toward active dungeon/boss

## Dungeon: per-kid clears

Previously dungeon damage was a single family aggregate. Now:
- Each kid's personal coin damage this week (sum of `coins_awarded` for approved completions since `week_start`) is checked independently
- A `dungeon_clears` table records which kids cleared — prevents double-paying
- On quest approval: if kid's weekly damage >= `dungeon_run.hp` and no existing clear for `(dungeon_run_id, kid_id)` → award `reward_coins` + `reward_xp` and insert a clear record

Schema: dropped `current_damage`, `status`, `cleared_at` from `dungeon_runs`; added `dungeon_clears(dungeon_run_id, kid_id)`.

## Display wall

When an active dungeon or boss exists, a compact panel appears between the header and kid columns:

**Raid Boss** (shared) — full-width HP bar with boss icon, current/max HP, and bounty amount.

**Weekly Dungeon** (per-kid) — grid of per-kid progress bars: avatar, name, % filled, ✓ icon when cleared. Columns match the kid column layout.

Both panels are invisible when nothing is active — no clutter for families not using these features. Live updates via Supabase Realtime.

## Test plan
- [ ] Open a dungeon, approve quests for one kid until cleared → only that kid gets reward, other kids still show progress
- [ ] Approve more quests for second kid → second kid clears independently
- [ ] Display wall shows per-kid dungeon bars and updates on approval
- [ ] Summon raid boss → display wall shows HP bar draining
- [ ] No dungeon/boss active → no panels on display wall

🤖 Generated with [Claude Code](https://claude.com/claude-code)