### PR TITLE
Add coin ledger: full transaction history for kids and parents

### DIFF
--- a/src/app/api/kid/[id]/ledger/route.ts
+++ b/src/app/api/kid/[id]/ledger/route.ts
@@ -1,0 +1,24 @@
+import { createServiceClient } from '@/lib/supabase/service'
+import { buildLedger } from '@/lib/ledger'
+import { NextRequest } from 'next/server'
+
+export type { LedgerEntry } from '@/lib/ledger'
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+  const supabase = createServiceClient()
+
+  const { data: kid } = await supabase
+    .from('kids')
+    .select('id, coins, family_id')
+    .eq('id', id)
+    .single()
+
+  if (!kid) return Response.json({ error: 'Not found' }, { status: 404 })
+
+  const { ledger } = await buildLedger(id, kid.coins)
+  return Response.json({ ledger, currentBalance: kid.coins })
+}

--- a/src/app/api/parent/kids/[kidId]/ledger/route.ts
+++ b/src/app/api/parent/kids/[kidId]/ledger/route.ts
@@ -1,0 +1,37 @@
+import { createClient } from '@/lib/supabase/server'
+import { createServiceClient } from '@/lib/supabase/service'
+import { NextRequest } from 'next/server'
+import { buildLedger } from '@/lib/ledger'
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ kidId: string }> }
+) {
+  const { kidId } = await params
+
+  const userClient = await createClient()
+  const { data: { user } } = await userClient.auth.getUser()
+  if (!user) return Response.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const supabase = createServiceClient()
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('family_id')
+    .eq('id', user.id)
+    .single()
+  if (!profile) return Response.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const { data: kid } = await supabase
+    .from('kids')
+    .select('id, coins, family_id, name')
+    .eq('id', kidId)
+    .single()
+
+  if (!kid || kid.family_id !== profile.family_id) {
+    return Response.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const { ledger } = await buildLedger(kidId, kid.coins)
+  return Response.json({ ledger, currentBalance: kid.coins, kidName: kid.name })
+}

--- a/src/app/kid/[id]/page.tsx
+++ b/src/app/kid/[id]/page.tsx
@@ -15,6 +15,8 @@ import { KID_COLORS, getLockDurationMs } from '@/lib/constants'
 import { questDateString, questWeekKey } from '@/lib/utils'
 import { isQuestVisibleToKid, kidHasActiveCompletion, sharedClaimedCount, kidCompletionForPeriod } from '@/lib/quest-rules'
 import { toast } from 'sonner'
+import { CoinLedger } from '@/components/coin-ledger'
+import type { LedgerEntry } from '@/lib/ledger'
 
 const PIN_SESSION_KEY = 'cq_kid_pin_'
 
@@ -35,7 +37,7 @@ export default function KidPage({ params }: { params: Promise<{ id: string }> })
   const [data, setData] = useState<KidDataPayload | null>(null)
   const prevPendingIdsRef = useRef<string[]>([])
   const isFirstFetchRef = useRef(true)
-  const [tab, setTab] = useState<'quests' | 'bounty' | 'rewards'>('quests')
+  const [tab, setTab] = useState<'quests' | 'bounty' | 'rewards' | 'history'>('quests')
   const [pinVerified, setPinVerified] = useState(() =>
     typeof window !== 'undefined'
       ? sessionStorage.getItem(PIN_SESSION_KEY + id) === 'verified'
@@ -397,8 +399,8 @@ export default function KidPage({ params }: { params: Promise<{ id: string }> })
         </motion.header>
 
         <div className="flex px-6 gap-2 mb-4 flex-shrink-0">
-          {(['quests', 'bounty', 'rewards'] as const).map((t) => {
-            const labels = { quests: '⚔️ Quests', bounty: '⚡ Bounty', rewards: '🎁 Rewards' }
+          {(['quests', 'bounty', 'rewards', 'history'] as const).map((t) => {
+            const labels = { quests: '⚔️ Quests', bounty: '⚡ Bounty', rewards: '🎁 Rewards', history: '📒 History' }
             const badge = t === 'quests' && pendingCompletions.length > 0
               ? pendingCompletions.length
               : t === 'bounty' && availableBountyCount > 0
@@ -528,6 +530,8 @@ export default function KidPage({ params }: { params: Promise<{ id: string }> })
                 onComplete={handleComplete}
                 onUndo={handleUndo}
               />
+            ) : tab === 'history' ? (
+              <HistoryTab key="history" kidId={id} kidColor={kid.color} />
             ) : (
               <RewardsTab
                 rewards={rewards}
@@ -870,4 +874,53 @@ function BountyTab({
 
 function kidColorRgb(color: string) {
   return color === 'azure' ? '56,189,248' : '167,139,250'
+}
+
+function HistoryTab({ kidId, kidColor }: { kidId: string; kidColor: 'azure' | 'mystic' }) {
+  const [ledger, setLedger] = useState<LedgerEntry[]>([])
+  const [balance, setBalance] = useState(0)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    fetch(`/api/kid/${kidId}/ledger`)
+      .then(r => r.json())
+      .then(d => {
+        setLedger(d.ledger ?? [])
+        setBalance(d.currentBalance ?? 0)
+      })
+      .finally(() => setLoading(false))
+  }, [kidId])
+
+  if (loading) {
+    return (
+      <motion.div
+        key="history"
+        className="flex items-center justify-center py-16"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        transition={{ duration: 0.2 }}
+      >
+        <motion.p
+          className="font-heading text-xl text-white/30"
+          animate={{ opacity: [0.3, 0.7, 0.3] }}
+          transition={{ duration: 1.6, repeat: Infinity }}
+        >
+          ✦ Loading ✦
+        </motion.p>
+      </motion.div>
+    )
+  }
+
+  return (
+    <motion.div
+      key="history"
+      initial={{ opacity: 0, x: 10 }}
+      animate={{ opacity: 1, x: 0 }}
+      exit={{ opacity: 0, x: -10 }}
+      transition={{ duration: 0.2 }}
+    >
+      <CoinLedger ledger={ledger} currentBalance={balance} kidColor={kidColor} />
+    </motion.div>
+  )
 }

--- a/src/app/parent/family-tab.tsx
+++ b/src/app/parent/family-tab.tsx
@@ -8,6 +8,8 @@ import { KID_AVATARS, KID_COLORS } from '@/lib/constants'
 import { PLAN_LABELS, PLAN_LIMITS } from '@/lib/plans'
 import { ActionButton, Empty, FormInput, Section, fadeSlide } from './_ui'
 import type { ParentActions } from './use-parent-actions'
+import { CoinLedger } from '@/components/coin-ledger'
+import type { LedgerEntry } from '@/lib/ledger'
 
 const RESET_HOUR_PRESETS = [0, 3, 5, 6] as const
 
@@ -278,6 +280,24 @@ function KidList({ kids, onShowQr, actions }: { kids: Kid[]; onShowQr: (kidId: s
   const [editingCoinsKidId, setEditingCoinsKidId] = useState<string | null>(null)
   const [editCoinsValue, setEditCoinsValue] = useState('')
   const [revealPinKidId, setRevealPinKidId] = useState<string | null>(null)
+  const [ledgerKid, setLedgerKid] = useState<Kid | null>(null)
+  const [ledger, setLedger] = useState<LedgerEntry[]>([])
+  const [ledgerBalance, setLedgerBalance] = useState(0)
+  const [ledgerLoading, setLedgerLoading] = useState(false)
+
+  const openLedger = async (kid: Kid) => {
+    setLedgerKid(kid)
+    setLedgerLoading(true)
+    setLedger([])
+    try {
+      const res = await fetch(`/api/parent/kids/${kid.id}/ledger`)
+      const data = await res.json()
+      setLedger(data.ledger ?? [])
+      setLedgerBalance(data.currentBalance ?? kid.coins)
+    } finally {
+      setLedgerLoading(false)
+    }
+  }
 
   const handleSaveCoins = async (kidId: string) => {
     const val = parseInt(editCoinsValue, 10)
@@ -352,6 +372,13 @@ function KidList({ kids, onShowQr, actions }: { kids: Kid[]; onShowQr: (kidId: s
                     {revealPinKidId === kid.id ? `PIN: ${kid.pin}` : 'PIN: ····'}
                   </button>
                   <button
+                    onClick={() => openLedger(kid)}
+                    className="text-lg hover:scale-110 transition-all"
+                    title="View coin ledger"
+                  >
+                    📒
+                  </button>
+                  <button
                     onClick={() => onShowQr(kid.id)}
                     className="text-lg hover:scale-110 transition-all"
                     title="Show QR code"
@@ -363,6 +390,69 @@ function KidList({ kids, onShowQr, actions }: { kids: Kid[]; onShowQr: (kidId: s
             )
           })}
         </div>
+      )}
+
+      {/* Per-kid ledger modal */}
+      {ledgerKid && (
+        <motion.div
+          className="fixed inset-0 z-50 flex items-center justify-center"
+          style={{ background: 'rgba(0,0,0,0.8)', backdropFilter: 'blur(10px)' }}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          onClick={() => setLedgerKid(null)}
+        >
+          <motion.div
+            className="rounded-3xl mx-4 w-full max-w-md overflow-hidden"
+            style={{
+              background: 'rgba(10,6,28,0.98)',
+              border: '1px solid rgba(251,191,36,0.18)',
+              boxShadow: '0 0 80px rgba(0,0,0,0.7)',
+              maxHeight: '80vh',
+              display: 'flex',
+              flexDirection: 'column',
+            }}
+            initial={{ scale: 0.88, opacity: 0, y: 20 }}
+            animate={{ scale: 1, opacity: 1, y: 0 }}
+            exit={{ scale: 0.88, opacity: 0, y: 20 }}
+            transition={{ type: 'spring', stiffness: 340, damping: 28 }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="px-6 pt-5 pb-4 flex-shrink-0 flex items-center justify-between"
+              style={{ borderBottom: '1px solid rgba(255,255,255,0.06)' }}
+            >
+              <div>
+                <h2 className="font-heading text-lg font-bold text-white/90">
+                  {ledgerKid.avatar} {ledgerKid.name}&apos;s Ledger
+                </h2>
+                <p className="text-white/35 text-xs mt-0.5">Full coin transaction history</p>
+              </div>
+              <button
+                onClick={() => setLedgerKid(null)}
+                className="w-8 h-8 rounded-full flex items-center justify-center text-white/30 hover:text-white/60 transition-all"
+                style={{ background: 'rgba(255,255,255,0.05)', border: '1px solid rgba(255,255,255,0.08)' }}
+              >
+                ✕
+              </button>
+            </div>
+
+            <div className="overflow-y-auto px-6 py-4 flex-1">
+              {ledgerLoading ? (
+                <div className="flex items-center justify-center py-16">
+                  <motion.p
+                    className="font-heading text-xl text-white/30"
+                    animate={{ opacity: [0.3, 0.7, 0.3] }}
+                    transition={{ duration: 1.6, repeat: Infinity }}
+                  >
+                    ✦ Loading ✦
+                  </motion.p>
+                </div>
+              ) : (
+                <CoinLedger ledger={ledger} currentBalance={ledgerBalance} kidColor={ledgerKid.color} />
+              )}
+            </div>
+          </motion.div>
+        </motion.div>
       )}
     </Section>
   )

--- a/src/components/coin-ledger.tsx
+++ b/src/components/coin-ledger.tsx
@@ -1,0 +1,145 @@
+'use client'
+
+import { motion } from 'framer-motion'
+import type { LedgerEntry } from '@/lib/ledger'
+
+interface CoinLedgerProps {
+  ledger: LedgerEntry[]
+  currentBalance: number
+  kidColor?: 'azure' | 'mystic'
+}
+
+const KIND_LABEL: Record<LedgerEntry['kind'], string> = {
+  quest_reward: 'Quest reward',
+  quest_rejected: 'Quest rejected',
+  reward_redeemed: 'Reward redeemed',
+  reward_denied: 'Reward denied',
+  curse: 'Curse applied',
+}
+
+function formatDate(iso: string): string {
+  if (!iso) return ''
+  const d = new Date(iso)
+  const today = new Date()
+  const yesterday = new Date(today)
+  yesterday.setDate(today.getDate() - 1)
+
+  if (d.toDateString() === today.toDateString()) return 'Today'
+  if (d.toDateString() === yesterday.toDateString()) return 'Yesterday'
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: d.getFullYear() !== today.getFullYear() ? 'numeric' : undefined })
+}
+
+function formatTime(iso: string): string {
+  if (!iso) return ''
+  return new Date(iso).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })
+}
+
+function groupByDate(ledger: LedgerEntry[]): Array<{ dateLabel: string; entries: LedgerEntry[] }> {
+  const groups = new Map<string, LedgerEntry[]>()
+  for (const entry of ledger) {
+    const label = formatDate(entry.occurred_at)
+    if (!groups.has(label)) groups.set(label, [])
+    groups.get(label)!.push(entry)
+  }
+  return Array.from(groups.entries()).map(([dateLabel, entries]) => ({ dateLabel, entries }))
+}
+
+export function CoinLedger({ ledger, currentBalance, kidColor = 'azure' }: CoinLedgerProps) {
+  const primaryColor = kidColor === 'azure' ? '#38bdf8' : '#a78bfa'
+
+  if (ledger.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-16 text-white/25">
+        <p className="text-4xl mb-3">📒</p>
+        <p className="text-sm">No transactions yet</p>
+      </div>
+    )
+  }
+
+  const groups = groupByDate(ledger)
+
+  return (
+    <motion.div
+      className="flex flex-col gap-1"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.2 }}
+    >
+      {/* Running balance header */}
+      <div
+        className="rounded-2xl p-4 mb-3 flex items-center gap-3"
+        style={{ background: 'rgba(251,191,36,0.08)', border: '1px solid rgba(251,191,36,0.2)' }}
+      >
+        <span className="text-2xl">🪙</span>
+        <div>
+          <p className="text-white/50 text-xs">Current balance</p>
+          <p className="font-heading text-2xl font-bold text-cq-gold">{currentBalance.toLocaleString()}</p>
+        </div>
+      </div>
+
+      {groups.map(({ dateLabel, entries }) => (
+        <div key={dateLabel}>
+          <p className="text-[10px] font-bold uppercase tracking-widest text-white/25 px-1 py-2">{dateLabel}</p>
+          <div className="flex flex-col gap-1.5">
+            {entries.map((entry, i) => {
+              const isCredit = entry.amount > 0
+              const isDebit = entry.amount < 0
+              const isNeutral = entry.amount === 0
+
+              return (
+                <motion.div
+                  key={entry.id}
+                  initial={{ opacity: 0, x: -8 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  transition={{ delay: i * 0.03 }}
+                  className="flex items-center gap-3 rounded-xl px-3 py-2.5"
+                  style={{
+                    background: isCredit
+                      ? 'rgba(74,222,128,0.05)'
+                      : isDebit
+                      ? 'rgba(239,68,68,0.05)'
+                      : 'rgba(255,255,255,0.02)',
+                    border: `1px solid ${isCredit ? 'rgba(74,222,128,0.12)' : isDebit ? 'rgba(239,68,68,0.1)' : 'rgba(255,255,255,0.06)'}`,
+                  }}
+                >
+                  {/* Icon */}
+                  <span className="text-lg flex-shrink-0 w-7 text-center">{entry.icon}</span>
+
+                  {/* Description + metadata */}
+                  <div className="flex-1 min-w-0">
+                    <p className={`text-sm font-medium truncate ${isNeutral ? 'text-white/40' : 'text-white/80'}`}>
+                      {entry.description}
+                    </p>
+                    <p className="text-[10px] text-white/25 mt-0.5">
+                      {KIND_LABEL[entry.kind]} · {formatTime(entry.occurred_at)}
+                    </p>
+                  </div>
+
+                  {/* Amount */}
+                  <div className="text-right flex-shrink-0">
+                    <p
+                      className="text-sm font-bold font-heading"
+                      style={{
+                        color: isCredit ? '#4ade80' : isDebit ? '#f87171' : 'rgba(255,255,255,0.3)',
+                      }}
+                    >
+                      {isCredit ? `+${entry.amount}` : isDebit ? `${entry.amount}` : '—'}
+                    </p>
+                    <p className="text-[10px] text-white/30 mt-0.5">
+                      → {entry.balance_after.toLocaleString()} 🪙
+                    </p>
+                  </div>
+                </motion.div>
+              )
+            })}
+          </div>
+        </div>
+      ))}
+
+      <p className="text-[10px] text-white/15 text-center pt-4 pb-2">
+        Balance shown is estimated from tracked events.
+        Manual adjustments may not be reflected.
+      </p>
+    </motion.div>
+  )
+}

--- a/src/lib/ledger.ts
+++ b/src/lib/ledger.ts
@@ -1,0 +1,102 @@
+import { createServiceClient } from './supabase/service'
+
+export type LedgerEntry = {
+  id: string
+  kind: 'quest_reward' | 'quest_rejected' | 'reward_redeemed' | 'reward_denied' | 'curse'
+  description: string
+  icon: string
+  amount: number        // positive = credit, negative = debit
+  balance_after: number
+  occurred_at: string
+}
+
+export async function buildLedger(kidId: string, currentCoins: number): Promise<{ ledger: LedgerEntry[] }> {
+  const supabase = createServiceClient()
+
+  const [completionsRes, redemptionsRes, cursesRes] = await Promise.all([
+    supabase
+      .from('completions')
+      .select('id, coins_awarded, approved_at, completed_at, status, quest:quests(title, icon)')
+      .eq('kid_id', kidId)
+      .in('status', ['approved', 'rejected'])
+      .order('approved_at', { ascending: false }),
+
+    supabase
+      .from('redemptions')
+      .select('id, status, redeemed_at, reward:rewards(title, icon, cost)')
+      .eq('kid_id', kidId)
+      .in('status', ['approved', 'denied'])
+      .order('redeemed_at', { ascending: false }),
+
+    supabase
+      .from('curse_instances')
+      .select('id, coins_deducted, cast_at, curse:curses(title, icon)')
+      .eq('kid_id', kidId)
+      .order('cast_at', { ascending: false }),
+  ])
+
+  type RawEvent = { id: string; kind: LedgerEntry['kind']; description: string; icon: string; amount: number; occurred_at: string }
+  const raw: RawEvent[] = []
+
+  for (const c of completionsRes.data ?? []) {
+    const quest = c.quest as unknown as { title: string; icon: string } | null
+    if (c.status === 'approved') {
+      raw.push({
+        id: c.id,
+        kind: 'quest_reward',
+        description: quest?.title ?? 'Quest',
+        icon: quest?.icon ?? '⚔️',
+        amount: c.coins_awarded ?? 0,
+        occurred_at: c.approved_at ?? c.completed_at,
+      })
+    } else if (c.status === 'rejected') {
+      raw.push({
+        id: c.id,
+        kind: 'quest_rejected',
+        description: quest?.title ?? 'Quest',
+        icon: quest?.icon ?? '⚔️',
+        amount: 0,
+        occurred_at: c.approved_at ?? c.completed_at,
+      })
+    }
+  }
+
+  for (const r of redemptionsRes.data ?? []) {
+    const reward = r.reward as unknown as { title: string; icon: string; cost: number } | null
+    raw.push({
+      id: r.id,
+      kind: r.status === 'approved' ? 'reward_redeemed' : 'reward_denied',
+      description: reward?.title ?? 'Reward',
+      icon: reward?.icon ?? '🎁',
+      amount: r.status === 'approved' ? -(reward?.cost ?? 0) : 0,
+      occurred_at: r.redeemed_at,
+    })
+  }
+
+  for (const ci of cursesRes.data ?? []) {
+    const curse = ci.curse as unknown as { title: string; icon: string } | null
+    if ((ci.coins_deducted ?? 0) > 0) {
+      raw.push({
+        id: ci.id,
+        kind: 'curse',
+        description: curse?.title ?? 'Curse',
+        icon: curse?.icon ?? '☠️',
+        amount: -(ci.coins_deducted ?? 0),
+        occurred_at: ci.cast_at,
+      })
+    }
+  }
+
+  // Sort newest first
+  raw.sort((a, b) => (b.occurred_at ?? '').localeCompare(a.occurred_at ?? ''))
+
+  // Compute balance_after by working backwards from the current known balance
+  let running = currentCoins
+  const ledger: LedgerEntry[] = raw.map(event => {
+    const entry: LedgerEntry = { ...event, balance_after: running }
+    running -= event.amount
+    return entry
+  })
+
+  return { ledger }
+}


### PR DESCRIPTION
## Summary
Full coin ledger view for both kids and parents.

**Kid page** — new `📒 History` tab (4th tab alongside Quests, Bounty, Rewards):
- Lazy-loads on first click via `GET /api/kid/:id/ledger`
- Groups transactions by date (Today / Yesterday / date)
- Each row: icon, description, event type, ±amount (green/red), balance after
- Shows quest rewards, reward redemptions, denials, and curses

**Parent family tab** — `📒` button per kid:
- Opens a modal with the same ledger view
- Served by `GET /api/parent/kids/:kidId/ledger` which authenticates the parent and verifies family ownership

**Ledger reconstruction algorithm** — no new DB table needed:
- Pulls approved completions, approved/denied redemptions, curse instances
- Sorts newest→oldest, walks backwards from `kid.coins` to compute `balance_after` at each entry
- Small disclaimer shown for manual adjustments (which aren't tracked in a dedicated table)

## Test plan
- [ ] Kid page shows 4 tabs with `📒 History` as the 4th
- [ ] History tab loads and shows transactions grouped by date
- [ ] Credits (quest rewards) show in green with `+N`
- [ ] Debits (redemptions, curses) show in red with `-N`
- [ ] Denied rewards show with `—` (no coin effect)
- [ ] Balance after each transaction is accurate
- [ ] Parent family tab shows 📒 button per kid; clicking opens ledger modal
- [ ] Parent modal only shows data for kids in their family (403 for other families)

🤖 Generated with [Claude Code](https://claude.com/claude-code)