### PR TITLE
Fix hover clipping: replace scale with box-shadow glow

### DIFF
--- a/src/components/quest-card.tsx
+++ b/src/components/quest-card.tsx
@@ -117,8 +117,8 @@ export function QuestCard({
         backdropFilter: 'blur(10px)',
         opacity: isShareLocked ? 0.45 : 1,
       }}
-      whileHover={isTodo && onComplete ? { scale: 1.015 } : {}}
-      whileTap={isTodo && onComplete ? { scale: 0.985 } : {}}
+      whileHover={isTodo && onComplete ? { boxShadow: `0 0 0 2px rgba(${kidRgb}, 0.5), 0 8px 28px rgba(${kidRgb}, 0.18)` } : {}}
+      whileTap={isTodo && onComplete ? { boxShadow: `0 0 0 1px rgba(${kidRgb}, 0.3)` } : {}}
       layout
       transition={{ type: 'spring', stiffness: 400, damping: 30 }}
     >


### PR DESCRIPTION
## Summary
`whileHover={{ scale: 1.015 }}` pushed the card beyond its container's overflow boundary, clipping the rounded edges. Replaced with a colored box-shadow ring that gives the same interactive feedback without changing the card's dimensions — clipping is impossible since box-shadow never affects layout or overflow.

## Test plan
- [ ] Hover a todo quest card — colored glow ring appears, edges stay crisp
- [ ] No edge clipping at the top/bottom of the quest list
- [ ] Tap feedback (slight shadow reduction) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)