### PR TITLE
feat: undo button on all review history items

### DIFF
--- a/src/app/parent/approvals-tab.tsx
+++ b/src/app/parent/approvals-tab.tsx
@@ -169,6 +169,13 @@ export function ApprovalsTab({
                   <span className="text-xs font-semibold flex-shrink-0 text-red-400">
                     ☠️ -{ci.coins_deducted}🪙
                   </span>
+                  <button
+                    onClick={() => actions.undoResolvedCurse(ci.id)}
+                    className="text-xs text-white/20 hover:text-cq-gold transition-all flex-shrink-0 ml-1"
+                    title="Undo"
+                  >
+                    ↩
+                  </button>
                 </div>
               )
             }
@@ -185,6 +192,13 @@ export function ApprovalsTab({
                 <span className="text-xs font-semibold flex-shrink-0 text-cq-gold">
                   🎁 -{reward.cost}🪙
                 </span>
+                <button
+                  onClick={() => actions.undoRedemption(r.id)}
+                  className="text-xs text-white/20 hover:text-cq-gold transition-all flex-shrink-0 ml-1"
+                  title="Undo"
+                >
+                  ↩
+                </button>
               </div>
             )
           })}

--- a/src/app/parent/use-parent-actions.ts
+++ b/src/app/parent/use-parent-actions.ts
@@ -22,6 +22,7 @@ interface Deps {
   rewards: Reward[]
   curses: Curse[]
   activeCurseInstances: CurseInstance[]
+  resolvedCurseInstances: CurseInstance[]
   activeDungeon: DungeonRun | null
   dungeonClears: DungeonClear[]
   activeBoss: RaidBoss | null
@@ -35,6 +36,8 @@ export interface ParentActions {
   undoRejection: (completionId: string) => Promise<void>
   fulfillRedemption: (redemptionId: string) => Promise<void>
   denyRedemption: (redemptionId: string) => Promise<void>
+  undoRedemption: (redemptionId: string) => Promise<void>
+  undoResolvedCurse: (instanceId: string) => Promise<void>
   addKid: (data: { name: string; avatar: string; color: 'azure' | 'mystic'; pin: string }) => Promise<void>
   addQuest: (data: AddQuestInput) => Promise<void>
   toggleQuest: (id: string, active: boolean) => Promise<void>
@@ -77,7 +80,7 @@ export interface AddQuestInput {
 }
 
 export function useParentActions(deps: Deps): ParentActions {
-  const { supabase, family, completions, redemptions, kids, quests, rewards, curses, activeCurseInstances, activeDungeon, dungeonClears, activeBoss, refetch } = deps
+  const { supabase, family, completions, redemptions, kids, quests, rewards, curses, activeCurseInstances, resolvedCurseInstances, activeDungeon, dungeonClears, activeBoss, refetch } = deps
   const router = useRouter()
 
   const approve = useCallback(async (completionId: string) => {
@@ -266,6 +269,28 @@ export function useParentActions(deps: Deps): ParentActions {
     }
     await refetch()
   }, [refetch, supabase])
+
+  const undoRedemption = useCallback(async (redemptionId: string) => {
+    const redemption = redemptions.find((r) => r.id === redemptionId)
+    if (!redemption) return
+    const kid = redemption.kid as Kid | undefined
+    const reward = redemption.reward as Reward | undefined
+    if (!kid || !reward) return
+    await supabase.from('redemptions').update({ status: 'pending' }).eq('id', redemptionId)
+    const { data: freshKid } = await supabase.from('kids').select('coins').eq('id', kid.id).single()
+    await supabase.from('kids').update({ coins: (freshKid?.coins ?? kid.coins) + reward.cost }).eq('id', kid.id)
+    toast.success(`Redemption undone — ${reward.cost} coins returned to ${kid.name}`)
+    await refetch()
+  }, [redemptions, refetch, supabase])
+
+  const undoResolvedCurse = useCallback(async (instanceId: string) => {
+    const instance = resolvedCurseInstances.find((ci) => ci.id === instanceId)
+    const kid = instance?.kid as Kid | undefined
+    const curse = instance?.curse as Curse | undefined
+    await supabase.from('curse_instances').update({ status: 'active', resolved_at: null }).eq('id', instanceId)
+    toast.success(`${curse?.title ?? 'Curse'} reopened for ${kid?.name ?? 'kid'}`)
+    await refetch()
+  }, [resolvedCurseInstances, refetch, supabase])
 
   const addKid = useCallback(async (data: { name: string; avatar: string; color: 'azure' | 'mystic'; pin: string }) => {
     if (!data.name.trim() || data.pin.length !== 4 || !family) return
@@ -642,7 +667,7 @@ export function useParentActions(deps: Deps): ParentActions {
 
   return {
     approve, reject, undoApproval, undoRejection,
-    fulfillRedemption, denyRedemption,
+    fulfillRedemption, denyRedemption, undoRedemption, undoResolvedCurse,
     addKid,
     addQuest, toggleQuest, deleteQuest, saveQuest, seedDefaultQuests,
     addReward, deleteReward, saveReward,


### PR DESCRIPTION
## Summary
- **Fulfilled redemptions**: new `undoRedemption` action — moves redemption back to pending and refunds coins to the kid.
- **Resolved curses**: new `undoResolvedCurse` action — moves curse instance back to active.
- **Quest completions**: already had ↩ undo — no change needed.

All three item types in the "Review history" section now show the ↩ undo button consistently.

## Test plan
- [ ] `npm test` — all unit tests pass
- [ ] Fulfill a reward redemption → appears in history with ↩ → click undo → moves back to pending, coins refunded
- [ ] Resolve a curse → appears in history with ↩ → click undo → curse becomes active again

🤖 Generated with [Claude Code](https://claude.com/claude-code)