### PR TITLE
fix: show redemptions and curses in approval history

### DIFF
--- a/src/app/parent/__tests__/approvals-tab.test.tsx
+++ b/src/app/parent/__tests__/approvals-tab.test.tsx
@@ -86,6 +86,7 @@ describe('ApprovalsTab — review history', () => {
         pendingRedemptions={[]}
         approvedRedemptions={[]}
         reviewedCompletions={[todayCompletion, yesterdayCompletion]}
+        resolvedCurseInstances={[]}
         actions={noActions}
       />
     )
@@ -106,6 +107,7 @@ describe('ApprovalsTab — review history', () => {
         pendingRedemptions={[]}
         approvedRedemptions={[]}
         reviewedCompletions={[twoDaysAgo]}
+        resolvedCurseInstances={[]}
         actions={noActions}
       />
     )
@@ -130,6 +132,7 @@ describe('ApprovalsTab — review history', () => {
         pendingRedemptions={[]}
         approvedRedemptions={[]}
         reviewedCompletions={[]}
+        resolvedCurseInstances={[]}
         actions={noActions}
       />
     )

--- a/src/app/parent/approvals-tab.tsx
+++ b/src/app/parent/approvals-tab.tsx
@@ -2,7 +2,7 @@
 
 import { motion } from 'framer-motion'
 import { QuestCard } from '@/components/quest-card'
-import type { Kid, Quest, Completion, Reward, Redemption } from '@/lib/types'
+import type { Kid, Quest, Completion, Reward, Redemption, CurseInstance, Curse } from '@/lib/types'
 import { Empty, fadeSlide } from './_ui'
 import type { ParentActions } from './use-parent-actions'
 
@@ -23,6 +23,7 @@ interface Props {
   pendingRedemptions: Redemption[]
   approvedRedemptions: Redemption[]
   reviewedCompletions: Completion[]
+  resolvedCurseInstances: CurseInstance[]
   actions: ParentActions
 }
 
@@ -31,15 +32,18 @@ export function ApprovalsTab({
   pendingRedemptions,
   approvedRedemptions,
   reviewedCompletions,
+  resolvedCurseInstances,
   actions,
 }: Props) {
   type ReviewedItem =
     | { kind: 'completion'; ts: string; item: Completion }
     | { kind: 'redemption'; ts: string; item: Redemption }
+    | { kind: 'curse'; ts: string; item: CurseInstance }
 
   const reviewed: ReviewedItem[] = [
     ...reviewedCompletions.map((c) => ({ kind: 'completion' as const, ts: c.completed_at, item: c })),
     ...approvedRedemptions.map((r) => ({ kind: 'redemption' as const, ts: r.redeemed_at, item: r })),
+    ...resolvedCurseInstances.map((ci) => ({ kind: 'curse' as const, ts: ci.resolved_at ?? ci.cast_at, item: ci })),
   ].sort((a, b) => b.ts.localeCompare(a.ts))
 
   return (
@@ -151,6 +155,23 @@ export function ApprovalsTab({
                 </div>
               )
             }
+            if (entry.kind === 'curse') {
+              const ci = entry.item
+              const kid = ci.kid as Kid | undefined
+              const curse = ci.curse as Curse | undefined
+              if (!kid || !curse) return null
+              return (
+                <div key={ci.id} className="flex items-center gap-3 py-2">
+                  <span className="text-lg">{kid.avatar}</span>
+                  <span className="text-white/50 text-sm">{kid.name}</span>
+                  <span className="text-white/35 text-sm flex-1 truncate flex items-center gap-1.5"><span>{curse.icon}</span> {curse.title}</span>
+                  <span className="text-white/25 text-xs flex-shrink-0">{ci.resolved_at ? formatQuestDate(ci.resolved_at.slice(0, 10)) : ''}</span>
+                  <span className="text-xs font-semibold flex-shrink-0 text-red-400">
+                    ☠️ -{ci.coins_deducted}🪙
+                  </span>
+                </div>
+              )
+            }
             const r = entry.item
             const kid = r.kid as Kid | undefined
             const reward = r.reward as Reward | undefined
@@ -160,6 +181,7 @@ export function ApprovalsTab({
                 <span className="text-lg">{kid.avatar}</span>
                 <span className="text-white/50 text-sm">{kid.name}</span>
                 <span className="text-white/35 text-sm flex-1 truncate flex items-center gap-1.5"><span>{reward.icon}</span> {reward.title}</span>
+                <span className="text-white/25 text-xs flex-shrink-0">{formatQuestDate(r.redeemed_at.slice(0, 10))}</span>
                 <span className="text-xs font-semibold flex-shrink-0 text-cq-gold">
                   🎁 -{reward.cost}🪙
                 </span>

--- a/src/app/parent/page.tsx
+++ b/src/app/parent/page.tsx
@@ -145,6 +145,7 @@ export default function ParentDashboard() {
                 pendingRedemptions={pendingRedemptions}
                 approvedRedemptions={approvedRedemptions}
                 reviewedCompletions={reviewedCompletions}
+                resolvedCurseInstances={data.resolvedCurseInstances}
                 actions={actions}
               />
             )}

--- a/src/app/parent/use-parent-data.ts
+++ b/src/app/parent/use-parent-data.ts
@@ -16,6 +16,7 @@ export interface ParentData {
   redemptions: Redemption[]
   curses: Curse[]
   activeCurseInstances: CurseInstance[]
+  resolvedCurseInstances: CurseInstance[]
   activeDungeon: DungeonRun | null
   dungeonClears: DungeonClear[]
   weeklyCompletions: Completion[]
@@ -39,6 +40,7 @@ export function useParentData(): ParentData {
   const [redemptions, setRedemptions] = useState<Redemption[]>([])
   const [curses, setCurses] = useState<Curse[]>([])
   const [activeCurseInstances, setActiveCurseInstances] = useState<CurseInstance[]>([])
+  const [resolvedCurseInstances, setResolvedCurseInstances] = useState<CurseInstance[]>([])
   const [activeDungeon, setActiveDungeon] = useState<DungeonRun | null>(null)
   const [dungeonClears, setDungeonClears] = useState<DungeonClear[]>([])
   const [weeklyCompletions, setWeeklyCompletions] = useState<Completion[]>([])
@@ -61,7 +63,7 @@ export function useParentData(): ParentData {
 
     const [
       familyRes, kidsRes, questsRes, pendingCompletionsRes, reviewedTodayRes, rewardsRes,
-      pendingRedemptionsRes, approvedRedemptionsRes, cursesRes, curseInstancesRes,
+      pendingRedemptionsRes, approvedRedemptionsRes, cursesRes, curseInstancesRes, resolvedCurseInstancesRes,
       activeDungeonRes, activeBossRes, pastDungeonsRes, defeatedBossesRes, weeklyCompletionsRes,
     ] = await Promise.all([
       supabase.from('families').select('id, name, invite_token, api_key, daily_reset_hour, created_at, parent_pin, plan').eq('id', profile.family_id).single(),
@@ -73,9 +75,10 @@ export function useParentData(): ParentData {
       supabase.from('completions').select(`*, quest:quests(*), kid:kids(${KID_COLS})`).in('status', ['approved', 'rejected']).order('completed_at', { ascending: false }).limit(200),
       supabase.from('rewards').select('*').eq('family_id', profile.family_id).order('created_at'),
       supabase.from('redemptions').select(`*, reward:rewards(*), kid:kids(${KID_COLS})`).eq('status', 'pending').order('redeemed_at', { ascending: false }),
-      supabase.from('redemptions').select(`*, reward:rewards(*), kid:kids(${KID_COLS})`).eq('status', 'approved').gte('redeemed_at', today).order('redeemed_at', { ascending: false }),
+      supabase.from('redemptions').select(`*, reward:rewards(*), kid:kids(${KID_COLS})`).eq('status', 'approved').order('redeemed_at', { ascending: false }).limit(200),
       supabase.from('curses').select('*').eq('family_id', profile.family_id).order('created_at'),
       supabase.from('curse_instances').select(`*, curse:curses(*), kid:kids(${KID_COLS})`).eq('status', 'active').order('cast_at', { ascending: false }),
+      supabase.from('curse_instances').select(`*, curse:curses(*), kid:kids(${KID_COLS})`).eq('status', 'resolved').order('resolved_at', { ascending: false }).limit(200),
       supabase.from('dungeon_runs').select('*').eq('family_id', profile.family_id).eq('week_start', monday).maybeSingle(),
       supabase.from('raid_bosses').select('*').eq('family_id', profile.family_id).eq('status', 'active').maybeSingle(),
       supabase.from('dungeon_runs').select('*').eq('family_id', profile.family_id).lt('week_start', monday).order('week_start', { ascending: false }).limit(5),
@@ -106,6 +109,7 @@ export function useParentData(): ParentData {
     ])
     if (cursesRes.data) setCurses(cursesRes.data as Curse[])
     if (curseInstancesRes.data) setActiveCurseInstances(curseInstancesRes.data as CurseInstance[])
+    if (resolvedCurseInstancesRes.data) setResolvedCurseInstances(resolvedCurseInstancesRes.data as CurseInstance[])
 
     const dungeon = (activeDungeonRes.data as DungeonRun) ?? null
     setActiveDungeon(dungeon)
@@ -139,7 +143,7 @@ export function useParentData(): ParentData {
   }, [refetch, supabase])
 
   return {
-    family, kids, quests, completions, rewards, redemptions, curses, activeCurseInstances,
+    family, kids, quests, completions, rewards, redemptions, curses, activeCurseInstances, resolvedCurseInstances,
     activeDungeon, dungeonClears, weeklyCompletions,
     activeBoss, pastDungeons, defeatedBosses,
     loading, supabase, refetch,


### PR DESCRIPTION
## Summary
- **Redemptions**: Approved redemptions query had `.gte('redeemed_at', today)` — only today's fulfilled rewards appeared. Removed date filter, added `.limit(200)`.
- **Curses**: Resolved curse instances were never included in the history. Now fetched separately and rendered in "Review history" with kid name, curse icon/title, date resolved, and coins deducted.
- **Redemption date label**: Added date badge to approved redemption rows (was missing while quest completions had one).

## Test plan
- [ ] `npm test` — all unit tests pass
- [ ] Open parent → Approvals → Review history shows past quest approvals, reward fulfillments, and resolved curses mixed in chronological order

🤖 Generated with [Claude Code](https://claude.com/claude-code)