### PR TITLE
fix: restore full approval history + date labels on pending items

### DIFF
--- a/src/app/parent/__tests__/approvals-tab.test.tsx
+++ b/src/app/parent/__tests__/approvals-tab.test.tsx
@@ -1,0 +1,140 @@
+// @vitest-environment jsdom
+import React from 'react'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+
+vi.mock('framer-motion', () => ({
+  motion: new Proxy({}, {
+    get: (_target, prop: string) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const Tag = prop as any
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return ({ children, ...rest }: any) => React.createElement(Tag, rest, children)
+    },
+  }),
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => React.createElement(React.Fragment, null, children),
+}))
+
+vi.mock('@/components/quest-card', () => ({
+  QuestCard: () => React.createElement('div', { 'data-testid': 'quest-card' }),
+}))
+
+import { ApprovalsTab } from '../approvals-tab'
+import type { Completion, Kid, Quest, Redemption } from '@/lib/types'
+
+function todayStr(offsetDays = 0) {
+  const d = new Date()
+  d.setDate(d.getDate() + offsetDays)
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+const baseKid: Kid = {
+  id: 'kid-1', family_id: 'fam-1', name: 'Aria', avatar: '🧙', color: 'azure',
+  coins: 50, streak: 1, last_completed_date: null, xp: 0, level: 1,
+  created_at: new Date().toISOString(),
+}
+
+const baseQuest: Quest = {
+  id: 'quest-1', family_id: 'fam-1', title: 'Feed the Dog', description: null,
+  icon: '🐕', coins: 10, assigned_to: null, kind: 'personal', frequency: 'daily',
+  tier: 'normal', slots: 1, active: true, active_days: null,
+  created_at: new Date().toISOString(),
+}
+
+function makeCompletion(overrides: Partial<Completion> & { date: string; status: 'approved' | 'rejected' }): Completion {
+  return {
+    id: Math.random().toString(36).slice(2),
+    quest_id: 'quest-1',
+    kid_id: 'kid-1',
+    completed_at: new Date().toISOString(),
+    approved_at: null,
+    coins_awarded: overrides.status === 'approved' ? 10 : null,
+    quest: baseQuest,
+    kid: baseKid,
+    ...overrides,
+  }
+}
+
+const noActions = {
+  approve: vi.fn(), reject: vi.fn(), undoApproval: vi.fn(), undoRejection: vi.fn(),
+  fulfillRedemption: vi.fn(), denyRedemption: vi.fn(),
+  createQuest: vi.fn(), updateQuest: vi.fn(), deleteQuest: vi.fn(), toggleQuest: vi.fn(),
+  createReward: vi.fn(), updateReward: vi.fn(), deleteReward: vi.fn(), toggleReward: vi.fn(),
+  createCurse: vi.fn(), deleteCurse: vi.fn(), castCurse: vi.fn(), resolveCurse: vi.fn(),
+  createDungeon: vi.fn(), clearDungeon: vi.fn(), deleteDungeon: vi.fn(),
+  createBoss: vi.fn(), deleteBoss: vi.fn(),
+  addKid: vi.fn(), updateKid: vi.fn(), deleteKid: vi.fn(),
+  saveFamily: vi.fn(), setResetHour: vi.fn(), generateApiKey: vi.fn(), revokeApiKey: vi.fn(),
+  saveParentPin: vi.fn(), removeParentPin: vi.fn(),
+  signOut: vi.fn(),
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+} as any
+
+afterEach(cleanup)
+
+describe('ApprovalsTab — review history', () => {
+  it('regression: shows completions from multiple dates, not only today', () => {
+    // Before the fix, the reviewed completions query used .eq('date', today),
+    // which meant yesterday's (and older) approved/rejected completions never appeared.
+    const todayCompletion = makeCompletion({ date: todayStr(0), status: 'approved' })
+    const yesterdayCompletion = makeCompletion({ date: todayStr(-1), status: 'approved' })
+
+    render(
+      <ApprovalsTab
+        pendingCompletions={[]}
+        pendingRedemptions={[]}
+        approvedRedemptions={[]}
+        reviewedCompletions={[todayCompletion, yesterdayCompletion]}
+        actions={noActions}
+      />
+    )
+
+    // Both completions must appear — section should be visible
+    expect(screen.getByText('Review history')).toBeInTheDocument()
+    // Two date labels should appear (Today + Yesterday)
+    expect(screen.getByText('Today')).toBeInTheDocument()
+    expect(screen.getByText('Yesterday')).toBeInTheDocument()
+  })
+
+  it('shows date labels correctly', () => {
+    const twoDaysAgo = makeCompletion({ date: todayStr(-2), status: 'rejected' })
+
+    render(
+      <ApprovalsTab
+        pendingCompletions={[]}
+        pendingRedemptions={[]}
+        approvedRedemptions={[]}
+        reviewedCompletions={[twoDaysAgo]}
+        actions={noActions}
+      />
+    )
+
+    // Should show a formatted date like "May 4" — verify it's not "Today" or "Yesterday"
+    const today = screen.queryByText('Today')
+    const yesterday = screen.queryByText('Yesterday')
+    expect(today).not.toBeInTheDocument()
+    expect(yesterday).not.toBeInTheDocument()
+    // The date label should be present (exact value depends on current date)
+    expect(screen.getByText('Review history')).toBeInTheDocument()
+  })
+
+  it('shows date on each pending completion', () => {
+    const pending = makeCompletion({ date: todayStr(-1), status: 'approved' })
+    // Re-use as a pending completion (override status)
+    const pendingItem = { ...pending, status: 'pending' as const, coins_awarded: null }
+
+    render(
+      <ApprovalsTab
+        pendingCompletions={[pendingItem]}
+        pendingRedemptions={[]}
+        approvedRedemptions={[]}
+        reviewedCompletions={[]}
+        actions={noActions}
+      />
+    )
+
+    // Pending row shows kid name + date in subtitle
+    expect(screen.getByText(/completed a quest · Yesterday/)).toBeInTheDocument()
+  })
+})

--- a/src/app/parent/approvals-tab.tsx
+++ b/src/app/parent/approvals-tab.tsx
@@ -6,6 +6,18 @@ import type { Kid, Quest, Completion, Reward, Redemption } from '@/lib/types'
 import { Empty, fadeSlide } from './_ui'
 import type { ParentActions } from './use-parent-actions'
 
+function formatQuestDate(date: string): string {
+  const now = new Date()
+  const todayStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`
+  const yest = new Date(now)
+  yest.setDate(yest.getDate() - 1)
+  const yestStr = `${yest.getFullYear()}-${String(yest.getMonth() + 1).padStart(2, '0')}-${String(yest.getDate()).padStart(2, '0')}`
+  if (date === todayStr) return 'Today'
+  if (date === yestStr) return 'Yesterday'
+  const d = new Date(date + 'T12:00:00')
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+}
+
 interface Props {
   pendingCompletions: Completion[]
   pendingRedemptions: Redemption[]
@@ -91,7 +103,7 @@ export function ApprovalsTab({
                 <span className="text-2xl">{kid.avatar}</span>
                 <div>
                   <p className="font-semibold text-white/90 text-sm">{kid.name}</p>
-                  <p className="text-white/40 text-xs">completed a quest</p>
+                  <p className="text-white/40 text-xs">completed a quest · {formatQuestDate(c.date)}</p>
                 </div>
                 {kid.streak > 1 && (
                   <span className="ml-auto text-xs text-cq-ember">🔥 {kid.streak} streak</span>
@@ -114,7 +126,7 @@ export function ApprovalsTab({
 
       {reviewed.length > 0 && (
         <div>
-          <p className="text-white/30 text-xs uppercase tracking-widest mb-3">Reviewed today</p>
+          <p className="text-white/30 text-xs uppercase tracking-widest mb-3">Review history</p>
           {reviewed.map((entry) => {
             if (entry.kind === 'completion') {
               const c = entry.item
@@ -125,6 +137,7 @@ export function ApprovalsTab({
                   <span className="text-lg">{kid.avatar}</span>
                   <span className="text-white/50 text-sm">{kid.name}</span>
                   <span className="text-white/35 text-sm flex-1 truncate">{(c.quest as Quest)?.title}</span>
+                  <span className="text-white/25 text-xs flex-shrink-0">{formatQuestDate(c.date)}</span>
                   <span className={`text-xs font-semibold flex-shrink-0 ${c.status === 'approved' ? 'text-cq-forest' : 'text-red-400'}`}>
                     {c.status === 'approved' ? `✓ +${c.coins_awarded}🪙` : '✗'}
                   </span>

--- a/src/app/parent/use-parent-data.ts
+++ b/src/app/parent/use-parent-data.ts
@@ -69,8 +69,8 @@ export function useParentData(): ParentData {
       supabase.from('quests').select('*').eq('family_id', profile.family_id).order('created_at'),
       // pending completions: no date filter — yesterday's unapproved items must surface
       supabase.from('completions').select(`*, quest:quests(*), kid:kids(${KID_COLS})`).eq('status', 'pending').order('completed_at', { ascending: false }),
-      // reviewed today: date-scoped for the "Reviewed today" section only
-      supabase.from('completions').select(`*, quest:quests(*), kid:kids(${KID_COLS})`).eq('date', today).in('status', ['approved', 'rejected']).order('completed_at', { ascending: false }),
+      // reviewed completions: no date filter — show full history
+      supabase.from('completions').select(`*, quest:quests(*), kid:kids(${KID_COLS})`).in('status', ['approved', 'rejected']).order('completed_at', { ascending: false }).limit(200),
       supabase.from('rewards').select('*').eq('family_id', profile.family_id).order('created_at'),
       supabase.from('redemptions').select(`*, reward:rewards(*), kid:kids(${KID_COLS})`).eq('status', 'pending').order('redeemed_at', { ascending: false }),
       supabase.from('redemptions').select(`*, reward:rewards(*), kid:kids(${KID_COLS})`).eq('status', 'approved').gte('redeemed_at', today).order('redeemed_at', { ascending: false }),


### PR DESCRIPTION
## Summary
- **Regression fix**: Reviewed completions query used `.eq('date', today)`, making any approval/rejection from a prior day invisible. Query now fetches all reviewed completions (`.in('status', [...]).limit(200)`) so full history is shown.
- **Date labels**: Pending completion rows now show the chore date ("completed a quest · Yesterday"). Reviewed history rows show a date badge ("Today", "Yesterday", "May 4").
- **Section rename**: "Reviewed today" → "Review history".
- **Test**: `ApprovalsTab` unit test with jsdom covers the multi-date regression and date label rendering.

## Test plan
- [ ] `npm test` — all unit tests pass
- [ ] Open parent → Approvals tab — review history section shows completions from multiple days
- [ ] Pending items show date in subtitle line
- [ ] Reviewed items show date badge next to approval status

🤖 Generated with [Claude Code](https://claude.com/claude-code)