### PR TITLE
fix: shared daily quests reset each day (not locked for the week)

### DIFF
--- a/src/app/kid/[id]/page.tsx
+++ b/src/app/kid/[id]/page.tsx
@@ -456,11 +456,14 @@ export default function KidPage({ params }: { params: Promise<{ id: string }> })
                     )}
                     <Section title="⚡ Up for Grabs" accent="gold">
                       {upForGrabs.map((q, i) => {
+                        const periodFilter = q.frequency === 'weekly'
+                          ? (date: string) => date >= weekStart
+                          : (date: string) => date === today
                         const claimed = familySharedCompletions.filter(
-                          (c) => c.quest_id === q.id && (c.status === 'approved' || c.status === 'pending'),
+                          (c) => c.quest_id === q.id && periodFilter(c.date) && (c.status === 'approved' || c.status === 'pending'),
                         ).length
                         const myCompletion = completions.find(
-                          (c) => c.quest_id === q.id && c.kid_id === kid.id && (c.date === today || c.date >= weekStart),
+                          (c) => c.quest_id === q.id && c.kid_id === kid.id && periodFilter(c.date),
                         )
                         const isShareLocked = !myCompletion && claimed >= q.slots
                         return (

--- a/src/app/kid/[id]/page.tsx
+++ b/src/app/kid/[id]/page.tsx
@@ -13,7 +13,7 @@ import { StreakBadge } from '@/components/streak-badge'
 import type { Kid, Quest, Completion, Reward, CurseInstance, Redemption } from '@/lib/types'
 import { KID_COLORS, getLockDurationMs } from '@/lib/constants'
 import { questDateString, questWeekKey } from '@/lib/utils'
-import { isQuestVisibleToKid, sharedSlotsLeft, kidHasActiveCompletion } from '@/lib/quest-rules'
+import { isQuestVisibleToKid, sharedSlotsLeft, kidHasActiveCompletion, sharedClaimedCount, kidCompletionForPeriod } from '@/lib/quest-rules'
 import { toast } from 'sonner'
 
 const PIN_SESSION_KEY = 'cq_kid_pin_'
@@ -456,15 +456,8 @@ export default function KidPage({ params }: { params: Promise<{ id: string }> })
                     )}
                     <Section title="⚡ Up for Grabs" accent="gold">
                       {upForGrabs.map((q, i) => {
-                        const periodFilter = q.frequency === 'weekly'
-                          ? (date: string) => date >= weekStart
-                          : (date: string) => date === today
-                        const claimed = familySharedCompletions.filter(
-                          (c) => c.quest_id === q.id && periodFilter(c.date) && (c.status === 'approved' || c.status === 'pending'),
-                        ).length
-                        const myCompletion = completions.find(
-                          (c) => c.quest_id === q.id && c.kid_id === kid.id && periodFilter(c.date),
-                        )
+                        const claimed = sharedClaimedCount(q, familySharedCompletions as Completion[], today, weekStart)
+                        const myCompletion = kidCompletionForPeriod(q, kid.id, completions, today, weekStart)
                         const isShareLocked = !myCompletion && claimed >= q.slots
                         return (
                           <QuestRowItem

--- a/src/lib/__tests__/quest-rules.test.ts
+++ b/src/lib/__tests__/quest-rules.test.ts
@@ -5,7 +5,14 @@ import {
   countActiveCompletions,
   sharedSlotsLeft,
   kidHasActiveCompletion,
+  sharedQuestPeriodFilter,
+  sharedClaimedCount,
+  kidCompletionForPeriod,
 } from '../quest-rules'
+
+const TODAY = '2026-05-05'
+const YESTERDAY = '2026-05-04'
+const WEEK_START = '2026-04-28' // Monday of the week containing TODAY
 
 const baseQuest: Quest = {
   id: 'q1',
@@ -32,64 +39,64 @@ const baseCompletion: Completion = {
   completed_at: new Date().toISOString(),
   approved_at: null,
   coins_awarded: null,
-  date: '2026-05-03',
+  date: TODAY,
 }
 
-describe('isQuestVisibleToKid', () => {
-  const today = '2026-05-03' // a Sunday (UTC) — getDay() depends on local TZ; assert against local
+// ─── isQuestVisibleToKid ─────────────────────────────────────────────────────
 
+describe('isQuestVisibleToKid', () => {
   it('shows quests with no assignee to any kid', () => {
-    expect(isQuestVisibleToKid(baseQuest, 'kid-a', today, new Set())).toBe(true)
+    expect(isQuestVisibleToKid(baseQuest, 'kid-a', TODAY, new Set())).toBe(true)
   })
 
   it('hides quests assigned to a different kid', () => {
     const q = { ...baseQuest, assigned_to: 'kid-b' }
-    expect(isQuestVisibleToKid(q, 'kid-a', today, new Set())).toBe(false)
+    expect(isQuestVisibleToKid(q, 'kid-a', TODAY, new Set())).toBe(false)
   })
 
   it('shows quests assigned to this kid', () => {
     const q = { ...baseQuest, assigned_to: 'kid-a' }
-    expect(isQuestVisibleToKid(q, 'kid-a', today, new Set())).toBe(true)
+    expect(isQuestVisibleToKid(q, 'kid-a', TODAY, new Set())).toBe(true)
   })
 
   it('hides oneoff quests already approved by anyone in the family', () => {
     const q = { ...baseQuest, kind: 'oneoff' as const, frequency: 'once' as const }
-    expect(isQuestVisibleToKid(q, 'kid-a', today, new Set(['q1']))).toBe(false)
+    expect(isQuestVisibleToKid(q, 'kid-a', TODAY, new Set(['q1']))).toBe(false)
   })
 
   it('shows oneoff quests not yet approved', () => {
     const q = { ...baseQuest, kind: 'oneoff' as const, frequency: 'once' as const }
-    expect(isQuestVisibleToKid(q, 'kid-a', today, new Set())).toBe(true)
+    expect(isQuestVisibleToKid(q, 'kid-a', TODAY, new Set())).toBe(true)
   })
 
   it('respects active_days filter', () => {
-    const dow = new Date(today).getDay()
+    const dow = new Date(TODAY).getDay()
     const otherDay = (dow + 1) % 7
     const q = { ...baseQuest, active_days: [otherDay] }
-    expect(isQuestVisibleToKid(q, 'kid-a', today, new Set())).toBe(false)
+    expect(isQuestVisibleToKid(q, 'kid-a', TODAY, new Set())).toBe(false)
 
     const q2 = { ...baseQuest, active_days: [dow] }
-    expect(isQuestVisibleToKid(q2, 'kid-a', today, new Set())).toBe(true)
+    expect(isQuestVisibleToKid(q2, 'kid-a', TODAY, new Set())).toBe(true)
   })
 
   it('treats empty active_days as "every day"', () => {
     const q = { ...baseQuest, active_days: [] }
-    expect(isQuestVisibleToKid(q, 'kid-a', today, new Set())).toBe(true)
+    expect(isQuestVisibleToKid(q, 'kid-a', TODAY, new Set())).toBe(true)
   })
 
   it('shows shared quests to all kids — approved family completions do NOT hide them', () => {
     const q = { ...baseQuest, kind: 'shared' as const, assigned_to: null }
-    // shared quests stay visible even when they appear in the approvedSet
-    // (they're not oneoff — they reset each period)
-    expect(isQuestVisibleToKid(q, 'kid-a', today, new Set(['q1']))).toBe(true)
-    expect(isQuestVisibleToKid(q, 'kid-b', today, new Set(['q1']))).toBe(true)
+    expect(isQuestVisibleToKid(q, 'kid-a', TODAY, new Set(['q1']))).toBe(true)
+    expect(isQuestVisibleToKid(q, 'kid-b', TODAY, new Set(['q1']))).toBe(true)
   })
 
   it('active_days with all 7 days behaves like no filter', () => {
     const q = { ...baseQuest, active_days: [0, 1, 2, 3, 4, 5, 6] }
-    expect(isQuestVisibleToKid(q, 'kid-a', today, new Set())).toBe(true)
+    expect(isQuestVisibleToKid(q, 'kid-a', TODAY, new Set())).toBe(true)
   })
 })
+
+// ─── countActiveCompletions ──────────────────────────────────────────────────
 
 describe('countActiveCompletions', () => {
   it('counts pending and approved, ignoring rejected', () => {
@@ -124,6 +131,8 @@ describe('countActiveCompletions', () => {
   })
 })
 
+// ─── sharedSlotsLeft ─────────────────────────────────────────────────────────
+
 describe('sharedSlotsLeft', () => {
   it('returns null for personal quests', () => {
     expect(sharedSlotsLeft(baseQuest, [])).toBeNull()
@@ -153,8 +162,10 @@ describe('sharedSlotsLeft', () => {
   })
 })
 
+// ─── kidHasActiveCompletion ──────────────────────────────────────────────────
+
 describe('kidHasActiveCompletion', () => {
-  it('returns true when kid has pending or approved', () => {
+  it('returns true when kid has pending', () => {
     const completions: Completion[] = [{ ...baseCompletion, status: 'pending' }]
     expect(kidHasActiveCompletion(baseQuest, 'kid-a', completions)).toBe(true)
   })
@@ -181,5 +192,134 @@ describe('kidHasActiveCompletion', () => {
   it('returns false for other quests even for the same kid', () => {
     const completions: Completion[] = [{ ...baseCompletion, quest_id: 'other', status: 'approved' }]
     expect(kidHasActiveCompletion(baseQuest, 'kid-a', completions)).toBe(false)
+  })
+})
+
+// ─── sharedQuestPeriodFilter ─────────────────────────────────────────────────
+
+describe('sharedQuestPeriodFilter', () => {
+  const dailyQuest = { ...baseQuest, kind: 'shared' as const, frequency: 'daily' as const }
+  const weeklyQuest = { ...baseQuest, kind: 'shared' as const, frequency: 'weekly' as const }
+
+  it('daily quest: only matches today', () => {
+    const filter = sharedQuestPeriodFilter(dailyQuest, TODAY, WEEK_START)
+    expect(filter(TODAY)).toBe(true)
+    expect(filter(YESTERDAY)).toBe(false)
+    expect(filter(WEEK_START)).toBe(false)
+  })
+
+  it('weekly quest: matches today and earlier dates within the week', () => {
+    const filter = sharedQuestPeriodFilter(weeklyQuest, TODAY, WEEK_START)
+    expect(filter(TODAY)).toBe(true)
+    expect(filter(YESTERDAY)).toBe(true)
+    expect(filter(WEEK_START)).toBe(true)
+  })
+
+  it('weekly quest: rejects dates before the week', () => {
+    const filter = sharedQuestPeriodFilter(weeklyQuest, TODAY, WEEK_START)
+    expect(filter('2026-04-27')).toBe(false) // day before WEEK_START
+  })
+})
+
+// ─── sharedClaimedCount ──────────────────────────────────────────────────────
+
+describe('sharedClaimedCount', () => {
+  const sharedDaily = { ...baseQuest, kind: 'shared' as const, frequency: 'daily' as const, slots: 2 }
+  const sharedWeekly = { ...baseQuest, kind: 'shared' as const, frequency: 'weekly' as const, slots: 2 }
+
+  it('daily: only counts completions from today', () => {
+    const completions: Completion[] = [
+      { ...baseCompletion, id: 'a', kid_id: 'kid-a', date: TODAY, status: 'approved' },
+      { ...baseCompletion, id: 'b', kid_id: 'kid-b', date: YESTERDAY, status: 'approved' }, // old — should not count
+    ]
+    expect(sharedClaimedCount(sharedDaily, completions, TODAY, WEEK_START)).toBe(1)
+  })
+
+  it('daily: counts pending and approved from today, ignores rejected', () => {
+    const completions: Completion[] = [
+      { ...baseCompletion, id: 'a', kid_id: 'kid-a', date: TODAY, status: 'approved' },
+      { ...baseCompletion, id: 'b', kid_id: 'kid-b', date: TODAY, status: 'pending' },
+      { ...baseCompletion, id: 'c', kid_id: 'kid-c', date: TODAY, status: 'rejected' },
+    ]
+    expect(sharedClaimedCount(sharedDaily, completions, TODAY, WEEK_START)).toBe(2)
+  })
+
+  it('daily: returns 0 when only yesterday completions exist (quest resets)', () => {
+    const completions: Completion[] = [
+      { ...baseCompletion, id: 'a', kid_id: 'kid-a', date: YESTERDAY, status: 'approved' },
+    ]
+    expect(sharedClaimedCount(sharedDaily, completions, TODAY, WEEK_START)).toBe(0)
+  })
+
+  it('weekly: counts completions across the whole week', () => {
+    const completions: Completion[] = [
+      { ...baseCompletion, id: 'a', kid_id: 'kid-a', date: WEEK_START, status: 'approved' },
+      { ...baseCompletion, id: 'b', kid_id: 'kid-b', date: YESTERDAY, status: 'approved' },
+    ]
+    expect(sharedClaimedCount(sharedWeekly, completions, TODAY, WEEK_START)).toBe(2)
+  })
+
+  it('weekly: excludes completions from before the week', () => {
+    const completions: Completion[] = [
+      { ...baseCompletion, id: 'a', kid_id: 'kid-a', date: '2026-04-27', status: 'approved' }, // before week
+      { ...baseCompletion, id: 'b', kid_id: 'kid-b', date: YESTERDAY, status: 'approved' },
+    ]
+    expect(sharedClaimedCount(sharedWeekly, completions, TODAY, WEEK_START)).toBe(1)
+  })
+
+  it('does not count completions for other quests', () => {
+    const completions: Completion[] = [
+      { ...baseCompletion, id: 'a', quest_id: 'other', date: TODAY, status: 'approved' },
+    ]
+    expect(sharedClaimedCount(sharedDaily, completions, TODAY, WEEK_START)).toBe(0)
+  })
+})
+
+// ─── kidCompletionForPeriod ───────────────────────────────────────────────────
+
+describe('kidCompletionForPeriod', () => {
+  const sharedDaily = { ...baseQuest, kind: 'shared' as const, frequency: 'daily' as const }
+  const sharedWeekly = { ...baseQuest, kind: 'shared' as const, frequency: 'weekly' as const }
+
+  it('daily: finds today completion', () => {
+    const c = { ...baseCompletion, date: TODAY, status: 'approved' as const }
+    expect(kidCompletionForPeriod(sharedDaily, 'kid-a', [c], TODAY, WEEK_START)).toBe(c)
+  })
+
+  it('daily: returns undefined for yesterday completion — quest has reset', () => {
+    // This is the core bug scenario: kid completed yesterday, approved today.
+    // Quest should be available again → no completion found for today.
+    const c = { ...baseCompletion, date: YESTERDAY, status: 'approved' as const }
+    expect(kidCompletionForPeriod(sharedDaily, 'kid-a', [c], TODAY, WEEK_START)).toBeUndefined()
+  })
+
+  it('daily: returns undefined when only other kids completed today', () => {
+    const c = { ...baseCompletion, kid_id: 'kid-b', date: TODAY, status: 'approved' as const }
+    expect(kidCompletionForPeriod(sharedDaily, 'kid-a', [c], TODAY, WEEK_START)).toBeUndefined()
+  })
+
+  it('daily: picks up pending completion from today', () => {
+    const c = { ...baseCompletion, date: TODAY, status: 'pending' as const }
+    expect(kidCompletionForPeriod(sharedDaily, 'kid-a', [c], TODAY, WEEK_START)).toBe(c)
+  })
+
+  it('weekly: finds completion from earlier this week', () => {
+    const c = { ...baseCompletion, date: YESTERDAY, status: 'approved' as const }
+    expect(kidCompletionForPeriod(sharedWeekly, 'kid-a', [c], TODAY, WEEK_START)).toBe(c)
+  })
+
+  it('weekly: finds completion from the start of the week', () => {
+    const c = { ...baseCompletion, date: WEEK_START, status: 'approved' as const }
+    expect(kidCompletionForPeriod(sharedWeekly, 'kid-a', [c], TODAY, WEEK_START)).toBe(c)
+  })
+
+  it('weekly: returns undefined for completion from last week', () => {
+    const c = { ...baseCompletion, date: '2026-04-27', status: 'approved' as const }
+    expect(kidCompletionForPeriod(sharedWeekly, 'kid-a', [c], TODAY, WEEK_START)).toBeUndefined()
+  })
+
+  it('weekly: does not return another kid\'s completion', () => {
+    const c = { ...baseCompletion, kid_id: 'kid-b', date: YESTERDAY, status: 'approved' as const }
+    expect(kidCompletionForPeriod(sharedWeekly, 'kid-a', [c], TODAY, WEEK_START)).toBeUndefined()
   })
 })

--- a/src/lib/quest-rules.ts
+++ b/src/lib/quest-rules.ts
@@ -48,3 +48,54 @@ export function kidHasActiveCompletion(quest: Quest, kidId: string, completions:
     (c.status === 'approved' || c.status === 'pending'),
   )
 }
+
+/**
+ * Returns a date-filter predicate scoped to the correct period for a shared quest:
+ * - daily → only today's completions count
+ * - weekly (or unset) → any completion since weekStart counts
+ *
+ * This is used both for the family-wide "claimed" slot count and for finding
+ * a kid's own completion, so that daily shared quests reset every day and don't
+ * stay locked for the whole week after a single completion.
+ */
+export function sharedQuestPeriodFilter(
+  quest: Quest,
+  today: string,
+  weekStart: string,
+): (date: string) => boolean {
+  if (quest.frequency === 'daily') return (date) => date === today
+  return (date) => date >= weekStart
+}
+
+/**
+ * Returns how many family-wide slots have been claimed for the current period.
+ * Respects the quest's frequency — daily quests only count today's completions.
+ */
+export function sharedClaimedCount(
+  quest: Quest,
+  familyCompletions: Completion[],
+  today: string,
+  weekStart: string,
+): number {
+  const inPeriod = sharedQuestPeriodFilter(quest, today, weekStart)
+  return familyCompletions.filter(
+    (c) => c.quest_id === quest.id && inPeriod(c.date) && (c.status === 'approved' || c.status === 'pending'),
+  ).length
+}
+
+/**
+ * Returns this kid's active completion for the quest in the current period, or undefined.
+ * Respects the quest's frequency — daily quests only look at today's completions.
+ */
+export function kidCompletionForPeriod(
+  quest: Quest,
+  kidId: string,
+  completions: Completion[],
+  today: string,
+  weekStart: string,
+): Completion | undefined {
+  const inPeriod = sharedQuestPeriodFilter(quest, today, weekStart)
+  return completions.find(
+    (c) => c.quest_id === quest.id && c.kid_id === kidId && inPeriod(c.date),
+  )
+}


### PR DESCRIPTION
## Summary
- Shared daily quests in "Up for Grabs" were incorrectly locking for the entire week after a single completion
- Root cause: `claimed` count and `myCompletion` lookup both used `date >= weekStart` for all shared quests — correct for weekly, wrong for daily
- Fix: scope to `date === today` for daily shared quests, `date >= weekStart` for weekly shared quests

## Reproduction
1. Parent creates a shared daily quest (e.g. "Fed the Dog")
2. Kid completes it Monday, parent approves
3. Tuesday the quest showed as "claimed" / greyed out instead of resetting

## Test plan
- [ ] Shared daily quest appears available again after it was completed and approved the previous day
- [ ] Shared weekly quest still locks for the full week after being claimed
- [ ] Oneoff quests still disappear permanently after approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)