### PR TITLE
Fix alignment: pinned action slot + fixed approvals grid

### DIFF
--- a/src/app/parent/approvals-tab.tsx
+++ b/src/app/parent/approvals-tab.tsx
@@ -138,7 +138,7 @@ export function ApprovalsTab({
               const kid = c.kid as Kid | undefined
               if (!kid) return null
               return (
-                <div key={c.id} className="grid items-center gap-x-2 py-1.5" style={{ gridTemplateColumns: '1fr auto auto 1.5rem' }}>
+                <div key={c.id} className="grid items-center gap-x-2 py-1.5" style={{ gridTemplateColumns: '1fr 5.5rem 6.5rem 1.5rem' }}>
                   <span className="text-sm truncate flex items-center gap-1.5 min-w-0">
                     <span className="text-base flex-shrink-0">{kid.avatar}</span>
                     <span className="text-white/50 flex-shrink-0">{kid.name}</span>
@@ -162,7 +162,7 @@ export function ApprovalsTab({
               const curse = ci.curse as Curse | undefined
               if (!kid || !curse) return null
               return (
-                <div key={ci.id} className="grid items-center gap-x-2 py-1.5" style={{ gridTemplateColumns: '1fr auto auto 1.5rem' }}>
+                <div key={ci.id} className="grid items-center gap-x-2 py-1.5" style={{ gridTemplateColumns: '1fr 5.5rem 6.5rem 1.5rem' }}>
                   <span className="text-sm truncate flex items-center gap-1.5 min-w-0">
                     <span className="text-base flex-shrink-0">{kid.avatar}</span>
                     <span className="text-white/50 flex-shrink-0">{kid.name}</span>
@@ -185,7 +185,7 @@ export function ApprovalsTab({
             const reward = r.reward as Reward | undefined
             if (!kid || !reward) return null
             return (
-              <div key={r.id} className="grid items-center gap-x-2 py-1.5" style={{ gridTemplateColumns: '1fr auto auto 1.5rem' }}>
+              <div key={r.id} className="grid items-center gap-x-2 py-1.5" style={{ gridTemplateColumns: '1fr 5.5rem 6.5rem 1.5rem' }}>
                 <span className="text-sm truncate flex items-center gap-1.5 min-w-0">
                   <span className="text-base flex-shrink-0">{kid.avatar}</span>
                   <span className="text-white/50 flex-shrink-0">{kid.name}</span>

--- a/src/components/quest-card.tsx
+++ b/src/components/quest-card.tsx
@@ -219,46 +219,51 @@ export function QuestCard({
             )}
           </div>
 
-          {/* Action: Done/Claim/Retry button OR status chip */}
-          {(isTodo || isRejected) && onComplete ? (
-            <motion.button
-              onClick={handleComplete}
-              disabled={loading}
-              className="text-sm px-4 py-1.5 rounded-xl font-bold flex-shrink-0 transition-all disabled:opacity-50"
-              style={{
-                background: `linear-gradient(135deg, rgba(${kidRgb}, 0.16), rgba(${kidRgb}, 0.06))`,
-                border: `1px solid ${colors.border}`,
-                color: colors.primary,
-              }}
-              whileHover={{ background: `linear-gradient(135deg, rgba(${kidRgb}, 0.26), rgba(${kidRgb}, 0.10))` }}
-              whileTap={{ scale: 0.95 }}
-            >
-              {actionBtnLabel}
-            </motion.button>
-          ) : (isPending || isApproved || isShareLocked) ? (
-            <div className="flex items-center gap-1.5 flex-shrink-0">
-              <StatusChip status={isPending ? 'pending' : isApproved ? 'approved' : 'locked'} />
-              {!isParent && isPending && onUndo && (
+          {/* Right side: fixed-width action slot + fixed-width coins — keeps coins pinned */}
+          <div className="flex items-center gap-2 flex-shrink-0">
+            {/* Action slot: min-width matches Done button so coins never shift */}
+            <div className="flex items-center justify-end gap-1.5 min-w-[88px]">
+              {(isTodo || isRejected) && onComplete ? (
                 <motion.button
-                  onClick={async () => { setLoading(true); await onUndo(); setLoading(false) }}
+                  onClick={handleComplete}
                   disabled={loading}
-                  className="text-sm text-white/25 transition-all disabled:opacity-40"
-                  whileHover={{ color: 'rgba(255,255,255,0.65)' }}
-                  whileTap={{ scale: 0.9 }}
-                  title="Undo submission"
+                  className="text-sm px-4 py-1.5 rounded-xl font-bold transition-all disabled:opacity-50"
+                  style={{
+                    background: `linear-gradient(135deg, rgba(${kidRgb}, 0.16), rgba(${kidRgb}, 0.06))`,
+                    border: `1px solid ${colors.border}`,
+                    color: colors.primary,
+                  }}
+                  whileHover={{ background: `linear-gradient(135deg, rgba(${kidRgb}, 0.26), rgba(${kidRgb}, 0.10))` }}
+                  whileTap={{ scale: 0.95 }}
                 >
-                  ↩
+                  {actionBtnLabel}
                 </motion.button>
-              )}
+              ) : (isPending || isApproved || isShareLocked) ? (
+                <>
+                  <StatusChip status={isPending ? 'pending' : isApproved ? 'approved' : 'locked'} />
+                  {!isParent && isPending && onUndo && (
+                    <motion.button
+                      onClick={async () => { setLoading(true); await onUndo(); setLoading(false) }}
+                      disabled={loading}
+                      className="text-sm text-white/25 transition-all disabled:opacity-40"
+                      whileHover={{ color: 'rgba(255,255,255,0.65)' }}
+                      whileTap={{ scale: 0.9 }}
+                      title="Undo submission"
+                    >
+                      ↩
+                    </motion.button>
+                  )}
+                </>
+              ) : null}
             </div>
-          ) : null}
 
-          {/* Coins */}
-          <div className="flex items-center gap-0.5 flex-shrink-0">
-            <span className="text-sm">🪙</span>
-            <span className="font-heading font-bold text-sm" style={{ color: isNormal ? '#fbbf24' : tier.color }}>
-              {quest.coins}
-            </span>
+            {/* Coins: fixed width so action state never affects position */}
+            <div className="flex items-center gap-0.5 w-12 justify-end">
+              <span className="text-sm">🪙</span>
+              <span className="font-heading font-bold text-sm" style={{ color: isNormal ? '#fbbf24' : tier.color }}>
+                {quest.coins}
+              </span>
+            </div>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- **Quest card**: action slot (`⚔️ Done` button ↔ `✓ done` chip) wrapped in a `min-w-[88px] justify-end` container so the chip right-aligns within the same space the button occupies. Coins get `w-12 justify-end` — pinned regardless of which action state renders.
- **Approvals tab**: history grid was `1fr auto auto 1.5rem` — `auto` columns let the date and status columns resize independently per row, drifting the undo `↩` button. Changed to `1fr 5.5rem 6.5rem 1.5rem` so all row types (completion, curse, redemption) lock to the same column positions.

## Test plan
- [ ] Quest card: approved row (`✓ done` chip) — coins at same x-position as todo row (`⚔️ Done` button)
- [ ] Quest card: pending row (`⏳ awaiting` chip + `↩`) — coins still pinned
- [ ] Quest card: share-locked row (`claimed` chip) — coins still pinned
- [ ] Approvals tab: scroll through a mix of completion/curse/redemption history rows — undo `↩` button stays in the same column

🤖 Generated with [Claude Code](https://claude.com/claude-code)