### PR TITLE
fix: bounty board daily reset (display page)

### DIFF
--- a/e2e/shared-quest-daily-reset.spec.ts
+++ b/e2e/shared-quest-daily-reset.spec.ts
@@ -1,0 +1,257 @@
+import { test, expect } from '@playwright/test'
+import type { Quest, Completion, Kid, Reward } from '../src/lib/types'
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function localDate(offset = 0): string {
+  const d = new Date()
+  d.setDate(d.getDate() + offset)
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
+
+function mondayOfWeek(): string {
+  const d = new Date()
+  const dow = d.getDay() // 0=Sun
+  d.setDate(d.getDate() - (dow === 0 ? 6 : dow - 1))
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
+
+function lastMonday(): string {
+  const d = new Date()
+  const dow = d.getDay()
+  d.setDate(d.getDate() - (dow === 0 ? 6 : dow - 1) - 7)
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const KID_ID = '00000000-0000-0000-0000-aaaaaaaaaaaa'
+const OTHER_KID_ID = '00000000-0000-0000-0000-bbbbbbbbbbbb'
+const QUEST_ID = '00000000-0000-0000-0000-cccccccccccc'
+const PIN_SESSION_KEY = 'cq_kid_pin_'
+
+const baseKid: Kid = {
+  id: KID_ID,
+  family_id: 'fam-1',
+  name: 'Aria',
+  avatar: '🧙',
+  color: 'azure',
+  coins: 50,
+  streak: 2,
+  last_completed_date: null,
+  xp: 0,
+  level: 1,
+  created_at: new Date().toISOString(),
+}
+
+const baseQuest: Quest = {
+  id: QUEST_ID,
+  family_id: 'fam-1',
+  title: 'Feed the Dog',
+  description: null,
+  icon: '🐕',
+  coins: 10,
+  assigned_to: null,
+  kind: 'shared',
+  frequency: 'daily',
+  tier: 'normal',
+  slots: 1,
+  active: true,
+  active_days: null,
+  created_at: new Date().toISOString(),
+}
+
+function makePayload(overrides: {
+  familySharedCompletions?: Array<{ quest_id: string; kid_id: string; status: string; date: string }>
+  completions?: Completion[]
+  quests?: Quest[]
+}) {
+  return {
+    kid: baseKid,
+    resetHour: 0,
+    quests: overrides.quests ?? [baseQuest],
+    completions: overrides.completions ?? [],
+    rewards: [] as Reward[],
+    activeCurses: [],
+    familySharedCompletions: overrides.familySharedCompletions ?? [],
+    pendingRedemptions: [],
+  }
+}
+
+// ─── Test setup helpers ───────────────────────────────────────────────────────
+
+async function setupPage(
+  page: import('@playwright/test').Page,
+  payload: ReturnType<typeof makePayload>,
+) {
+  // Bypass PIN gate by pre-setting sessionStorage
+  await page.addInitScript(
+    ({ key, kidId }: { key: string; kidId: string }) => {
+      sessionStorage.setItem(key + kidId, 'verified')
+    },
+    { key: PIN_SESSION_KEY, kidId: KID_ID },
+  )
+
+  // Intercept the data API — serve controlled payload
+  await page.route(`**/api/kid/${KID_ID}/data`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(payload),
+    }),
+  )
+
+  // Silence any supabase realtime connection attempts
+  await page.route('**/realtime/**', (route) => route.abort())
+  await page.route('**/rest/v1/**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }),
+  )
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+test.describe('Shared quest — daily reset', () => {
+  test('quest is available when the only family completion is from yesterday (regression: daily must not use week-scoped filter)', async ({ page }) => {
+    const yesterday = localDate(-1)
+
+    await setupPage(page, makePayload({
+      familySharedCompletions: [
+        // Another kid completed yesterday — approved today.
+        // With the old bug, this was counted as "claimed this week" → slot appeared full.
+        { quest_id: QUEST_ID, kid_id: OTHER_KID_ID, status: 'approved', date: yesterday },
+      ],
+    }))
+
+    await page.goto(`/kid/${KID_ID}`)
+    await page.waitForLoadState('networkidle')
+
+    // Quest should be claimable — not locked
+    await expect(page.getByText('⚡ Claim & Complete')).toBeVisible()
+
+    // Slot count shows 0/1, not 1/1
+    await expect(page.getByText('0/1 claimed')).toBeVisible()
+  })
+
+  test('quest is locked when all slots are claimed TODAY', async ({ page }) => {
+    const today = localDate(0)
+
+    await setupPage(page, makePayload({
+      familySharedCompletions: [
+        // Another kid claimed the only slot today
+        { quest_id: QUEST_ID, kid_id: OTHER_KID_ID, status: 'approved', date: today },
+      ],
+    }))
+
+    await page.goto(`/kid/${KID_ID}`)
+    await page.waitForLoadState('networkidle')
+
+    // Claim button should NOT be present
+    await expect(page.getByText('⚡ Claim & Complete')).not.toBeVisible()
+
+    // Slot count shows 1/1 (all taken)
+    await expect(page.getByText('1/1 claimed')).toBeVisible()
+
+    // "claimed" badge visible on the locked card (exact: true distinguishes it from "1/1 claimed" slot label)
+    await expect(page.getByText('claimed', { exact: true })).toBeVisible()
+  })
+
+  test('this kid sees their own completion as submitted (pending), not as locked', async ({ page }) => {
+    const today = localDate(0)
+
+    await setupPage(page, makePayload({
+      // This kid completed today — shows in both completions and familySharedCompletions
+      completions: [
+        {
+          id: 'comp-1',
+          quest_id: QUEST_ID,
+          kid_id: KID_ID,
+          status: 'pending',
+          completed_at: new Date().toISOString(),
+          approved_at: null,
+          coins_awarded: null,
+          date: today,
+        },
+      ],
+      familySharedCompletions: [
+        { quest_id: QUEST_ID, kid_id: KID_ID, status: 'pending', date: today },
+      ],
+    }))
+
+    await page.goto(`/kid/${KID_ID}`)
+    await page.waitForLoadState('networkidle')
+
+    // Not locked — pending shows "awaiting..."
+    await expect(page.getByText('awaiting...')).toBeVisible()
+
+    // Claim button should not be shown (quest already submitted)
+    await expect(page.getByText('⚡ Claim & Complete')).not.toBeVisible()
+  })
+})
+
+test.describe('Shared quest — weekly reset', () => {
+  test('weekly quest is locked when a slot was claimed earlier this week', async ({ page }) => {
+    const weekStart = mondayOfWeek()
+    const quest: Quest = { ...baseQuest, frequency: 'weekly', slots: 1 }
+
+    await setupPage(page, makePayload({
+      quests: [quest],
+      familySharedCompletions: [
+        // Claimed at the start of this week
+        { quest_id: QUEST_ID, kid_id: OTHER_KID_ID, status: 'approved', date: weekStart },
+      ],
+    }))
+
+    await page.goto(`/kid/${KID_ID}`)
+    await page.waitForLoadState('networkidle')
+
+    await expect(page.getByText('⚡ Claim & Complete')).not.toBeVisible()
+    await expect(page.getByText('claimed', { exact: true })).toBeVisible()
+  })
+
+  test('weekly quest is available when the only completion is from last week', async ({ page }) => {
+    const prevMonday = lastMonday()
+    const quest: Quest = { ...baseQuest, frequency: 'weekly', slots: 1 }
+
+    await setupPage(page, makePayload({
+      quests: [quest],
+      familySharedCompletions: [
+        // Claimed last week — should not carry over to this week
+        { quest_id: QUEST_ID, kid_id: OTHER_KID_ID, status: 'approved', date: prevMonday },
+      ],
+    }))
+
+    await page.goto(`/kid/${KID_ID}`)
+    await page.waitForLoadState('networkidle')
+
+    await expect(page.getByText('⚡ Claim & Complete')).toBeVisible()
+    await expect(page.getByText('0/1 claimed')).toBeVisible()
+  })
+
+  test('weekly quest with multiple slots: partially claimed still shows as available', async ({ page }) => {
+    const today = localDate(0)
+    const quest: Quest = { ...baseQuest, frequency: 'weekly', slots: 3 }
+
+    await setupPage(page, makePayload({
+      quests: [quest],
+      familySharedCompletions: [
+        { quest_id: QUEST_ID, kid_id: OTHER_KID_ID, status: 'approved', date: today },
+        // 1 of 3 slots taken — should still show Claim button
+      ],
+    }))
+
+    await page.goto(`/kid/${KID_ID}`)
+    await page.waitForLoadState('networkidle')
+
+    await expect(page.getByText('⚡ Claim & Complete')).toBeVisible()
+    await expect(page.getByText('1/3 claimed')).toBeVisible()
+  })
+})

--- a/src/app/display/page.tsx
+++ b/src/app/display/page.tsx
@@ -11,6 +11,7 @@ import { KidColumn } from '@/components/kid-column'
 import type { Kid, Quest, Completion, Family, Reward, DungeonRun, DungeonClear, RaidBoss } from '@/lib/types'
 import { KID_COLORS, TIER_CONFIG } from '@/lib/constants'
 import { questDateString, questWeekKey } from '@/lib/utils'
+import { sharedQuestPeriodFilter } from '@/lib/quest-rules'
 import { getWeekMonday } from '@/lib/xp'
 import { toast } from 'sonner'
 
@@ -121,9 +122,12 @@ export default function WallDisplay() {
       const today = questDateString(family?.daily_reset_hour ?? 0)
 
       if (quest.kind === 'shared') {
+        const weekStartNow = questWeekKey(family?.daily_reset_hour ?? 0)
+        const inPeriod = sharedQuestPeriodFilter(quest, today, weekStartNow)
         const familyCount = completions.filter(c =>
           c.quest_id === questId &&
-          (c.status === 'approved' || c.status === 'pending')
+          inPeriod(c.date) &&
+          (c.status === 'approved' || c.status === 'pending'),
         ).length
         if (familyCount >= quest.slots) {
           toast.error('All slots claimed!')
@@ -161,6 +165,7 @@ export default function WallDisplay() {
   )
 
   const today = questDateString(family?.daily_reset_hour ?? 0)
+  const weekStart = questWeekKey(family?.daily_reset_hour ?? 0)
   const dayOfWeek = new Date().getDay()
 
   const getKidPersonalQuests = (kid: Kid) =>
@@ -177,11 +182,14 @@ export default function WallDisplay() {
     return true
   })
 
-  const getFamilyCount = (questId: string) =>
-    completions.filter(c =>
-      c.quest_id === questId &&
-      (c.status === 'approved' || c.status === 'pending')
+  const getFamilyCount = (quest: Quest) => {
+    const inPeriod = sharedQuestPeriodFilter(quest, today, weekStart)
+    return completions.filter(c =>
+      c.quest_id === quest.id &&
+      inPeriod(c.date) &&
+      (c.status === 'approved' || c.status === 'pending'),
     ).length
+  }
 
   const getKidCompletions = (kid: Kid) =>
     completions.filter((c) => c.kid_id === kid.id)
@@ -444,7 +452,7 @@ export default function WallDisplay() {
             style={{ gridTemplateColumns: `repeat(${isMobile ? Math.min(bountyQuests.length, 2) : Math.min(bountyQuests.length, 4)}, 1fr)` }}
           >
             {bountyQuests.map((quest, i) => {
-              const count = getFamilyCount(quest.id)
+              const count = getFamilyCount(quest)
               const isFull = count >= quest.slots
               const tier = TIER_CONFIG[quest.tier ?? 'normal']
               return (


### PR DESCRIPTION
## Root cause

The display page's bounty board was counting ALL completions since `weekStart` with no period filter — same bug as the kid page (#75) but in a different file.

`getFamilyCount` and the `handleComplete` pre-submit guard both used:
```ts
completions.filter(c => c.quest_id === questId && (c.status === 'approved' || c.status === 'pending'))
```

For a daily shared quest, this counted yesterday's approved completion today → `isFull = true` → "✓ all claimed".

## Fix

Import `sharedQuestPeriodFilter` from `quest-rules` (same function used by the kid page fix) and apply it in both `getFamilyCount` and the `handleComplete` guard. Daily quests now only count completions where `date === today`.

## Test plan
- [x] TypeScript clean
- [x] Open display page after approving a daily shared quest yesterday — bounty card should show `0/1 taken`, not `✓ all claimed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)