### PR TITLE
UI alignment polish: fix misalignment across 5 surfaces, extract 3 components

### DIFF
--- a/docs/superpowers/plans/2026-05-07-ui-polish.md
+++ b/docs/superpowers/plans/2026-05-07-ui-polish.md
@@ -1,0 +1,1031 @@
+# ChoreQuest UI Polish Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix element misalignment across 5 UI surfaces by extracting 3 presentational components and correcting flex/grid layout patterns.
+
+**Architecture:** Three new pure-display components (`StatusChip`, `TierBadge`, `KindBadge`) replace copy-pasted inline badge markup. Five existing components get targeted layout corrections — no logic, data, or animation changes.
+
+**Tech Stack:** Next.js 14, React, TypeScript, Tailwind CSS, Framer Motion, Vitest + Testing Library
+
+---
+
+## File Map
+
+| File | Action |
+|------|--------|
+| `src/components/ui/status-chip.tsx` | Create |
+| `src/components/ui/tier-badge.tsx` | Create |
+| `src/components/ui/kind-badge.tsx` | Create |
+| `src/components/quest-card.tsx` | Modify (Fix 1) |
+| `src/app/parent/page.tsx` | Modify (Fix 2) |
+| `src/app/parent/quest-row.tsx` | Modify (Fix 3) |
+| `src/components/kid-column.tsx` | Modify (Fix 4) |
+| `src/app/parent/approvals-tab.tsx` | Modify (Fix 5) |
+| `src/components/ui/__tests__/status-chip.test.tsx` | Create (tests for StatusChip) |
+
+---
+
+## Task 1: StatusChip component
+
+**Files:**
+- Create: `src/components/ui/status-chip.tsx`
+- Create: `src/components/ui/__tests__/status-chip.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// src/components/ui/__tests__/status-chip.test.tsx
+// @vitest-environment jsdom
+import React from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen } from '@testing-library/react'
+
+vi.mock('framer-motion', () => ({
+  motion: new Proxy({}, {
+    get: (_target, prop: string) => {
+      const Tag = prop as keyof JSX.IntrinsicElements
+      return ({ children, ...rest }: React.HTMLAttributes<HTMLElement> & { children?: React.ReactNode }) =>
+        React.createElement(Tag, rest, children)
+    },
+  }),
+}))
+
+import { StatusChip } from '../status-chip'
+
+describe('StatusChip', () => {
+  it('renders "⏳ awaiting" for pending', () => {
+    render(<StatusChip status="pending" />)
+    expect(screen.getByText('⏳ awaiting')).toBeInTheDocument()
+  })
+
+  it('renders "✓ done" for approved', () => {
+    render(<StatusChip status="approved" />)
+    expect(screen.getByText('✓ done')).toBeInTheDocument()
+  })
+
+  it('renders "✗ retry" for rejected', () => {
+    render(<StatusChip status="rejected" />)
+    expect(screen.getByText('✗ retry')).toBeInTheDocument()
+  })
+
+  it('renders "claimed" for locked', () => {
+    render(<StatusChip status="locked" />)
+    expect(screen.getByText('claimed')).toBeInTheDocument()
+  })
+})
+```
+
+- [ ] **Step 2: Run test to confirm it fails**
+
+```bash
+cd /tmp/chorequest && npx vitest run src/components/ui/__tests__/status-chip.test.tsx
+```
+
+Expected: 4 failures — `Cannot find module '../status-chip'`
+
+- [ ] **Step 3: Create StatusChip**
+
+```tsx
+// src/components/ui/status-chip.tsx
+'use client'
+
+import { motion } from 'framer-motion'
+
+type StatusChipStatus = 'pending' | 'approved' | 'rejected' | 'locked'
+
+const CHIP_CONFIG: Record<StatusChipStatus, {
+  label: string
+  bg: string
+  border: string
+  color: string
+  pulse?: true
+}> = {
+  pending: {
+    label: '⏳ awaiting',
+    bg: 'rgba(251,191,36,0.15)',
+    border: 'rgba(251,191,36,0.3)',
+    color: '#fbbf24',
+    pulse: true,
+  },
+  approved: {
+    label: '✓ done',
+    bg: 'rgba(74,222,128,0.12)',
+    border: 'rgba(74,222,128,0.3)',
+    color: '#4ade80',
+  },
+  rejected: {
+    label: '✗ retry',
+    bg: 'rgba(239,68,68,0.12)',
+    border: 'rgba(239,68,68,0.3)',
+    color: '#f87171',
+  },
+  locked: {
+    label: 'claimed',
+    bg: 'rgba(255,255,255,0.05)',
+    border: 'rgba(255,255,255,0.1)',
+    color: 'rgba(255,255,255,0.3)',
+  },
+}
+
+const chipClass = 'text-[10px] px-2 py-0.5 rounded-full whitespace-nowrap font-semibold'
+
+export function StatusChip({ status }: { status: StatusChipStatus }) {
+  const cfg = CHIP_CONFIG[status]
+  const style = { background: cfg.bg, border: `1px solid ${cfg.border}`, color: cfg.color }
+
+  if (cfg.pulse) {
+    return (
+      <motion.span
+        className={chipClass}
+        style={style}
+        animate={{ opacity: [0.5, 1, 0.5] }}
+        transition={{ duration: 1.6, repeat: Infinity }}
+      >
+        {cfg.label}
+      </motion.span>
+    )
+  }
+
+  return (
+    <span className={chipClass} style={style}>
+      {cfg.label}
+    </span>
+  )
+}
+```
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+```bash
+cd /tmp/chorequest && npx vitest run src/components/ui/__tests__/status-chip.test.tsx
+```
+
+Expected: 4 tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /tmp/chorequest && git add src/components/ui/status-chip.tsx src/components/ui/__tests__/status-chip.test.tsx
+git commit -m "feat: add StatusChip presentational component"
+```
+
+---
+
+## Task 2: TierBadge component
+
+**Files:**
+- Create: `src/components/ui/tier-badge.tsx`
+
+- [ ] **Step 1: Create TierBadge**
+
+```tsx
+// src/components/ui/tier-badge.tsx
+import type { QuestTier } from '@/lib/types'
+import { TIER_CONFIG } from '@/lib/constants'
+
+export function TierBadge({ tier }: { tier: QuestTier | null | undefined }) {
+  const resolved = tier ?? 'normal'
+  if (resolved === 'normal') return null
+  const cfg = TIER_CONFIG[resolved]
+  return (
+    <span
+      className="text-[10px] px-1.5 py-0.5 rounded-md font-bold flex-shrink-0"
+      style={{
+        background: `${cfg.color}18`,
+        color: cfg.color,
+        border: `1px solid ${cfg.color}40`,
+      }}
+    >
+      {cfg.label}
+    </span>
+  )
+}
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+```bash
+cd /tmp/chorequest && npx tsc --noEmit 2>&1 | head -20
+```
+
+Expected: no output (no errors)
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /tmp/chorequest && git add src/components/ui/tier-badge.tsx
+git commit -m "feat: add TierBadge presentational component"
+```
+
+---
+
+## Task 3: KindBadge component
+
+**Files:**
+- Create: `src/components/ui/kind-badge.tsx`
+
+- [ ] **Step 1: Create KindBadge**
+
+```tsx
+// src/components/ui/kind-badge.tsx
+import type { QuestKind } from '@/lib/types'
+
+const KIND_CONFIG: Partial<Record<QuestKind, { label: string; color: string; bg: string; border: string }>> = {
+  shared: {
+    label: '⚡ Shared',
+    color: '#fbbf24',
+    bg: 'rgba(251,191,36,0.12)',
+    border: 'rgba(251,191,36,0.25)',
+  },
+  oneoff: {
+    label: '⭐ One-time',
+    color: '#a78bfa',
+    bg: 'rgba(167,139,250,0.12)',
+    border: 'rgba(167,139,250,0.2)',
+  },
+}
+
+export function KindBadge({ kind }: { kind: QuestKind }) {
+  const cfg = KIND_CONFIG[kind]
+  if (!cfg) return null
+  return (
+    <span
+      className="text-[10px] px-1.5 py-0.5 rounded-md flex-shrink-0"
+      style={{ background: cfg.bg, color: cfg.color, border: `1px solid ${cfg.border}` }}
+    >
+      {cfg.label}
+    </span>
+  )
+}
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+```bash
+cd /tmp/chorequest && npx tsc --noEmit 2>&1 | head -20
+```
+
+Expected: no output
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /tmp/chorequest && git add src/components/ui/kind-badge.tsx
+git commit -m "feat: add KindBadge presentational component"
+```
+
+---
+
+## Task 4: Fix QuestCard (Fix 1)
+
+**Files:**
+- Modify: `src/components/quest-card.tsx`
+
+The change: outer row switches from `items-start` to `items-center`. The right column becomes a proper `flex-col` with a consistent 2-row structure (coin amount + optional StatusChip). The inline tier badge span is replaced with `<TierBadge>`.
+
+- [ ] **Step 1: Add imports at the top of quest-card.tsx**
+
+Current imports (lines 1–8):
+```tsx
+'use client'
+
+import { useState } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+import type { Quest, Completion, KidColor } from '@/lib/types'
+import { KID_COLORS, TIER_CONFIG } from '@/lib/constants'
+import { CoinBurst } from './coin-burst'
+```
+
+Replace with:
+```tsx
+'use client'
+
+import { useState } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+import type { Quest, Completion, KidColor } from '@/lib/types'
+import { KID_COLORS, TIER_CONFIG } from '@/lib/constants'
+import { CoinBurst } from './coin-burst'
+import { StatusChip } from './ui/status-chip'
+import { TierBadge } from './ui/tier-badge'
+```
+
+- [ ] **Step 2: Add statusChipStatus derived value after the existing status variables**
+
+Find this block (around line 55–63):
+```tsx
+  const isShared = quest.kind === 'shared' || quest.kind === 'oneoff'
+  const status = completion?.status
+  const isTodo = !isShareLocked && !status
+  const isPending = status === 'pending'
+  const isApproved = status === 'approved'
+  const isRejected = status === 'rejected'
+```
+
+Replace with:
+```tsx
+  const isShared = quest.kind === 'shared' || quest.kind === 'oneoff'
+  const status = completion?.status
+  const isTodo = !isShareLocked && !status
+  const isPending = status === 'pending'
+  const isApproved = status === 'approved'
+  const isRejected = status === 'rejected'
+
+  const statusChipStatus = isPending ? 'pending'
+    : isApproved ? 'approved'
+    : isRejected ? 'rejected'
+    : isShareLocked ? 'locked'
+    : null
+```
+
+- [ ] **Step 3: Fix the outer card row and icon**
+
+Find (line ~160):
+```tsx
+      <div className="p-4">
+        <div className="flex items-start gap-3">
+          <span className="text-2xl leading-none mt-0.5 flex-shrink-0">{quest.icon}</span>
+```
+
+Replace with:
+```tsx
+      <div className="p-4">
+        <div className="flex items-center gap-3">
+          <span className="text-2xl leading-none flex-shrink-0">{quest.icon}</span>
+```
+
+- [ ] **Step 4: Replace inline tier badge with TierBadge**
+
+Find (lines ~172–179):
+```tsx
+            <div className="flex items-center gap-1.5 flex-wrap">
+              <p
+                className={`font-semibold text-sm leading-snug ${
+                  isApproved ? 'line-through opacity-40' : isShareLocked ? 'text-white/35' : 'text-white/90'
+                }`}
+              >
+                {quest.title}
+              </p>
+              {!isNormal && (
+                <span
+                  className="text-xs px-1.5 py-0.5 rounded-md font-bold flex-shrink-0"
+                  style={{ background: `${tier.color}18`, color: tier.color, border: `1px solid ${tier.color}40` }}
+                >
+                  {tier.label}
+                </span>
+              )}
+            </div>
+```
+
+Replace with:
+```tsx
+            <div className="flex items-center gap-1.5 flex-wrap">
+              <p
+                className={`font-semibold text-sm leading-snug ${
+                  isApproved ? 'line-through opacity-40' : isShareLocked ? 'text-white/35' : 'text-white/90'
+                }`}
+              >
+                {quest.title}
+              </p>
+              <TierBadge tier={quest.tier} />
+            </div>
+```
+
+- [ ] **Step 5: Replace right column with consistent flex-col structure**
+
+Find (lines ~219–244):
+```tsx
+          <div className="flex-shrink-0 text-right">
+            <div className="flex items-center gap-1 justify-end">
+              <span className="text-sm">🪙</span>
+              <span className="font-heading font-bold text-sm" style={{ color: isNormal ? '#fbbf24' : tier.color }}>
+                {quest.coins}
+              </span>
+            </div>
+            {isPending && (
+              <motion.p
+                className="text-xs text-amber-400 mt-0.5"
+                animate={{ opacity: [0.5, 1, 0.5] }}
+                transition={{ duration: 1.6, repeat: Infinity }}
+              >
+                awaiting...
+              </motion.p>
+            )}
+            {isApproved && !isPending && (
+              <p className="text-xs text-cq-forest mt-0.5">✓ done!</p>
+            )}
+            {isRejected && (
+              <p className="text-xs text-red-400 mt-0.5">✗ retry</p>
+            )}
+            {isShareLocked && (
+              <p className="text-xs text-white/30 mt-0.5">claimed</p>
+            )}
+          </div>
+```
+
+Replace with:
+```tsx
+          <div className="flex flex-col items-end gap-1 flex-shrink-0">
+            <div className="flex items-center gap-1">
+              <span className="text-sm">🪙</span>
+              <span className="font-heading font-bold text-sm" style={{ color: isNormal ? '#fbbf24' : tier.color }}>
+                {quest.coins}
+              </span>
+            </div>
+            {statusChipStatus && <StatusChip status={statusChipStatus} />}
+          </div>
+```
+
+- [ ] **Step 6: Verify TypeScript compiles**
+
+```bash
+cd /tmp/chorequest && npx tsc --noEmit 2>&1 | head -20
+```
+
+Expected: no output
+
+- [ ] **Step 7: Run full test suite**
+
+```bash
+cd /tmp/chorequest && npx vitest run
+```
+
+Expected: all tests pass
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /tmp/chorequest && git add src/components/quest-card.tsx
+git commit -m "fix: QuestCard layout — center-align row, StatusChip for status, TierBadge"
+```
+
+---
+
+## Task 5: Fix parent tab bar (Fix 2)
+
+**Files:**
+- Modify: `src/app/parent/page.tsx`
+
+Change: split `label` into `icon` + `label` in the tabs array. On mobile (`< sm`) render icon only with a corner badge dot. On desktop (`sm+`) render the current full label + inline badge.
+
+- [ ] **Step 1: Update the Tab type and tabs array**
+
+Find the tabs array (around line 68):
+```tsx
+  const tabs: { id: Tab; label: string; badge?: number }[] = [
+    { id: 'approvals', label: '✓ Approvals', badge: pendingCompletions.length + pendingRedemptions.length },
+    { id: 'quests', label: '⚔️ Quests' },
+    { id: 'rewards', label: '🎁 Rewards' },
+    { id: 'curses', label: '☠️ Curses', badge: data.activeCurseInstances.length || undefined },
+    { id: 'dungeons', label: '🏰 Dungeons' },
+    { id: 'family', label: '👨‍👩‍👧 Family' },
+  ]
+```
+
+Replace with:
+```tsx
+  const tabs: { id: Tab; icon: string; label: string; badge?: number }[] = [
+    { id: 'approvals', icon: '✓', label: 'Approvals', badge: pendingCompletions.length + pendingRedemptions.length },
+    { id: 'quests', icon: '⚔️', label: 'Quests' },
+    { id: 'rewards', icon: '🎁', label: 'Rewards' },
+    { id: 'curses', icon: '☠️', label: 'Curses', badge: data.activeCurseInstances.length || undefined },
+    { id: 'dungeons', icon: '🏰', label: 'Dungeons' },
+    { id: 'family', icon: '👨‍👩‍👧', label: 'Family' },
+  ]
+```
+
+- [ ] **Step 2: Update the tab button rendering**
+
+Find (around line 116):
+```tsx
+        <div className="flex gap-1.5 px-6 py-4 flex-shrink-0">
+          {tabs.map((t) => (
+            <button
+              key={t.id}
+              onClick={() => setTab(t.id)}
+              className="flex-1 min-w-0 flex items-center justify-center gap-1.5 px-3 py-2 rounded-xl text-sm font-semibold transition-all"
+              style={{
+                background: tab === t.id ? 'rgba(251,191,36,0.14)' : 'rgba(255,255,255,0.05)',
+                border: `1px solid ${tab === t.id ? 'rgba(251,191,36,0.35)' : 'rgba(255,255,255,0.08)'}`,
+                color: tab === t.id ? '#fbbf24' : 'rgba(255,255,255,0.5)',
+              }}
+            >
+              {t.label}
+              {t.badge && t.badge > 0 ? (
+                <span
+                  className="px-1.5 py-0.5 rounded-full text-xs font-bold"
+                  style={{ background: '#fbbf24', color: '#0a0620' }}
+                >
+                  {t.badge}
+                </span>
+              ) : null}
+            </button>
+          ))}
+        </div>
+```
+
+Replace with:
+```tsx
+        <div className="flex gap-1.5 px-6 py-4 flex-shrink-0">
+          {tabs.map((t) => (
+            <button
+              key={t.id}
+              onClick={() => setTab(t.id)}
+              className="relative flex-1 min-w-0 flex items-center justify-center gap-1.5 px-1 sm:px-3 py-2 rounded-xl text-sm font-semibold transition-all"
+              style={{
+                background: tab === t.id ? 'rgba(251,191,36,0.14)' : 'rgba(255,255,255,0.05)',
+                border: `1px solid ${tab === t.id ? 'rgba(251,191,36,0.35)' : 'rgba(255,255,255,0.08)'}`,
+                color: tab === t.id ? '#fbbf24' : 'rgba(255,255,255,0.5)',
+              }}
+            >
+              {/* Mobile: icon only */}
+              <span className="sm:hidden">{t.icon}</span>
+              {/* Desktop: icon + label */}
+              <span className="hidden sm:inline">{t.icon} {t.label}</span>
+              {/* Desktop badge: inline pill */}
+              {t.badge && t.badge > 0 ? (
+                <>
+                  <span
+                    className="hidden sm:inline px-1.5 py-0.5 rounded-full text-xs font-bold"
+                    style={{ background: '#fbbf24', color: '#0a0620' }}
+                  >
+                    {t.badge}
+                  </span>
+                  {/* Mobile badge: corner dot */}
+                  <span
+                    className="sm:hidden absolute top-0.5 right-0.5 min-w-[14px] h-[14px] flex items-center justify-center rounded-full text-[8px] font-bold leading-none px-0.5"
+                    style={{ background: '#fbbf24', color: '#0a0620' }}
+                  >
+                    {t.badge}
+                  </span>
+                </>
+              ) : null}
+            </button>
+          ))}
+        </div>
+```
+
+- [ ] **Step 3: Verify TypeScript compiles**
+
+```bash
+cd /tmp/chorequest && npx tsc --noEmit 2>&1 | head -20
+```
+
+Expected: no output
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /tmp/chorequest && git add src/app/parent/page.tsx
+git commit -m "fix: parent tab bar icon-only on mobile with corner badge dot"
+```
+
+---
+
+## Task 6: Fix QuestRow action buttons (Fix 3)
+
+**Files:**
+- Modify: `src/app/parent/quest-row.tsx`
+
+Change: outer row switches from `items-center` to `items-start`. Action buttons are wrapped in a single div with `self-start`. Inline tier and kind badge spans are replaced with `<TierBadge>` and `<KindBadge>`.
+
+- [ ] **Step 1: Update imports in quest-row.tsx**
+
+Find the import block at top of file:
+```tsx
+import type { Kid, Quest, QuestKind, QuestTier } from '@/lib/types'
+import { TIER_CONFIG } from '@/lib/constants'
+import { QuestFormFields, type QuestFormState } from './quest-form'
+```
+
+Replace with (drop `TIER_CONFIG`; keep `QuestKind`/`QuestTier` since `QuestTier` is used in the state initializer cast):
+```tsx
+import type { Kid, Quest, QuestKind, QuestTier } from '@/lib/types'
+import { QuestFormFields, type QuestFormState } from './quest-form'
+import { TierBadge } from '@/components/ui/tier-badge'
+import { KindBadge } from '@/components/ui/kind-badge'
+```
+
+- [ ] **Step 2: Remove now-unused constants**
+
+Find and delete the `KIND_BADGE` constant (lines ~17–21):
+```tsx
+const KIND_BADGE: Record<QuestKind, { label: string; color: string; bg: string; border: string } | null> = {
+  personal: null,
+  shared: { label: '⚡ Shared', color: '#fbbf24', bg: 'rgba(251,191,36,0.12)', border: 'rgba(251,191,36,0.25)' },
+  oneoff: { label: '⭐ One-time', color: '#a78bfa', bg: 'rgba(167,139,250,0.12)', border: 'rgba(167,139,250,0.2)' },
+}
+```
+
+- [ ] **Step 3: Remove unused derived variables inside the component**
+
+Find (around line 41–43):
+```tsx
+  const assignedKid = kids.find((k) => k.id === quest.assigned_to)
+  const tierCfg = TIER_CONFIG[quest.tier ?? 'normal']
+  const kindBadge = KIND_BADGE[quest.kind]
+```
+
+Replace with:
+```tsx
+  const assignedKid = kids.find((k) => k.id === quest.assigned_to)
+```
+
+(`tierCfg` and `kindBadge` are no longer used — TierBadge and KindBadge handle their own config internally.)
+
+- [ ] **Step 4: Fix the row layout — items-start, wrap buttons, replace badges**
+
+Find the inner row div (around line 70):
+```tsx
+      <div className="flex items-center gap-3 p-3">
+        <span className="text-xl">{quest.icon}</span>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <p className={`text-sm font-semibold ${quest.active ? 'text-white/90' : 'text-white/40 line-through'}`}>
+              {quest.title}
+            </p>
+            {(quest.tier ?? 'normal') !== 'normal' && (
+              <span
+                className="text-xs px-1.5 py-0.5 rounded-md flex-shrink-0"
+                style={{ background: `${tierCfg.color}18`, color: tierCfg.color, border: `1px solid ${tierCfg.border}` }}
+              >
+                {tierCfg.label}
+              </span>
+            )}
+            {kindBadge && (
+              <span
+                className="text-xs px-1.5 py-0.5 rounded-md flex-shrink-0"
+                style={{ background: kindBadge.bg, color: kindBadge.color, border: `1px solid ${kindBadge.border}` }}
+              >
+                {kindBadge.label}
+              </span>
+            )}
+          </div>
+          <p className="text-white/35 text-xs">
+            🪙 {quest.coins} · {assignedKid ? assignedKid.name : 'All kids'} · {cadenceLabel}
+            {quest.active_days && quest.active_days.length > 0
+              ? ` · ${quest.active_days.map(d => ['Su','Mo','Tu','We','Th','Fr','Sa'][d]).join(' ')}`
+              : ''}
+          </p>
+        </div>
+        <button
+          onClick={() => setEditing((e) => !e)}
+          className="text-xs px-2.5 py-1 rounded-lg transition-all"
+          style={{
+            background: editing ? 'rgba(251,191,36,0.12)' : 'rgba(255,255,255,0.05)',
+            color: editing ? '#fbbf24' : 'rgba(255,255,255,0.4)',
+          }}
+        >
+          ✏️
+        </button>
+        <button
+          onClick={() => onToggle(quest.id, quest.active)}
+          className="text-xs px-2.5 py-1 rounded-lg transition-all"
+          style={{
+            background: quest.active ? 'rgba(74,222,128,0.1)' : 'rgba(255,255,255,0.05)',
+            color: quest.active ? '#4ade80' : 'rgba(255,255,255,0.35)',
+          }}
+        >
+          {quest.active ? 'On' : 'Off'}
+        </button>
+        <button
+          onClick={() => onDelete(quest.id)}
+          className="text-white/20 hover:text-red-400 transition-all text-xs ml-1"
+        >
+          ✕
+        </button>
+      </div>
+```
+
+Replace with:
+```tsx
+      <div className="flex items-start gap-3 p-3">
+        <span className="text-xl mt-0.5 flex-shrink-0">{quest.icon}</span>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <p className={`text-sm font-semibold ${quest.active ? 'text-white/90' : 'text-white/40 line-through'}`}>
+              {quest.title}
+            </p>
+            <TierBadge tier={quest.tier} />
+            <KindBadge kind={quest.kind} />
+          </div>
+          <p className="text-white/35 text-xs">
+            🪙 {quest.coins} · {assignedKid ? assignedKid.name : 'All kids'} · {cadenceLabel}
+            {quest.active_days && quest.active_days.length > 0
+              ? ` · ${quest.active_days.map(d => ['Su','Mo','Tu','We','Th','Fr','Sa'][d]).join(' ')}`
+              : ''}
+          </p>
+        </div>
+        <div className="flex gap-1 flex-shrink-0 self-start pt-0.5">
+          <button
+            onClick={() => setEditing((e) => !e)}
+            className="text-xs px-2.5 py-1 rounded-lg transition-all"
+            style={{
+              background: editing ? 'rgba(251,191,36,0.12)' : 'rgba(255,255,255,0.05)',
+              color: editing ? '#fbbf24' : 'rgba(255,255,255,0.4)',
+            }}
+          >
+            ✏️
+          </button>
+          <button
+            onClick={() => onToggle(quest.id, quest.active)}
+            className="text-xs px-2.5 py-1 rounded-lg transition-all"
+            style={{
+              background: quest.active ? 'rgba(74,222,128,0.1)' : 'rgba(255,255,255,0.05)',
+              color: quest.active ? '#4ade80' : 'rgba(255,255,255,0.35)',
+            }}
+          >
+            {quest.active ? 'On' : 'Off'}
+          </button>
+          <button
+            onClick={() => onDelete(quest.id)}
+            className="text-white/20 hover:text-red-400 transition-all text-xs ml-0.5"
+          >
+            ✕
+          </button>
+        </div>
+      </div>
+```
+
+- [ ] **Step 5: Verify TypeScript compiles**
+
+```bash
+cd /tmp/chorequest && npx tsc --noEmit 2>&1 | head -20
+```
+
+Expected: no output
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /tmp/chorequest && git add src/app/parent/quest-row.tsx
+git commit -m "fix: QuestRow top-align action buttons, use TierBadge + KindBadge"
+```
+
+---
+
+## Task 7: Fix kid column header badge row (Fix 4)
+
+**Files:**
+- Modify: `src/components/kid-column.tsx`
+
+Change: wrap the badge row div in a conditional so it only renders when there is content to display, eliminating the phantom gap on columns with no streak and no curses.
+
+- [ ] **Step 1: Conditionally render the badge row**
+
+Find (around line 136):
+```tsx
+        <div className="flex items-center gap-2">
+          {kid.streak > 1 && <StreakBadge streak={kid.streak} />}
+          {activeCurseCount > 0 && (
+            <motion.span
+              className="text-xs px-2 py-0.5 rounded-full font-bold"
+              style={{ background: 'rgba(239,68,68,0.2)', border: '1px solid rgba(239,68,68,0.35)', color: '#f87171' }}
+              animate={{ scale: [1, 1.06, 1] }}
+              transition={{ duration: 2, repeat: Infinity }}
+            >
+              ☠️ {activeCurseCount} curse{activeCurseCount > 1 ? 's' : ''}
+            </motion.span>
+          )}
+        </div>
+```
+
+Replace with:
+```tsx
+        {(kid.streak > 1 || activeCurseCount > 0) && (
+          <div className="flex items-center gap-2">
+            {kid.streak > 1 && <StreakBadge streak={kid.streak} />}
+            {activeCurseCount > 0 && (
+              <motion.span
+                className="text-xs px-2 py-0.5 rounded-full font-bold"
+                style={{ background: 'rgba(239,68,68,0.2)', border: '1px solid rgba(239,68,68,0.35)', color: '#f87171' }}
+                animate={{ scale: [1, 1.06, 1] }}
+                transition={{ duration: 2, repeat: Infinity }}
+              >
+                ☠️ {activeCurseCount} curse{activeCurseCount > 1 ? 's' : ''}
+              </motion.span>
+            )}
+          </div>
+        )}
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+```bash
+cd /tmp/chorequest && npx tsc --noEmit 2>&1 | head -20
+```
+
+Expected: no output
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /tmp/chorequest && git add src/components/kid-column.tsx
+git commit -m "fix: only render kid header badge row when badges are present"
+```
+
+---
+
+## Task 8: Fix approvals history rows (Fix 5)
+
+**Files:**
+- Modify: `src/app/parent/approvals-tab.tsx`
+
+Change: switch the 3 history row types from `flex` to `grid` with columns `[1fr_auto_auto_1.5rem]`. The title column merges avatar + name + quest/reward/curse title into one flex span. The undo button is in a fixed `w-6` column so it never shifts. Completion rows use `<StatusChip>` for the status column.
+
+- [ ] **Step 1: Add StatusChip import**
+
+Find the import block at top of file:
+```tsx
+import { QuestCard } from '@/components/quest-card'
+import type { Kid, Quest, Completion, Reward, Redemption, CurseInstance, Curse } from '@/lib/types'
+import { Empty, fadeSlide } from './_ui'
+import type { ParentActions } from './use-parent-actions'
+```
+
+Replace with:
+```tsx
+import { QuestCard } from '@/components/quest-card'
+import { StatusChip } from '@/components/ui/status-chip'
+import type { Kid, Quest, Completion, Reward, Redemption, CurseInstance, Curse } from '@/lib/types'
+import { Empty, fadeSlide } from './_ui'
+import type { ParentActions } from './use-parent-actions'
+```
+
+- [ ] **Step 2: Replace completion history rows with grid layout**
+
+Find (around line 140):
+```tsx
+              <div key={c.id} className="flex items-center gap-3 py-2">
+                  <span className="text-lg">{kid.avatar}</span>
+                  <span className="text-white/50 text-sm">{kid.name}</span>
+                  <span className="text-white/35 text-sm flex-1 truncate">{(c.quest as Quest)?.title}</span>
+                  <span className="text-white/25 text-xs flex-shrink-0">{formatQuestDate(c.date)}</span>
+                  <span className={`text-xs font-semibold flex-shrink-0 ${c.status === 'approved' ? 'text-cq-forest' : 'text-red-400'}`}>
+                    {c.status === 'approved' ? `✓ +${c.coins_awarded}🪙` : '✗'}
+                  </span>
+                  <button
+                    onClick={() => c.status === 'approved' ? actions.undoApproval(c.id) : actions.undoRejection(c.id)}
+                    className="text-xs text-white/20 hover:text-cq-gold transition-all flex-shrink-0 ml-1"
+                    title="Undo"
+                  >
+                    ↩
+                  </button>
+                </div>
+```
+
+Replace with:
+```tsx
+              <div key={c.id} className="grid items-center gap-x-2 py-1.5" style={{ gridTemplateColumns: '1fr auto auto 1.5rem' }}>
+                  <span className="text-sm truncate flex items-center gap-1.5 min-w-0">
+                    <span className="text-base flex-shrink-0">{kid.avatar}</span>
+                    <span className="text-white/50 flex-shrink-0">{kid.name}</span>
+                    <span className="text-white/35 truncate">{(c.quest as Quest)?.title}</span>
+                  </span>
+                  <span className="text-white/25 text-xs whitespace-nowrap">{formatQuestDate(c.date)}</span>
+                  <StatusChip status={c.status === 'approved' ? 'approved' : 'rejected'} />
+                  <button
+                    onClick={() => c.status === 'approved' ? actions.undoApproval(c.id) : actions.undoRejection(c.id)}
+                    className="text-xs text-white/20 hover:text-cq-gold transition-all text-center w-6"
+                    title="Undo"
+                  >
+                    ↩
+                  </button>
+                </div>
+```
+
+- [ ] **Step 3: Replace curse history rows with grid layout**
+
+Find (around line 164):
+```tsx
+              <div key={ci.id} className="flex items-center gap-3 py-2">
+                  <span className="text-lg">{kid.avatar}</span>
+                  <span className="text-white/50 text-sm">{kid.name}</span>
+                  <span className="text-white/35 text-sm flex-1 truncate flex items-center gap-1.5"><span>{curse.icon}</span> {curse.title}</span>
+                  <span className="text-white/25 text-xs flex-shrink-0">{ci.resolved_at ? formatQuestDate(ci.resolved_at.slice(0, 10)) : ''}</span>
+                  <span className="text-xs font-semibold flex-shrink-0 text-red-400">
+                    ☠️ -{ci.coins_deducted}🪙
+                  </span>
+                  <button
+                    onClick={() => actions.undoResolvedCurse(ci.id)}
+                    className="text-xs text-white/20 hover:text-cq-gold transition-all flex-shrink-0 ml-1"
+                    title="Undo"
+                  >
+                    ↩
+                  </button>
+                </div>
+```
+
+Replace with:
+```tsx
+              <div key={ci.id} className="grid items-center gap-x-2 py-1.5" style={{ gridTemplateColumns: '1fr auto auto 1.5rem' }}>
+                  <span className="text-sm truncate flex items-center gap-1.5 min-w-0">
+                    <span className="text-base flex-shrink-0">{kid.avatar}</span>
+                    <span className="text-white/50 flex-shrink-0">{kid.name}</span>
+                    <span className="text-white/35 truncate flex items-center gap-1"><span>{curse.icon}</span>{curse.title}</span>
+                  </span>
+                  <span className="text-white/25 text-xs whitespace-nowrap">{ci.resolved_at ? formatQuestDate(ci.resolved_at.slice(0, 10)) : ''}</span>
+                  <span className="text-xs font-semibold text-red-400 whitespace-nowrap">☠️ -{ci.coins_deducted}🪙</span>
+                  <button
+                    onClick={() => actions.undoResolvedCurse(ci.id)}
+                    className="text-xs text-white/20 hover:text-cq-gold transition-all text-center w-6"
+                    title="Undo"
+                  >
+                    ↩
+                  </button>
+                </div>
+```
+
+- [ ] **Step 4: Replace redemption history rows with grid layout**
+
+Find (around line 187):
+```tsx
+            <div key={r.id} className="flex items-center gap-3 py-2">
+                <span className="text-lg">{kid.avatar}</span>
+                <span className="text-white/50 text-sm">{kid.name}</span>
+                <span className="text-white/35 text-sm flex-1 truncate flex items-center gap-1.5"><span>{reward.icon}</span> {reward.title}</span>
+                <span className="text-white/25 text-xs flex-shrink-0">{formatQuestDate(r.redeemed_at.slice(0, 10))}</span>
+                <span className="text-xs font-semibold flex-shrink-0 text-cq-gold">
+                  🎁 -{reward.cost}🪙
+                </span>
+                <button
+                  onClick={() => actions.undoRedemption(r.id)}
+                  className="text-xs text-white/20 hover:text-cq-gold transition-all flex-shrink-0 ml-1"
+                  title="Undo"
+                >
+                  ↩
+                </button>
+              </div>
+```
+
+Replace with:
+```tsx
+            <div key={r.id} className="grid items-center gap-x-2 py-1.5" style={{ gridTemplateColumns: '1fr auto auto 1.5rem' }}>
+                <span className="text-sm truncate flex items-center gap-1.5 min-w-0">
+                  <span className="text-base flex-shrink-0">{kid.avatar}</span>
+                  <span className="text-white/50 flex-shrink-0">{kid.name}</span>
+                  <span className="text-white/35 truncate flex items-center gap-1"><span>{reward.icon}</span>{reward.title}</span>
+                </span>
+                <span className="text-white/25 text-xs whitespace-nowrap">{formatQuestDate(r.redeemed_at.slice(0, 10))}</span>
+                <span className="text-xs font-semibold text-cq-gold whitespace-nowrap">🎁 -{reward.cost}🪙</span>
+                <button
+                  onClick={() => actions.undoRedemption(r.id)}
+                  className="text-xs text-white/20 hover:text-cq-gold transition-all text-center w-6"
+                  title="Undo"
+                >
+                  ↩
+                </button>
+              </div>
+```
+
+- [ ] **Step 5: Verify TypeScript compiles**
+
+```bash
+cd /tmp/chorequest && npx tsc --noEmit 2>&1 | head -20
+```
+
+Expected: no output
+
+- [ ] **Step 6: Run full test suite including existing approvals test**
+
+```bash
+cd /tmp/chorequest && npx vitest run
+```
+
+Expected: all tests pass (existing approvals-tab tests check section labels and date labels, which are unaffected by the grid layout change)
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /tmp/chorequest && git add src/app/parent/approvals-tab.tsx
+git commit -m "fix: approvals history rows use grid layout, undo button in fixed column"
+```
+
+---
+
+## Final verification
+
+- [ ] **Full type check**
+
+```bash
+cd /tmp/chorequest && npx tsc --noEmit
+```
+
+Expected: no output
+
+- [ ] **Full test suite**
+
+```bash
+cd /tmp/chorequest && npx vitest run
+```
+
+Expected: all tests pass
+
+- [ ] **Build check**
+
+```bash
+cd /tmp/chorequest && npm run build 2>&1 | tail -10
+```
+
+Expected: `✓ Compiled successfully`

--- a/docs/superpowers/specs/2026-05-07-ui-polish-design.md
+++ b/docs/superpowers/specs/2026-05-07-ui-polish-design.md
@@ -1,0 +1,154 @@
+# ChoreQuest UI Polish — Design Spec
+
+**Date:** 2026-05-07  
+**Status:** Approved  
+**Scope:** Alignment fixes across 5 problem areas + 3 extracted presentational components
+
+---
+
+## Problem Statement
+
+Several UI components misalign when optional content is present — tier badges, status text, and notification badges all cause sibling elements to shift. The root causes are: raw text used where a fixed-height chip is needed, `items-start`/`items-center` mismatches, always-rendered empty containers, and variable-width columns in list rows.
+
+---
+
+## New Components
+
+Three new files under `src/components/ui/`:
+
+### `StatusChip`
+**File:** `src/components/ui/status-chip.tsx`
+
+A fixed-height pill for quest completion status. Replaces the raw `<p>` status text in QuestCard and the inline status spans in Approvals history rows.
+
+Props:
+```ts
+{ status: 'pending' | 'approved' | 'rejected' | 'locked' }
+```
+
+Visual spec:
+- `pending` — amber background/border, text `⏳ awaiting`, animated opacity pulse
+- `approved` — green background/border, text `✓ done`
+- `rejected` — red background/border, text `✗ retry`
+- `locked` — white/5% background, text `claimed`
+- All variants: `text-[10px] px-2 py-0.5 rounded-full whitespace-nowrap`
+
+### `TierBadge`
+**File:** `src/components/ui/tier-badge.tsx`
+
+The EPIC/LEGENDARY/RARE/NORMAL tier label. Consolidates copy-pasted inline badge markup from QuestCard and QuestRow.
+
+Props:
+```ts
+{ tier: QuestTier }
+```
+
+- `normal` → renders nothing (return null)
+- Other tiers → reads from `TIER_CONFIG[tier]` for color/label; `text-[10px] px-1.5 py-0.5 rounded-md font-bold flex-shrink-0`
+
+### `KindBadge`
+**File:** `src/components/ui/kind-badge.tsx`
+
+The Shared / One-time kind indicator. Currently only in QuestRow; extracted for consistency.
+
+Props:
+```ts
+{ kind: QuestKind }
+```
+
+- `personal` → renders nothing
+- `shared` → `⚡ Shared` in amber
+- `oneoff` → `⭐ One-time` in purple
+- Style: `text-[10px] px-1.5 py-0.5 rounded-md flex-shrink-0`
+
+---
+
+## Fix 1 — QuestCard (`src/components/quest-card.tsx`)
+
+**Root cause:** `flex items-start` on the outer row means the icon sits at the top-left while the coin+status column also starts at the top. When the status text (`awaiting...`, `✓ done!`, etc.) is raw `<p>` with variable width, the right column changes height between states and the layout jumps.
+
+**Changes:**
+1. Change outer row `items-start` → `items-center`
+2. Replace all four status `<p>` elements with `<StatusChip status={...} />` — consistent pill height regardless of content
+3. Right column structure becomes: `flex flex-col items-end gap-1` with coin row on top, `StatusChip` below (only rendered when there is a status)
+4. Replace inline tier badge `<span>` with `<TierBadge tier={quest.tier} />`
+5. Add `min-w-0` to middle `flex-1` div to prevent overflow pushing right column
+
+**Result:** Icon and coin amount center-align with the title regardless of how many badges wrap in the middle. Right column is consistently 1–2 rows tall.
+
+---
+
+## Fix 2 — Parent tab bar (`src/app/parent/page.tsx`)
+
+**Root cause:** 6 `flex-1` tabs each contain emoji + text label + optional badge. Below ~500px the content overflows: labels clip mid-character and badges overlap icons.
+
+**Changes:**
+- Below `sm` breakpoint: show emoji only (`<span className="sm:hidden">`) with badge as an absolute-positioned corner dot (`top-0.5 right-0.5`)
+- At `sm` and above: current full-label layout unchanged
+- Tab button gets `relative` so the corner badge positions correctly
+- Badge dot on mobile shows count if > 0, otherwise not rendered (same logic as today)
+
+**Result:** Each tab is a clean emoji square on mobile, full label on desktop. Badge never overlaps the icon.
+
+---
+
+## Fix 3 — QuestRow action buttons (`src/app/parent/quest-row.tsx`)
+
+**Root cause:** Action buttons (✏️ / On / ✕) use `align-self: center` (default in `items-center` flex). When the title wraps to 2+ lines due to tier + kind badges, the buttons float to the vertical middle of the row instead of aligning with the title.
+
+**Changes:**
+1. Outer row: keep `flex items-start gap-3` (already `items-center` — change to `items-start`)
+2. Action button group `div`: add `self-start pt-0.5` so buttons pin to top
+3. Replace inline tier badge `<span>` with `<TierBadge tier={quest.tier} />`
+4. Replace inline kind badge `<span>` with `<KindBadge kind={quest.kind} />`
+
+**Result:** Buttons always align with the first line of the title regardless of wrapping.
+
+---
+
+## Fix 4 — Kid column header badge row (`src/components/kid-column.tsx`)
+
+**Root cause:** The `<div className="flex items-center gap-2">` that holds streak badge + curse badge always renders, even when both are absent. This adds ~8px of invisible vertical space to every kid column header that has no streak or curse, making columns with badges taller than columns without.
+
+**Change:**
+- Wrap the entire badge row div in a conditional: only render if `kid.streak > 1 || activeCurseCount > 0`
+- When rendered, content and spacing are unchanged
+
+**Result:** Consistent header card height across all kid columns regardless of which badges are active.
+
+---
+
+## Fix 5 — Approvals history rows (`src/app/parent/approvals-tab.tsx`)
+
+**Root cause:** History rows use `flex items-center gap-3` with a variable-width status column (`+25🪙`, `✗`, `🎁 -50🪙`, `☠️ -5🪙`). The undo ↩ button shifts left/right depending on status text length.
+
+**Changes:**
+1. Switch each history row from `flex` to `grid` with fixed columns: `grid-cols-[1fr_auto_w-16_w-5]` — flexible title, auto date, fixed-width status, fixed-width undo
+2. Status column uses `text-right` so all values right-align within their fixed slot
+3. Replace inline status text with `<StatusChip>` for completion rows
+
+**Result:** ↩ button is always in the same horizontal position regardless of which status is shown.
+
+---
+
+## Files Changed
+
+| File | Change type |
+|------|------------|
+| `src/components/ui/status-chip.tsx` | New |
+| `src/components/ui/tier-badge.tsx` | New |
+| `src/components/ui/kind-badge.tsx` | New |
+| `src/components/quest-card.tsx` | Modified — Fix 1 |
+| `src/app/parent/page.tsx` | Modified — Fix 2 |
+| `src/app/parent/quest-row.tsx` | Modified — Fix 3 |
+| `src/components/kid-column.tsx` | Modified — Fix 4 |
+| `src/app/parent/approvals-tab.tsx` | Modified — Fix 5 |
+
+---
+
+## Out of Scope
+
+- Display page bounty board cards (separate component, no reported issues)
+- Kid page layout (no reported alignment issues)
+- Any logic, data fetching, or animation changes
+- New features or behavior changes

--- a/docs/superpowers/specs/2026-05-07-ui-polish-design.md
+++ b/docs/superpowers/specs/2026-05-07-ui-polish-design.md
@@ -97,7 +97,7 @@ Props:
 **Root cause:** Action buttons (✏️ / On / ✕) use `align-self: center` (default in `items-center` flex). When the title wraps to 2+ lines due to tier + kind badges, the buttons float to the vertical middle of the row instead of aligning with the title.
 
 **Changes:**
-1. Outer row: keep `flex items-start gap-3` (already `items-center` — change to `items-start`)
+1. Change outer row from `flex items-center gap-3` → `flex items-start gap-3`
 2. Action button group `div`: add `self-start pt-0.5` so buttons pin to top
 3. Replace inline tier badge `<span>` with `<TierBadge tier={quest.tier} />`
 4. Replace inline kind badge `<span>` with `<KindBadge kind={quest.kind} />`
@@ -123,7 +123,7 @@ Props:
 **Root cause:** History rows use `flex items-center gap-3` with a variable-width status column (`+25🪙`, `✗`, `🎁 -50🪙`, `☠️ -5🪙`). The undo ↩ button shifts left/right depending on status text length.
 
 **Changes:**
-1. Switch each history row from `flex` to `grid` with fixed columns: `grid-cols-[1fr_auto_w-16_w-5]` — flexible title, auto date, fixed-width status, fixed-width undo
+1. Switch each history row from `flex` to `grid` with fixed columns: `grid-cols-[1fr_auto_4rem_1.25rem]` — flexible title, auto date, fixed-width status (4rem), fixed-width undo (1.25rem)
 2. Status column uses `text-right` so all values right-align within their fixed slot
 3. Replace inline status text with `<StatusChip>` for completion rows
 

--- a/src/app/parent/approvals-tab.tsx
+++ b/src/app/parent/approvals-tab.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from 'framer-motion'
 import { QuestCard } from '@/components/quest-card'
+import { StatusChip } from '@/components/ui/status-chip'
 import type { Kid, Quest, Completion, Reward, Redemption, CurseInstance, Curse } from '@/lib/types'
 import { Empty, fadeSlide } from './_ui'
 import type { ParentActions } from './use-parent-actions'
@@ -137,17 +138,17 @@ export function ApprovalsTab({
               const kid = c.kid as Kid | undefined
               if (!kid) return null
               return (
-                <div key={c.id} className="flex items-center gap-3 py-2">
-                  <span className="text-lg">{kid.avatar}</span>
-                  <span className="text-white/50 text-sm">{kid.name}</span>
-                  <span className="text-white/35 text-sm flex-1 truncate">{(c.quest as Quest)?.title}</span>
-                  <span className="text-white/25 text-xs flex-shrink-0">{formatQuestDate(c.date)}</span>
-                  <span className={`text-xs font-semibold flex-shrink-0 ${c.status === 'approved' ? 'text-cq-forest' : 'text-red-400'}`}>
-                    {c.status === 'approved' ? `✓ +${c.coins_awarded}🪙` : '✗'}
+                <div key={c.id} className="grid items-center gap-x-2 py-1.5" style={{ gridTemplateColumns: '1fr auto auto 1.5rem' }}>
+                  <span className="text-sm truncate flex items-center gap-1.5 min-w-0">
+                    <span className="text-base flex-shrink-0">{kid.avatar}</span>
+                    <span className="text-white/50 flex-shrink-0">{kid.name}</span>
+                    <span className="text-white/35 truncate">{(c.quest as Quest)?.title}</span>
                   </span>
+                  <span className="text-white/25 text-xs whitespace-nowrap">{formatQuestDate(c.date)}</span>
+                  <StatusChip status={c.status === 'approved' ? 'approved' : 'rejected'} />
                   <button
                     onClick={() => c.status === 'approved' ? actions.undoApproval(c.id) : actions.undoRejection(c.id)}
-                    className="text-xs text-white/20 hover:text-cq-gold transition-all flex-shrink-0 ml-1"
+                    className="text-xs text-white/20 hover:text-cq-gold transition-all text-center w-6"
                     title="Undo"
                   >
                     ↩
@@ -161,17 +162,17 @@ export function ApprovalsTab({
               const curse = ci.curse as Curse | undefined
               if (!kid || !curse) return null
               return (
-                <div key={ci.id} className="flex items-center gap-3 py-2">
-                  <span className="text-lg">{kid.avatar}</span>
-                  <span className="text-white/50 text-sm">{kid.name}</span>
-                  <span className="text-white/35 text-sm flex-1 truncate flex items-center gap-1.5"><span>{curse.icon}</span> {curse.title}</span>
-                  <span className="text-white/25 text-xs flex-shrink-0">{ci.resolved_at ? formatQuestDate(ci.resolved_at.slice(0, 10)) : ''}</span>
-                  <span className="text-xs font-semibold flex-shrink-0 text-red-400">
-                    ☠️ -{ci.coins_deducted}🪙
+                <div key={ci.id} className="grid items-center gap-x-2 py-1.5" style={{ gridTemplateColumns: '1fr auto auto 1.5rem' }}>
+                  <span className="text-sm truncate flex items-center gap-1.5 min-w-0">
+                    <span className="text-base flex-shrink-0">{kid.avatar}</span>
+                    <span className="text-white/50 flex-shrink-0">{kid.name}</span>
+                    <span className="text-white/35 truncate flex items-center gap-1"><span>{curse.icon}</span>{curse.title}</span>
                   </span>
+                  <span className="text-white/25 text-xs whitespace-nowrap">{ci.resolved_at ? formatQuestDate(ci.resolved_at.slice(0, 10)) : ''}</span>
+                  <span className="text-xs font-semibold text-red-400 whitespace-nowrap">☠️ -{ci.coins_deducted}🪙</span>
                   <button
                     onClick={() => actions.undoResolvedCurse(ci.id)}
-                    className="text-xs text-white/20 hover:text-cq-gold transition-all flex-shrink-0 ml-1"
+                    className="text-xs text-white/20 hover:text-cq-gold transition-all text-center w-6"
                     title="Undo"
                   >
                     ↩
@@ -184,17 +185,17 @@ export function ApprovalsTab({
             const reward = r.reward as Reward | undefined
             if (!kid || !reward) return null
             return (
-              <div key={r.id} className="flex items-center gap-3 py-2">
-                <span className="text-lg">{kid.avatar}</span>
-                <span className="text-white/50 text-sm">{kid.name}</span>
-                <span className="text-white/35 text-sm flex-1 truncate flex items-center gap-1.5"><span>{reward.icon}</span> {reward.title}</span>
-                <span className="text-white/25 text-xs flex-shrink-0">{formatQuestDate(r.redeemed_at.slice(0, 10))}</span>
-                <span className="text-xs font-semibold flex-shrink-0 text-cq-gold">
-                  🎁 -{reward.cost}🪙
+              <div key={r.id} className="grid items-center gap-x-2 py-1.5" style={{ gridTemplateColumns: '1fr auto auto 1.5rem' }}>
+                <span className="text-sm truncate flex items-center gap-1.5 min-w-0">
+                  <span className="text-base flex-shrink-0">{kid.avatar}</span>
+                  <span className="text-white/50 flex-shrink-0">{kid.name}</span>
+                  <span className="text-white/35 truncate flex items-center gap-1"><span>{reward.icon}</span>{reward.title}</span>
                 </span>
+                <span className="text-white/25 text-xs whitespace-nowrap">{formatQuestDate(r.redeemed_at.slice(0, 10))}</span>
+                <span className="text-xs font-semibold text-cq-gold whitespace-nowrap">🎁 -{reward.cost}🪙</span>
                 <button
                   onClick={() => actions.undoRedemption(r.id)}
-                  className="text-xs text-white/20 hover:text-cq-gold transition-all flex-shrink-0 ml-1"
+                  className="text-xs text-white/20 hover:text-cq-gold transition-all text-center w-6"
                   title="Undo"
                 >
                   ↩

--- a/src/app/parent/approvals-tab.tsx
+++ b/src/app/parent/approvals-tab.tsx
@@ -145,7 +145,7 @@ export function ApprovalsTab({
                     <span className="text-white/35 truncate">{(c.quest as Quest)?.title}</span>
                   </span>
                   <span className="text-white/25 text-xs whitespace-nowrap">{formatQuestDate(c.date)}</span>
-                  <StatusChip status={c.status === 'approved' ? 'approved' : 'rejected'} />
+                  <StatusChip status={c.status} />
                   <button
                     onClick={() => c.status === 'approved' ? actions.undoApproval(c.id) : actions.undoRejection(c.id)}
                     className="text-xs text-white/20 hover:text-cq-gold transition-all text-center w-6"

--- a/src/app/parent/page.tsx
+++ b/src/app/parent/page.tsx
@@ -65,13 +65,13 @@ export default function ParentDashboard() {
     )
   }
 
-  const tabs: { id: Tab; label: string; badge?: number }[] = [
-    { id: 'approvals', label: '✓ Approvals', badge: pendingCompletions.length + pendingRedemptions.length },
-    { id: 'quests', label: '⚔️ Quests' },
-    { id: 'rewards', label: '🎁 Rewards' },
-    { id: 'curses', label: '☠️ Curses', badge: data.activeCurseInstances.length || undefined },
-    { id: 'dungeons', label: '🏰 Dungeons' },
-    { id: 'family', label: '👨‍👩‍👧 Family' },
+  const tabs: { id: Tab; icon: string; label: string; badge?: number }[] = [
+    { id: 'approvals', icon: '✓', label: 'Approvals', badge: pendingCompletions.length + pendingRedemptions.length },
+    { id: 'quests', icon: '⚔️', label: 'Quests' },
+    { id: 'rewards', icon: '🎁', label: 'Rewards' },
+    { id: 'curses', icon: '☠️', label: 'Curses', badge: data.activeCurseInstances.length || undefined },
+    { id: 'dungeons', icon: '🏰', label: 'Dungeons' },
+    { id: 'family', icon: '👨‍👩‍👧', label: 'Family' },
   ]
 
   const qrKid = qrKidId ? data.kids.find((k) => k.id === qrKidId) ?? null : null
@@ -117,21 +117,34 @@ export default function ParentDashboard() {
             <button
               key={t.id}
               onClick={() => setTab(t.id)}
-              className="flex-1 min-w-0 flex items-center justify-center gap-1.5 px-3 py-2 rounded-xl text-sm font-semibold transition-all"
+              className="relative flex-1 min-w-0 flex items-center justify-center gap-1.5 px-1 sm:px-3 py-2 rounded-xl text-sm font-semibold transition-all"
               style={{
                 background: tab === t.id ? 'rgba(251,191,36,0.14)' : 'rgba(255,255,255,0.05)',
                 border: `1px solid ${tab === t.id ? 'rgba(251,191,36,0.35)' : 'rgba(255,255,255,0.08)'}`,
                 color: tab === t.id ? '#fbbf24' : 'rgba(255,255,255,0.5)',
               }}
             >
-              {t.label}
+              {/* Mobile: icon only */}
+              <span className="sm:hidden">{t.icon}</span>
+              {/* Desktop: icon + label */}
+              <span className="hidden sm:inline">{t.icon} {t.label}</span>
+              {/* Desktop badge: inline pill */}
               {t.badge && t.badge > 0 ? (
-                <span
-                  className="px-1.5 py-0.5 rounded-full text-xs font-bold"
-                  style={{ background: '#fbbf24', color: '#0a0620' }}
-                >
-                  {t.badge}
-                </span>
+                <>
+                  <span
+                    className="hidden sm:inline px-1.5 py-0.5 rounded-full text-xs font-bold"
+                    style={{ background: '#fbbf24', color: '#0a0620' }}
+                  >
+                    {t.badge}
+                  </span>
+                  {/* Mobile badge: corner dot */}
+                  <span
+                    className="sm:hidden absolute top-0.5 right-0.5 min-w-[14px] h-[14px] flex items-center justify-center rounded-full text-[8px] font-bold leading-none px-0.5"
+                    style={{ background: '#fbbf24', color: '#0a0620' }}
+                  >
+                    {t.badge}
+                  </span>
+                </>
               ) : null}
             </button>
           ))}

--- a/src/app/parent/quest-row.tsx
+++ b/src/app/parent/quest-row.tsx
@@ -3,8 +3,9 @@
 import { useState } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import type { Kid, Quest, QuestKind, QuestTier } from '@/lib/types'
-import { TIER_CONFIG } from '@/lib/constants'
 import { QuestFormFields, type QuestFormState } from './quest-form'
+import { TierBadge } from '@/components/ui/tier-badge'
+import { KindBadge } from '@/components/ui/kind-badge'
 
 interface Props {
   quest: Quest
@@ -12,12 +13,6 @@ interface Props {
   onToggle: (id: string, active: boolean) => void
   onDelete: (id: string) => void
   onSave: (id: string, updates: Partial<Quest>) => Promise<void>
-}
-
-const KIND_BADGE: Record<QuestKind, { label: string; color: string; bg: string; border: string } | null> = {
-  personal: null,
-  shared: { label: '⚡ Shared', color: '#fbbf24', bg: 'rgba(251,191,36,0.12)', border: 'rgba(251,191,36,0.25)' },
-  oneoff: { label: '⭐ One-time', color: '#a78bfa', bg: 'rgba(167,139,250,0.12)', border: 'rgba(167,139,250,0.2)' },
 }
 
 export function QuestRow({ quest, kids, onToggle, onDelete, onSave }: Props) {
@@ -38,8 +33,6 @@ export function QuestRow({ quest, kids, onToggle, onDelete, onSave }: Props) {
   const update = (patch: Partial<QuestFormState>) => setState((s) => ({ ...s, ...patch }))
 
   const assignedKid = kids.find((k) => k.id === quest.assigned_to)
-  const tierCfg = TIER_CONFIG[quest.tier ?? 'normal']
-  const kindBadge = KIND_BADGE[quest.kind]
 
   const handleSave = async () => {
     await onSave(quest.id, {
@@ -67,29 +60,15 @@ export function QuestRow({ quest, kids, onToggle, onDelete, onSave }: Props) {
       className="rounded-xl mb-2 overflow-hidden"
       style={{ background: 'rgba(255,255,255,0.03)', border: '1px solid rgba(255,255,255,0.07)' }}
     >
-      <div className="flex items-center gap-3 p-3">
-        <span className="text-xl">{quest.icon}</span>
+      <div className="flex items-start gap-3 p-3">
+        <span className="text-xl mt-0.5 flex-shrink-0">{quest.icon}</span>
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 flex-wrap">
             <p className={`text-sm font-semibold ${quest.active ? 'text-white/90' : 'text-white/40 line-through'}`}>
               {quest.title}
             </p>
-            {(quest.tier ?? 'normal') !== 'normal' && (
-              <span
-                className="text-xs px-1.5 py-0.5 rounded-md flex-shrink-0"
-                style={{ background: `${tierCfg.color}18`, color: tierCfg.color, border: `1px solid ${tierCfg.border}` }}
-              >
-                {tierCfg.label}
-              </span>
-            )}
-            {kindBadge && (
-              <span
-                className="text-xs px-1.5 py-0.5 rounded-md flex-shrink-0"
-                style={{ background: kindBadge.bg, color: kindBadge.color, border: `1px solid ${kindBadge.border}` }}
-              >
-                {kindBadge.label}
-              </span>
-            )}
+            <TierBadge tier={quest.tier} />
+            <KindBadge kind={quest.kind} />
           </div>
           <p className="text-white/35 text-xs">
             🪙 {quest.coins} · {assignedKid ? assignedKid.name : 'All kids'} · {cadenceLabel}
@@ -98,32 +77,34 @@ export function QuestRow({ quest, kids, onToggle, onDelete, onSave }: Props) {
               : ''}
           </p>
         </div>
-        <button
-          onClick={() => setEditing((e) => !e)}
-          className="text-xs px-2.5 py-1 rounded-lg transition-all"
-          style={{
-            background: editing ? 'rgba(251,191,36,0.12)' : 'rgba(255,255,255,0.05)',
-            color: editing ? '#fbbf24' : 'rgba(255,255,255,0.4)',
-          }}
-        >
-          ✏️
-        </button>
-        <button
-          onClick={() => onToggle(quest.id, quest.active)}
-          className="text-xs px-2.5 py-1 rounded-lg transition-all"
-          style={{
-            background: quest.active ? 'rgba(74,222,128,0.1)' : 'rgba(255,255,255,0.05)',
-            color: quest.active ? '#4ade80' : 'rgba(255,255,255,0.35)',
-          }}
-        >
-          {quest.active ? 'On' : 'Off'}
-        </button>
-        <button
-          onClick={() => onDelete(quest.id)}
-          className="text-white/20 hover:text-red-400 transition-all text-xs ml-1"
-        >
-          ✕
-        </button>
+        <div className="flex gap-1 flex-shrink-0 self-start pt-0.5">
+          <button
+            onClick={() => setEditing((e) => !e)}
+            className="text-xs px-2.5 py-1 rounded-lg transition-all"
+            style={{
+              background: editing ? 'rgba(251,191,36,0.12)' : 'rgba(255,255,255,0.05)',
+              color: editing ? '#fbbf24' : 'rgba(255,255,255,0.4)',
+            }}
+          >
+            ✏️
+          </button>
+          <button
+            onClick={() => onToggle(quest.id, quest.active)}
+            className="text-xs px-2.5 py-1 rounded-lg transition-all"
+            style={{
+              background: quest.active ? 'rgba(74,222,128,0.1)' : 'rgba(255,255,255,0.05)',
+              color: quest.active ? '#4ade80' : 'rgba(255,255,255,0.35)',
+            }}
+          >
+            {quest.active ? 'On' : 'Off'}
+          </button>
+          <button
+            onClick={() => onDelete(quest.id)}
+            className="text-white/20 hover:text-red-400 transition-all text-xs ml-0.5"
+          >
+            ✕
+          </button>
+        </div>
       </div>
 
       <AnimatePresence>

--- a/src/components/kid-column.tsx
+++ b/src/components/kid-column.tsx
@@ -133,19 +133,21 @@ export function KidColumn({
           </div>
         </div>
 
-        <div className="flex items-center gap-2">
-          {kid.streak > 1 && <StreakBadge streak={kid.streak} />}
-          {activeCurseCount > 0 && (
-            <motion.span
-              className="text-xs px-2 py-0.5 rounded-full font-bold"
-              style={{ background: 'rgba(239,68,68,0.2)', border: '1px solid rgba(239,68,68,0.35)', color: '#f87171' }}
-              animate={{ scale: [1, 1.06, 1] }}
-              transition={{ duration: 2, repeat: Infinity }}
-            >
-              ☠️ {activeCurseCount} curse{activeCurseCount > 1 ? 's' : ''}
-            </motion.span>
-          )}
-        </div>
+        {(kid.streak > 1 || activeCurseCount > 0) && (
+          <div className="flex items-center gap-2">
+            {kid.streak > 1 && <StreakBadge streak={kid.streak} />}
+            {activeCurseCount > 0 && (
+              <motion.span
+                className="text-xs px-2 py-0.5 rounded-full font-bold"
+                style={{ background: 'rgba(239,68,68,0.2)', border: '1px solid rgba(239,68,68,0.35)', color: '#f87171' }}
+                animate={{ scale: [1, 1.06, 1] }}
+                transition={{ duration: 2, repeat: Infinity }}
+              >
+                ☠️ {activeCurseCount} curse{activeCurseCount > 1 ? 's' : ''}
+              </motion.span>
+            )}
+          </div>
+        )}
 
         {/* Progress bar */}
         {totalCount > 0 && (

--- a/src/components/quest-card.tsx
+++ b/src/components/quest-card.tsx
@@ -5,6 +5,8 @@ import { motion, AnimatePresence } from 'framer-motion'
 import type { Quest, Completion, KidColor } from '@/lib/types'
 import { KID_COLORS, TIER_CONFIG } from '@/lib/constants'
 import { CoinBurst } from './coin-burst'
+import { StatusChip } from './ui/status-chip'
+import { TierBadge } from './ui/tier-badge'
 
 interface QuestCardProps {
   quest: Quest
@@ -57,6 +59,12 @@ export function QuestCard({
   const isPending = status === 'pending'
   const isApproved = status === 'approved'
   const isRejected = status === 'rejected'
+
+  const statusChipStatus = isPending ? 'pending'
+    : isApproved ? 'approved'
+    : isRejected ? 'rejected'
+    : isShareLocked ? 'locked'
+    : null
 
   const tier = TIER_CONFIG[quest.tier ?? 'normal']
   const isNormal = (quest.tier ?? 'normal') === 'normal'
@@ -157,8 +165,8 @@ export function QuestCard({
       )}
 
       <div className="p-4">
-        <div className="flex items-start gap-3">
-          <span className="text-2xl leading-none mt-0.5 flex-shrink-0">{quest.icon}</span>
+        <div className="flex items-center gap-3">
+          <span className="text-2xl leading-none flex-shrink-0">{quest.icon}</span>
 
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-1.5 flex-wrap">
@@ -169,14 +177,7 @@ export function QuestCard({
               >
                 {quest.title}
               </p>
-              {!isNormal && (
-                <span
-                  className="text-xs px-1.5 py-0.5 rounded-md font-bold flex-shrink-0"
-                  style={{ background: `${tier.color}18`, color: tier.color, border: `1px solid ${tier.color}40` }}
-                >
-                  {tier.label}
-                </span>
-              )}
+              <TierBadge tier={quest.tier} />
             </div>
 
             {quest.description && (
@@ -216,31 +217,14 @@ export function QuestCard({
             )}
           </div>
 
-          <div className="flex-shrink-0 text-right">
-            <div className="flex items-center gap-1 justify-end">
+          <div className="flex flex-col items-end gap-1 flex-shrink-0">
+            <div className="flex items-center gap-1">
               <span className="text-sm">🪙</span>
               <span className="font-heading font-bold text-sm" style={{ color: isNormal ? '#fbbf24' : tier.color }}>
                 {quest.coins}
               </span>
             </div>
-            {isPending && (
-              <motion.p
-                className="text-xs text-amber-400 mt-0.5"
-                animate={{ opacity: [0.5, 1, 0.5] }}
-                transition={{ duration: 1.6, repeat: Infinity }}
-              >
-                awaiting...
-              </motion.p>
-            )}
-            {isApproved && !isPending && (
-              <p className="text-xs text-cq-forest mt-0.5">✓ done!</p>
-            )}
-            {isRejected && (
-              <p className="text-xs text-red-400 mt-0.5">✗ retry</p>
-            )}
-            {isShareLocked && (
-              <p className="text-xs text-white/30 mt-0.5">claimed</p>
-            )}
+            {statusChipStatus && <StatusChip status={statusChipStatus} />}
           </div>
         </div>
 

--- a/src/components/ui/__tests__/status-chip.test.tsx
+++ b/src/components/ui/__tests__/status-chip.test.tsx
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+import React from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen } from '@testing-library/react'
+
+vi.mock('framer-motion', () => ({
+  motion: new Proxy({}, {
+    get: (_target, prop: string) => {
+      const Tag = prop as keyof JSX.IntrinsicElements
+      return ({ children, ...rest }: React.HTMLAttributes<HTMLElement> & { children?: React.ReactNode }) =>
+        React.createElement(Tag, rest, children)
+    },
+  }),
+}))
+
+import { StatusChip } from '../status-chip'
+
+describe('StatusChip', () => {
+  it('renders "⏳ awaiting" for pending', () => {
+    render(<StatusChip status="pending" />)
+    expect(screen.getByText('⏳ awaiting')).toBeInTheDocument()
+  })
+
+  it('renders "✓ done" for approved', () => {
+    render(<StatusChip status="approved" />)
+    expect(screen.getByText('✓ done')).toBeInTheDocument()
+  })
+
+  it('renders "✗ retry" for rejected', () => {
+    render(<StatusChip status="rejected" />)
+    expect(screen.getByText('✗ retry')).toBeInTheDocument()
+  })
+
+  it('renders "claimed" for locked', () => {
+    render(<StatusChip status="locked" />)
+    expect(screen.getByText('claimed')).toBeInTheDocument()
+  })
+})

--- a/src/components/ui/__tests__/status-chip.test.tsx
+++ b/src/components/ui/__tests__/status-chip.test.tsx
@@ -7,9 +7,10 @@ import { render, screen } from '@testing-library/react'
 vi.mock('framer-motion', () => ({
   motion: new Proxy({}, {
     get: (_target, prop: string) => {
-      const Tag = prop as keyof JSX.IntrinsicElements
-      return ({ children, ...rest }: React.HTMLAttributes<HTMLElement> & { children?: React.ReactNode }) =>
-        React.createElement(Tag, rest, children)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const Tag = prop as any
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return ({ children, ...rest }: any) => React.createElement(Tag, rest, children)
     },
   }),
 }))

--- a/src/components/ui/kind-badge.tsx
+++ b/src/components/ui/kind-badge.tsx
@@ -1,0 +1,29 @@
+import type { QuestKind } from '@/lib/types'
+
+const KIND_CONFIG: Partial<Record<QuestKind, { label: string; color: string; bg: string; border: string }>> = {
+  shared: {
+    label: '⚡ Shared',
+    color: '#fbbf24',
+    bg: 'rgba(251,191,36,0.12)',
+    border: 'rgba(251,191,36,0.25)',
+  },
+  oneoff: {
+    label: '⭐ One-time',
+    color: '#a78bfa',
+    bg: 'rgba(167,139,250,0.12)',
+    border: 'rgba(167,139,250,0.2)',
+  },
+}
+
+export function KindBadge({ kind }: { kind: QuestKind }) {
+  const cfg = KIND_CONFIG[kind]
+  if (!cfg) return null
+  return (
+    <span
+      className="text-[10px] px-1.5 py-0.5 rounded-md flex-shrink-0"
+      style={{ background: cfg.bg, color: cfg.color, border: `1px solid ${cfg.border}` }}
+    >
+      {cfg.label}
+    </span>
+  )
+}

--- a/src/components/ui/status-chip.tsx
+++ b/src/components/ui/status-chip.tsx
@@ -1,0 +1,65 @@
+'use client'
+
+import { motion } from 'framer-motion'
+
+type StatusChipStatus = 'pending' | 'approved' | 'rejected' | 'locked'
+
+const CHIP_CONFIG: Record<StatusChipStatus, {
+  label: string
+  bg: string
+  border: string
+  color: string
+  pulse?: true
+}> = {
+  pending: {
+    label: '⏳ awaiting',
+    bg: 'rgba(251,191,36,0.15)',
+    border: 'rgba(251,191,36,0.3)',
+    color: '#fbbf24',
+    pulse: true,
+  },
+  approved: {
+    label: '✓ done',
+    bg: 'rgba(74,222,128,0.12)',
+    border: 'rgba(74,222,128,0.3)',
+    color: '#4ade80',
+  },
+  rejected: {
+    label: '✗ retry',
+    bg: 'rgba(239,68,68,0.12)',
+    border: 'rgba(239,68,68,0.3)',
+    color: '#f87171',
+  },
+  locked: {
+    label: 'claimed',
+    bg: 'rgba(255,255,255,0.05)',
+    border: 'rgba(255,255,255,0.1)',
+    color: 'rgba(255,255,255,0.3)',
+  },
+}
+
+const chipClass = 'text-[10px] px-2 py-0.5 rounded-full whitespace-nowrap font-semibold'
+
+export function StatusChip({ status }: { status: StatusChipStatus }) {
+  const cfg = CHIP_CONFIG[status]
+  const style = { background: cfg.bg, border: `1px solid ${cfg.border}`, color: cfg.color }
+
+  if (cfg.pulse) {
+    return (
+      <motion.span
+        className={chipClass}
+        style={style}
+        animate={{ opacity: [0.5, 1, 0.5] }}
+        transition={{ duration: 1.6, repeat: Infinity }}
+      >
+        {cfg.label}
+      </motion.span>
+    )
+  }
+
+  return (
+    <span className={chipClass} style={style}>
+      {cfg.label}
+    </span>
+  )
+}

--- a/src/components/ui/status-chip.tsx
+++ b/src/components/ui/status-chip.tsx
@@ -49,8 +49,8 @@ export function StatusChip({ status }: { status: StatusChipStatus }) {
       <motion.span
         className={chipClass}
         style={style}
-        animate={{ opacity: [0.5, 1, 0.5] }}
-        transition={{ duration: 1.6, repeat: Infinity }}
+        animate={{ opacity: [0.5, 1] }}
+        transition={{ duration: 0.8, repeat: Infinity, repeatType: 'mirror', ease: 'easeInOut' }}
       >
         {cfg.label}
       </motion.span>

--- a/src/components/ui/tier-badge.tsx
+++ b/src/components/ui/tier-badge.tsx
@@ -1,0 +1,20 @@
+import type { QuestTier } from '@/lib/types'
+import { TIER_CONFIG } from '@/lib/constants'
+
+export function TierBadge({ tier }: { tier: QuestTier | null | undefined }) {
+  const resolved = tier ?? 'normal'
+  if (resolved === 'normal') return null
+  const cfg = TIER_CONFIG[resolved]
+  return (
+    <span
+      className="text-[10px] px-1.5 py-0.5 rounded-md font-bold flex-shrink-0"
+      style={{
+        background: `${cfg.color}18`,
+        color: cfg.color,
+        border: `1px solid ${cfg.color}40`,
+      }}
+    >
+      {cfg.label}
+    </span>
+  )
+}


### PR DESCRIPTION
## Summary

- **StatusChip**: new fixed-height pill component replacing raw status text in QuestCard and history rows — pending/approved/rejected/locked states with consistent sizing
- **TierBadge + KindBadge**: extracted from copy-pasted inline markup in QuestCard and QuestRow
- **QuestCard**: outer row `items-start` → `items-center`; right column restructured to `flex-col` with StatusChip; icon and coin amount now center-align with title regardless of how many tier badges wrap
- **Parent tab bar**: icon-only on mobile with corner badge dot; full label on desktop — eliminates badge overflow on narrow screens
- **QuestRow**: action buttons wrapped in `self-start` div so they pin to top when title wraps across multiple lines with badges
- **KidColumn header**: badge row only renders when streak or curse is actually present — removes phantom 8px gap on columns with neither
- **Approvals history rows**: switched from `flex` to CSS grid `[1fr_auto_auto_1.5rem]` — undo ↩ button always in the same fixed column regardless of status text width

## Test plan

- [ ] All 120 existing tests pass
- [ ] TypeScript compiles clean
- [ ] Build succeeds
- [ ] Visual: open `/display` with 2 kids — one with streak+curse, one without — confirm header card heights match
- [ ] Visual: open `/parent` on a narrow screen — confirm tab bar shows icons only with badge dots
- [ ] Visual: on a quest with LEGENDARY tier + pending status — confirm icon/coin/title center-align
- [ ] Visual: approvals history with a mix of completions/redemptions/curses — confirm ↩ button stays in the same column for every row

🤖 Generated with [Claude Code](https://claude.com/claude-code)