### PR TITLE
Fix streak reset on batch approvals + move streak badge inline

### DIFF
--- a/src/app/parent/_streak.ts
+++ b/src/app/parent/_streak.ts
@@ -1,7 +1,13 @@
 export { getStreakBonus } from '@/lib/constants'
 
-export function yesterday(): string {
+/**
+ * Returns the quest-day before today, respecting resetHour.
+ * e.g. at 2 AM with resetHour=6, quest-today is still "yesterday" in calendar terms,
+ * so quest-yesterday is the day before that.
+ */
+export function yesterday(resetHour = 0): string {
   const d = new Date()
-  d.setDate(d.getDate() - 1)
+  if (d.getHours() < resetHour) d.setDate(d.getDate() - 1) // roll to quest-today
+  d.setDate(d.getDate() - 1) // one quest-day back
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
 }

--- a/src/app/parent/use-parent-actions.ts
+++ b/src/app/parent/use-parent-actions.ts
@@ -111,8 +111,14 @@ export function useParentActions(deps: Deps): ParentActions {
 
     const newXP = (freshKid?.xp ?? 0) + coinsAwarded
     const newLevel = getLevelFromXP(newXP)
-    const today = questDateString(family?.daily_reset_hour ?? 0)
-    const newStreak = freshKid?.last_completed_date === yesterday() ? (freshKid?.streak ?? 0) + 1 : 1
+    const resetHour = family?.daily_reset_hour ?? 0
+    const today = questDateString(resetHour)
+    // Preserve streak if already approved something today; increment if last was quest-yesterday; reset otherwise.
+    const newStreak = freshKid?.last_completed_date === today
+      ? (freshKid?.streak ?? 1)
+      : freshKid?.last_completed_date === yesterday(resetHour)
+      ? (freshKid?.streak ?? 0) + 1
+      : 1
 
     await supabase.from('kids').update({
       coins: (freshKid?.coins ?? 0) + coinsAwarded,

--- a/src/components/kid-column.tsx
+++ b/src/components/kid-column.tsx
@@ -106,9 +106,12 @@ export function KidColumn({
         )}
 
         <div className="text-center">
-          <h2 className="font-heading text-xl font-bold text-white/95 tracking-wide">
-            {kid.name}
-          </h2>
+          <div className="flex items-center justify-center gap-2">
+            <h2 className="font-heading text-xl font-bold text-white/95 tracking-wide">
+              {kid.name}
+            </h2>
+            {kid.streak > 1 && <StreakBadge streak={kid.streak} compact />}
+          </div>
           <p className="text-xs mt-0.5 font-medium" style={{ color: colors.primary }}>
             {getLevelTitle(kid.level ?? 1)} · Lv {kid.level ?? 1}
           </p>
@@ -133,20 +136,15 @@ export function KidColumn({
           </div>
         </div>
 
-        {(kid.streak > 1 || activeCurseCount > 0) && (
-          <div className="flex items-center gap-2">
-            {kid.streak > 1 && <StreakBadge streak={kid.streak} />}
-            {activeCurseCount > 0 && (
-              <motion.span
-                className="text-xs px-2 py-0.5 rounded-full font-bold"
-                style={{ background: 'rgba(239,68,68,0.2)', border: '1px solid rgba(239,68,68,0.35)', color: '#f87171' }}
-                animate={{ scale: [1, 1.06, 1] }}
-                transition={{ duration: 2, repeat: Infinity }}
-              >
-                ☠️ {activeCurseCount} curse{activeCurseCount > 1 ? 's' : ''}
-              </motion.span>
-            )}
-          </div>
+        {activeCurseCount > 0 && (
+          <motion.span
+            className="text-xs px-2 py-0.5 rounded-full font-bold"
+            style={{ background: 'rgba(239,68,68,0.2)', border: '1px solid rgba(239,68,68,0.35)', color: '#f87171' }}
+            animate={{ scale: [1, 1.06, 1] }}
+            transition={{ duration: 2, repeat: Infinity }}
+          >
+            ☠️ {activeCurseCount} curse{activeCurseCount > 1 ? 's' : ''}
+          </motion.span>
         )}
 
         {/* Progress bar */}


### PR DESCRIPTION
## Summary
- **Streak bug fix**: approving multiple quests in one session was resetting the streak to 1 after the first approval. Root cause: the second approval saw `last_completed_date === today` (just set by the first approval), which didn't match `yesterday()`, so `newStreak` was hardcoded to 1. Fix: three-way check — preserve if already approved today, increment if quest-yesterday, reset otherwise.
- **`yesterday()` resetHour fix**: the function ignored `daily_reset_hour`, causing an off-by-one when approving before the reset hour (e.g. 2 AM with a 6 AM reset). Now rolls to quest-today first, then subtracts one quest-day.
- **Header alignment**: streak badge moved from a standalone pill row (below XP bar) to compact inline next to the kid's name. Both header cards are now the same height regardless of streak state.

## Test plan
- [ ] Approving 3+ quests for the same kid in one session keeps the streak incrementing, not resetting to 1
- [ ] Streak increments correctly day-over-day (approve today → tomorrow's first approval goes +1)
- [ ] Streak resets to 1 if a day is genuinely skipped
- [ ] Streak badge appears next to the kid's name on the realm board (compact flame + number)
- [ ] Both kid header cards are the same height when one has a streak and one doesn't
- [ ] Curse badge still appears in its own row when active

🤖 Generated with [Claude Code](https://claude.com/claude-code)