### PR TITLE
feat: keyboard input for PIN screens

### DIFF
--- a/src/app/kid/[id]/page.tsx
+++ b/src/app/kid/[id]/page.tsx
@@ -92,7 +92,7 @@ export default function KidPage({ params }: { params: Promise<{ id: string }> })
     return () => clearInterval(timerId)
   }, [lockedUntil])
 
-  const handlePinDigit = async (digit: string) => {
+  const handlePinDigit = useCallback(async (digit: string) => {
     if (lockedUntil && now < lockedUntil) return
     const next = pinInput + digit
     setPinInput(next)
@@ -122,7 +122,20 @@ export default function KidPage({ params }: { params: Promise<{ id: string }> })
         }, 700)
       }
     }
-  }
+  }, [lockedUntil, now, pinInput, pinAttempts, id])
+
+  useEffect(() => {
+    if (pinVerified) return
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key >= '0' && e.key <= '9') handlePinDigit(e.key)
+      if (e.key === 'Backspace' || e.key === 'Delete') {
+        setPinInput((p) => p.slice(0, -1))
+        setPinError(false)
+      }
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [pinVerified, handlePinDigit])
 
   const handleComplete = useCallback(
     async (questId: string) => {

--- a/src/app/parent/pin-lock-screen.tsx
+++ b/src/app/parent/pin-lock-screen.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useEffect } from 'react'
 import Link from 'next/link'
 import { motion } from 'framer-motion'
 import { StarField } from '@/components/star-field'
@@ -14,6 +15,15 @@ interface Props {
 }
 
 export function PinLockScreen({ lockPinInput, lockPinError, parentLockedUntil, now, onDigit, onBackspace }: Props) {
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key >= '0' && e.key <= '9' && lockPinInput.length < 4) onDigit(e.key)
+      if (e.key === 'Backspace' || e.key === 'Delete') onBackspace()
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [lockPinInput, onDigit, onBackspace])
+
   return (
     <div className="min-h-screen bg-quest-void flex items-center justify-center px-4">
       <StarField />


### PR DESCRIPTION
## Summary

- Physical keyboard now works on both PIN screens (kid PIN and parent lock screen)
- Digits 0–9 type into the PIN field; Backspace/Delete removes the last digit
- Kid PIN: `handlePinDigit` converted to `useCallback`; keyboard listener active only while PIN screen is shown (`!pinVerified`)
- Parent lock screen: keyboard listener added directly to `PinLockScreen` component
- Touchscreen button grid still works — keyboard is additive, not a replacement

## Test plan

- [ ] Open kid PIN screen on desktop — type digits 0-9, confirm they fill the dots
- [ ] Press Backspace — confirm last dot clears
- [ ] Type 4 digits — confirm PIN verification fires
- [ ] After PIN verified, confirm keyboard no longer intercepts digits (listener cleaned up)
- [ ] Repeat on parent lock screen via 🔒 button in parent dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)