### PR TITLE
fix: pre-submit slot guard respects daily quest period

### DIFF
--- a/src/app/kid/[id]/page.tsx
+++ b/src/app/kid/[id]/page.tsx
@@ -13,7 +13,7 @@ import { StreakBadge } from '@/components/streak-badge'
 import type { Kid, Quest, Completion, Reward, CurseInstance, Redemption } from '@/lib/types'
 import { KID_COLORS, getLockDurationMs } from '@/lib/constants'
 import { questDateString, questWeekKey } from '@/lib/utils'
-import { isQuestVisibleToKid, sharedSlotsLeft, kidHasActiveCompletion, sharedClaimedCount, kidCompletionForPeriod } from '@/lib/quest-rules'
+import { isQuestVisibleToKid, kidHasActiveCompletion, sharedClaimedCount, kidCompletionForPeriod } from '@/lib/quest-rules'
 import { toast } from 'sonner'
 
 const PIN_SESSION_KEY = 'cq_kid_pin_'
@@ -130,16 +130,17 @@ export default function KidPage({ params }: { params: Promise<{ id: string }> })
       const quest = data.quests.find((q) => q.id === questId)
       if (!quest) return
 
+      const today = questDateString(data.resetHour)
+      const weekStart = questWeekKey(data.resetHour)
+
       // For shared quests, double-check slot availability before posting
       if (quest.kind === 'shared') {
-        const left = sharedSlotsLeft(quest, data.familySharedCompletions as Completion[])
-        if (left !== null && left <= 0) {
+        const left = quest.slots - sharedClaimedCount(quest, data.familySharedCompletions as Completion[], today, weekStart)
+        if (left <= 0) {
           toast.error('All slots claimed for this period!')
           return
         }
       }
-
-      const today = questDateString(data.resetHour)
       const res = await fetch(`/api/kid/${id}/complete`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- Second half of the shared daily quest bug: the "All slots claimed" pre-submit guard was using `sharedSlotsLeft()` → `countActiveCompletions()` which has no date filter
- A daily shared quest completed yesterday would block submission today with "All slots claimed for this period!"
- Fix: replace with `sharedClaimedCount()` which uses the same period filter already applied to the display

## Test plan
- [ ] Daily shared quest completed yesterday: clicking "Complete Quest" today goes through (no "All slots claimed" toast)
- [ ] Daily shared quest already completed today: clicking again correctly blocks with "All slots claimed"
- [ ] Weekly shared quest at capacity: still correctly blocked for the whole week

🤖 Generated with [Claude Code](https://claude.com/claude-code)