### PR TITLE
ui: comprehensive UX pass — mobile, consistency, feedback, a11y

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -73,18 +73,18 @@ export default async function BlogPostPage({ params }: Props) {
 
       {/* Nav */}
       <header
-        className="sticky top-0 z-50 flex items-center justify-between px-6 py-4"
+        className="sticky top-0 z-50 flex items-center justify-between px-4 sm:px-6 py-3 sm:py-4 gap-3"
         style={{ background: 'rgba(5,3,16,0.8)', backdropFilter: 'blur(16px)', borderBottom: '1px solid rgba(255,255,255,0.06)' }}
       >
-        <Link href="/" className="flex items-center gap-2">
-          <span className="text-xl">⚔️</span>
-          <span className="font-heading font-bold text-lg tracking-widest text-white/90">ChoreQuest</span>
+        <Link href="/" className="flex items-center gap-2 min-w-0">
+          <span className="text-xl flex-shrink-0">⚔️</span>
+          <span className="font-heading font-bold text-base sm:text-lg tracking-widest text-white/90 truncate">ChoreQuest</span>
         </Link>
-        <div className="flex items-center gap-4">
-          <Link href="/blog" className="text-sm text-white/45 hover:text-white/70 transition-colors">← All posts</Link>
+        <div className="flex items-center gap-3 sm:gap-4">
+          <Link href="/blog" className="text-sm text-white/45 hover:text-white/70 transition-colors whitespace-nowrap">← All posts</Link>
           <Link
             href="/login"
-            className="px-4 py-2 rounded-xl text-sm font-bold transition-all hidden sm:block"
+            className="px-3 sm:px-4 py-2 rounded-xl text-sm font-bold transition-all whitespace-nowrap"
             style={{ background: 'rgba(251,191,36,0.12)', border: '1px solid rgba(251,191,36,0.3)', color: '#fbbf24' }}
           >
             Sign in

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -51,19 +51,20 @@ export default async function BlogListingPage() {
 
       {/* Nav */}
       <header
-        className="sticky top-0 z-50 flex items-center justify-between px-6 py-4"
+        className="sticky top-0 z-50 flex items-center justify-between px-4 sm:px-6 py-3 sm:py-4 gap-3"
         style={{ background: 'rgba(5,3,16,0.8)', backdropFilter: 'blur(16px)', borderBottom: '1px solid rgba(255,255,255,0.06)' }}
       >
-        <Link href="/" className="flex items-center gap-2">
-          <span className="text-xl">⚔️</span>
-          <span className="font-heading font-bold text-lg tracking-widest text-white/90">ChoreQuest</span>
+        <Link href="/" className="flex items-center gap-2 min-w-0">
+          <span className="text-xl flex-shrink-0">⚔️</span>
+          <span className="font-heading font-bold text-base sm:text-lg tracking-widest text-white/90 truncate">ChoreQuest</span>
         </Link>
-        <nav className="flex items-center gap-6 text-sm text-white/45">
-          <Link href="/#features" className="hover:text-white/80 transition-colors hidden sm:block">Features</Link>
-          <Link href="/blog" className="text-white/80 font-medium">Blog</Link>
+        <nav className="flex items-center gap-4 sm:gap-6 text-sm text-white/45">
+          <Link href="/" className="hidden sm:block hover:text-white/80 transition-colors">Home</Link>
+          <Link href="/#features" className="hidden sm:block hover:text-white/80 transition-colors">Features</Link>
+          <Link href="/blog" className="text-white/80 font-medium hidden sm:block">Blog</Link>
           <Link
             href="/login"
-            className="px-4 py-2 rounded-xl font-bold transition-all"
+            className="px-3 sm:px-4 py-2 rounded-xl font-bold transition-all whitespace-nowrap text-sm"
             style={{ background: 'rgba(251,191,36,0.12)', border: '1px solid rgba(251,191,36,0.3)', color: '#fbbf24' }}
           >
             Sign in

--- a/src/app/display/page.tsx
+++ b/src/app/display/page.tsx
@@ -7,6 +7,7 @@ import { motion, AnimatePresence } from 'framer-motion'
 import Link from 'next/link'
 import { createClient } from '@/lib/supabase/client'
 import { StarField } from '@/components/star-field'
+import { LoadingScreen } from '@/components/loading-screen'
 import { KidColumn } from '@/components/kid-column'
 import type { Kid, Quest, Completion, Family, Reward, DungeonRun, DungeonClear, RaidBoss } from '@/lib/types'
 import { KID_COLORS, TIER_CONFIG } from '@/lib/constants'
@@ -207,18 +208,7 @@ export default function WallDisplay() {
   })
 
   if (loading) {
-    return (
-      <div className="min-h-screen bg-quest-void flex items-center justify-center">
-        <StarField />
-        <motion.p
-          className="relative z-10 font-heading text-3xl text-white/40"
-          animate={{ opacity: [0.3, 0.8, 0.3] }}
-          transition={{ duration: 2, repeat: Infinity }}
-        >
-          ✦ Loading the realm ✦
-        </motion.p>
-      </div>
-    )
+    return <LoadingScreen label="Loading the realm" size="lg" />
   }
 
   if (kids.length === 0) {

--- a/src/app/display/page.tsx
+++ b/src/app/display/page.tsx
@@ -265,11 +265,12 @@ export default function WallDisplay() {
           )}
         </div>
 
-        <div className="flex-1 flex justify-end items-center gap-2 sm:gap-3">
+        <div className="flex-1 flex justify-end items-center gap-1.5 sm:gap-3">
           {bountyQuests.length > 0 && (
             <button
               onClick={() => setShowBounty(true)}
-              className="relative flex items-center gap-1.5 px-2.5 sm:px-4 py-2 rounded-xl text-sm font-semibold transition-all"
+              aria-label="Open bounty board"
+              className="relative flex items-center justify-center gap-1.5 min-w-11 min-h-11 px-2.5 sm:px-4 py-2 rounded-xl text-sm font-semibold transition-all"
               style={{
                 background: 'rgba(251,191,36,0.12)',
                 border: '1px solid rgba(251,191,36,0.35)',
@@ -281,13 +282,15 @@ export default function WallDisplay() {
                 <span
                   className="absolute -top-1 -right-1 w-2.5 h-2.5 rounded-full"
                   style={{ background: '#fbbf24' }}
+                  aria-hidden="true"
                 />
               )}
             </button>
           )}
           <button
             onClick={() => setShowRewards(true)}
-            className="flex items-center gap-1.5 px-2.5 sm:px-4 py-2 rounded-xl text-sm font-semibold transition-all"
+            aria-label="View rewards"
+            className="flex items-center justify-center gap-1.5 min-w-11 min-h-11 px-2.5 sm:px-4 py-2 rounded-xl text-sm font-semibold transition-all"
             style={{
               background: 'rgba(251,191,36,0.08)',
               border: '1px solid rgba(251,191,36,0.2)',
@@ -303,24 +306,27 @@ export default function WallDisplay() {
             >
               <Link
                 href="/parent"
-                className="flex items-center gap-1.5 px-2.5 sm:px-4 py-2 rounded-xl text-sm font-semibold transition-all"
+                aria-label={`${pendingCount} pending approvals`}
+                className="flex items-center justify-center gap-1.5 min-w-11 min-h-11 px-2.5 sm:px-4 py-2 rounded-xl text-sm font-semibold transition-all"
                 style={{
                   background: 'rgba(251, 191, 36, 0.14)',
                   border: '1px solid rgba(251, 191, 36, 0.32)',
                   color: '#fbbf24',
                 }}
               >
-                <span className="relative flex h-2 w-2 flex-shrink-0">
+                <span className="relative flex h-2 w-2 flex-shrink-0" aria-hidden="true">
                   <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-cq-gold opacity-75" />
                   <span className="relative inline-flex rounded-full h-2 w-2 bg-cq-gold" />
                 </span>
                 <span className="hidden sm:inline">{pendingCount} pending</span>
+                <span className="sm:hidden text-xs font-bold">{pendingCount}</span>
               </Link>
             </motion.div>
           )}
           <Link
             href="/parent"
-            className="px-2.5 sm:px-4 py-2 rounded-xl text-sm text-white/50 hover:text-white/80 transition-all glass border-glass"
+            aria-label="Parent dashboard"
+            className="flex items-center justify-center min-w-11 min-h-11 px-2.5 sm:px-4 py-2 rounded-xl text-sm text-white/50 hover:text-white/80 transition-all glass border-glass"
           >
             ⚙️<span className="hidden sm:inline"> Parent</span>
           </Link>

--- a/src/app/display/page.tsx
+++ b/src/app/display/page.tsx
@@ -15,6 +15,7 @@ import { questDateString, questWeekKey } from '@/lib/utils'
 import { sharedQuestPeriodFilter } from '@/lib/quest-rules'
 import { getWeekMonday } from '@/lib/xp'
 import { toast } from 'sonner'
+import { useEscapeToClose } from '@/lib/use-escape-to-close'
 
 export default function WallDisplay() {
   const [family, setFamily] = useState<Family | null>(null)
@@ -34,6 +35,10 @@ export default function WallDisplay() {
   const [weeklyCompletions, setWeeklyCompletions] = useState<Completion[]>([])
   const [activeBoss, setActiveBoss] = useState<RaidBoss | null>(null)
   const [supabase] = useState(createClient)
+
+  useEscapeToClose(showBounty, () => setShowBounty(false))
+  useEscapeToClose(showRewards, () => setShowRewards(false))
+  useEscapeToClose(claimingBounty !== null, () => setClaimingBounty(null))
 
   const fetchData = useCallback(async () => {
     const { data: profile } = await supabase
@@ -552,6 +557,9 @@ export default function WallDisplay() {
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
             onClick={() => setShowBounty(false)}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="bounty-modal-title"
           >
             <motion.div
               className="rounded-3xl mx-4 w-full max-w-sm sm:max-w-lg overflow-hidden"
@@ -569,15 +577,16 @@ export default function WallDisplay() {
               transition={{ type: 'spring', stiffness: 340, damping: 28 }}
               onClick={(e) => e.stopPropagation()}
             >
-              <div className="px-7 pt-6 pb-4 flex-shrink-0" style={{ borderBottom: '1px solid rgba(255,255,255,0.06)' }}>
-                <div className="flex items-center justify-between">
-                  <div>
-                    <h2 className="font-heading text-xl font-bold text-white/90 tracking-wide">⚡ Bounty Board</h2>
+              <div className="px-6 sm:px-7 pt-5 sm:pt-6 pb-4 flex-shrink-0" style={{ borderBottom: '1px solid rgba(255,255,255,0.06)' }}>
+                <div className="flex items-center justify-between gap-3">
+                  <div className="min-w-0">
+                    <h2 id="bounty-modal-title" className="font-heading text-lg sm:text-xl font-bold text-white/90 tracking-wide">⚡ Bounty Board</h2>
                     <p className="text-white/35 text-xs mt-0.5">First to claim earns the coins</p>
                   </div>
                   <button
                     onClick={() => setShowBounty(false)}
-                    className="w-8 h-8 rounded-full flex items-center justify-center text-white/30 hover:text-white/60 transition-all"
+                    aria-label="Close bounty board"
+                    className="w-11 h-11 rounded-full flex items-center justify-center text-white/35 hover:text-white/70 transition-all flex-shrink-0"
                     style={{ background: 'rgba(255,255,255,0.05)', border: '1px solid rgba(255,255,255,0.08)' }}
                   >
                     ✕
@@ -644,6 +653,9 @@ export default function WallDisplay() {
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
             onClick={() => setShowRewards(false)}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="rewards-modal-title"
           >
             <motion.div
               className="rounded-3xl mx-4 w-full max-w-sm sm:max-w-lg overflow-hidden"
@@ -663,19 +675,20 @@ export default function WallDisplay() {
             >
               {/* Modal header */}
               <div
-                className="px-7 pt-6 pb-4 flex-shrink-0"
+                className="px-6 sm:px-7 pt-5 sm:pt-6 pb-4 flex-shrink-0"
                 style={{ borderBottom: '1px solid rgba(255,255,255,0.06)' }}
               >
-                <div className="flex items-center justify-between">
-                  <div>
-                    <h2 className="font-heading text-xl font-bold text-white/90 tracking-wide">
+                <div className="flex items-center justify-between gap-3">
+                  <div className="min-w-0">
+                    <h2 id="rewards-modal-title" className="font-heading text-lg sm:text-xl font-bold text-white/90 tracking-wide">
                       🏆 Reward Vault
                     </h2>
                     <p className="text-white/35 text-xs mt-0.5">Spend your coins wisely, adventurer</p>
                   </div>
                   <button
                     onClick={() => setShowRewards(false)}
-                    className="w-8 h-8 rounded-full flex items-center justify-center text-white/30 hover:text-white/60 transition-all"
+                    aria-label="Close reward vault"
+                    className="w-11 h-11 rounded-full flex items-center justify-center text-white/35 hover:text-white/70 transition-all flex-shrink-0"
                     style={{ background: 'rgba(255,255,255,0.05)', border: '1px solid rgba(255,255,255,0.08)' }}
                   >
                     ✕
@@ -750,6 +763,9 @@ export default function WallDisplay() {
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
             onClick={() => setClaimingBounty(null)}
+            role="dialog"
+            aria-modal="true"
+            aria-label="Choose adventurer for bounty"
           >
             <motion.div
               className="rounded-3xl p-7 mx-4 max-w-sm w-full"

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -81,6 +81,7 @@
   html {
     @apply antialiased;
     color-scheme: dark;
+    -webkit-text-size-adjust: 100%;
   }
   body {
     background-color: #050310;
@@ -88,6 +89,47 @@
   }
   button:not(:disabled) {
     cursor: pointer;
+  }
+  /* Prevent iOS Safari auto-zoom on focus by ensuring the rendered size is >= 16px.
+     On sm+ we let Tailwind's text-sm (14px) apply for compact desktop forms. */
+  input,
+  select,
+  textarea {
+    font-size: 16px;
+  }
+  @media (min-width: 640px) {
+    input,
+    select,
+    textarea {
+      font-size: inherit;
+    }
+  }
+  /* Unified focus state for form fields — replaces ad-hoc onFocus/onBlur handlers. */
+  input:not([type='checkbox']):not([type='radio']):focus-visible,
+  select:focus-visible,
+  textarea:focus-visible {
+    border-color: rgba(251, 191, 36, 0.45);
+    box-shadow: 0 0 0 3px rgba(251, 191, 36, 0.12);
+    outline: none;
+  }
+  /* Visible keyboard focus on interactive elements — accessibility baseline. */
+  button:focus-visible,
+  a:focus-visible,
+  [role='button']:focus-visible {
+    outline: 2px solid rgba(251, 191, 36, 0.55);
+    outline-offset: 2px;
+    border-radius: inherit;
+  }
+  /* Honor user motion preference — kills heavy framer/animations for sensitive users. */
+  @media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+      scroll-behavior: auto !important;
+    }
   }
 }
 

--- a/src/app/join/[token]/page.tsx
+++ b/src/app/join/[token]/page.tsx
@@ -8,6 +8,7 @@ import { motion } from 'framer-motion'
 import Link from 'next/link'
 import { createClient } from '@/lib/supabase/client'
 import { StarField } from '@/components/star-field'
+import { LoadingScreen } from '@/components/loading-screen'
 import { KID_COLORS } from '@/lib/constants'
 import type { KidColor } from '@/lib/types'
 
@@ -37,18 +38,7 @@ export default function JoinPage({ params }: { params: Promise<{ token: string }
   }, [token, supabase])
 
   if (loading) {
-    return (
-      <div className="min-h-screen bg-quest-void flex items-center justify-center">
-        <StarField />
-        <motion.p
-          className="relative z-10 font-heading text-2xl text-white/40"
-          animate={{ opacity: [0.3, 0.8, 0.3] }}
-          transition={{ duration: 2, repeat: Infinity }}
-        >
-          ✦ Loading ✦
-        </motion.p>
-      </div>
-    )
+    return <LoadingScreen />
   }
 
   if (notFound || !family) {

--- a/src/app/kid/[id]/page.tsx
+++ b/src/app/kid/[id]/page.tsx
@@ -10,6 +10,7 @@ import { StarField } from '@/components/star-field'
 import { QuestCard } from '@/components/quest-card'
 import { CoinCounter } from '@/components/coin-counter'
 import { StreakBadge } from '@/components/streak-badge'
+import { LoadingScreen } from '@/components/loading-screen'
 import type { Kid, Quest, Completion, Reward, CurseInstance, Redemption } from '@/lib/types'
 import { KID_COLORS, getLockDurationMs } from '@/lib/constants'
 import { questDateString, questWeekKey } from '@/lib/utils'
@@ -234,18 +235,7 @@ export default function KidPage({ params }: { params: Promise<{ id: string }> })
   )
 
   if (loading || !data) {
-    return (
-      <div className="min-h-screen bg-quest-void flex items-center justify-center">
-        <StarField />
-        <motion.p
-          className="relative z-10 font-heading text-2xl text-white/40"
-          animate={{ opacity: [0.3, 0.8, 0.3] }}
-          transition={{ duration: 2, repeat: Infinity }}
-        >
-          ✦ Loading ✦
-        </motion.p>
-      </div>
-    )
+    return <LoadingScreen />
   }
 
   const { kid, resetHour, quests, completions, rewards, activeCurses, familySharedCompletions } = data

--- a/src/app/kid/[id]/page.tsx
+++ b/src/app/kid/[id]/page.tsx
@@ -366,11 +366,14 @@ export default function KidPage({ params }: { params: Promise<{ id: string }> })
 
       <div className="relative z-10 flex flex-col flex-1 w-full max-w-md mx-auto">
         <motion.header
-          className="flex items-center gap-4 px-6 py-5 flex-shrink-0"
+          className="flex items-center gap-3 px-4 sm:px-6 py-4 sm:py-5 flex-shrink-0"
           initial={{ opacity: 0, y: -16 }}
           animate={{ opacity: 1, y: 0 }}
         >
-          <Link href="/display" className="text-white/40 hover:text-white/70 transition-all text-sm">
+          <Link
+            href="/display"
+            className="text-white/45 hover:text-white/80 transition-all text-sm min-h-[44px] flex items-center px-1"
+          >
             ← Realm
           </Link>
 
@@ -388,7 +391,11 @@ export default function KidPage({ params }: { params: Promise<{ id: string }> })
           </div>
         </motion.header>
 
-        <div className="flex px-6 gap-2 mb-4 flex-shrink-0">
+        <div
+          className="flex px-4 sm:px-6 gap-1.5 sm:gap-2 mb-4 flex-shrink-0"
+          role="tablist"
+          aria-label="Adventurer sections"
+        >
           {(['quests', 'bounty', 'rewards', 'history'] as const).map((t) => {
             const labels = { quests: '⚔️ Quests', bounty: '⚡ Bounty', rewards: '🎁 Rewards', history: '📒 History' }
             const badge = t === 'quests' && pendingCompletions.length > 0
@@ -396,12 +403,13 @@ export default function KidPage({ params }: { params: Promise<{ id: string }> })
               : t === 'bounty' && availableBountyCount > 0
               ? availableBountyCount
               : null
-            const isBountyActive = t === 'bounty' && tab === 'bounty'
             return (
               <button
                 key={t}
                 onClick={() => setTab(t)}
-                className="relative flex-1 py-2 rounded-xl text-sm font-semibold transition-all flex items-center justify-center gap-1.5"
+                role="tab"
+                aria-selected={tab === t}
+                className="relative flex-1 min-h-[44px] py-2 rounded-xl text-sm font-semibold transition-all flex items-center justify-center gap-1.5"
                 style={{
                   background: tab === t
                     ? (t === 'bounty' ? 'rgba(251,191,36,0.12)' : colors.bg)
@@ -419,6 +427,7 @@ export default function KidPage({ params }: { params: Promise<{ id: string }> })
                   <span
                     className="px-1.5 py-0.5 rounded-full text-[10px] font-bold leading-none"
                     style={{ background: 'rgba(251,191,36,0.9)', color: '#0a0620' }}
+                    aria-label={`${badge} new`}
                   >
                     {badge}
                   </span>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -22,17 +22,10 @@ export default function LoginPage() {
   const router = useRouter()
   const supabase = createClient()
 
+  const [showPassword, setShowPassword] = useState(false)
   const inputStyle = {
     background: 'rgba(255, 255, 255, 0.06)',
     border: '1px solid rgba(255, 255, 255, 0.1)',
-  }
-  const inputFocus = (e: React.FocusEvent<HTMLInputElement>) => {
-    e.target.style.borderColor = 'rgba(251, 191, 36, 0.45)'
-    e.target.style.boxShadow = '0 0 0 3px rgba(251, 191, 36, 0.1)'
-  }
-  const inputBlur = (e: React.FocusEvent<HTMLInputElement>) => {
-    e.target.style.borderColor = 'rgba(255, 255, 255, 0.1)'
-    e.target.style.boxShadow = 'none'
   }
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -164,14 +157,13 @@ export default function LoginPage() {
                       <label className="block text-xs font-semibold text-white/50 uppercase tracking-widest mb-1.5">Email</label>
                       <input
                         type="email"
+                        autoComplete="email"
                         value={email}
                         onChange={(e) => setEmail(e.target.value)}
                         placeholder="parent@family.com"
                         required
                         className="w-full px-4 py-3 rounded-xl text-sm text-white/90 placeholder:text-white/25 outline-none transition-all"
                         style={inputStyle}
-                        onFocus={inputFocus}
-                        onBlur={inputBlur}
                       />
                     </div>
                     <motion.button
@@ -210,12 +202,15 @@ export default function LoginPage() {
                 <div
                   className="flex rounded-xl p-1 mb-8"
                   style={{ background: 'rgba(255, 255, 255, 0.05)' }}
+                  role="tablist"
                 >
                   {(['login', 'signup'] as const).map((m) => (
                     <button
                       key={m}
                       onClick={() => setMode(m)}
-                      className="flex-1 py-2 rounded-lg text-sm font-semibold capitalize transition-all"
+                      role="tab"
+                      aria-selected={mode === m}
+                      className="flex-1 min-h-[44px] py-2.5 rounded-lg text-sm font-semibold capitalize transition-all"
                       style={{
                         background: mode === m ? 'rgba(255, 255, 255, 0.09)' : 'transparent',
                         color: mode === m ? 'rgba(255,255,255,0.92)' : 'rgba(255,255,255,0.38)',
@@ -228,45 +223,55 @@ export default function LoginPage() {
 
                 <form onSubmit={handleSubmit} className="flex flex-col gap-4">
                   <div>
-                    <label className="block text-xs font-semibold text-white/50 uppercase tracking-widest mb-1.5">Email</label>
+                    <label htmlFor="login-email" className="block text-xs font-semibold text-white/50 uppercase tracking-widest mb-1.5">Email</label>
                     <input
+                      id="login-email"
                       type="email"
+                      autoComplete="email"
                       value={email}
                       onChange={(e) => setEmail(e.target.value)}
                       placeholder="parent@family.com"
                       required
                       className="w-full px-4 py-3 rounded-xl text-sm text-white/90 placeholder:text-white/25 outline-none transition-all"
                       style={inputStyle}
-                      onFocus={inputFocus}
-                      onBlur={inputBlur}
                     />
                   </div>
 
                   <div>
                     <div className="flex items-center justify-between mb-1.5">
-                      <label className="block text-xs font-semibold text-white/50 uppercase tracking-widest">Password</label>
+                      <label htmlFor="login-password" className="block text-xs font-semibold text-white/50 uppercase tracking-widest">Password</label>
                       {mode === 'login' && (
                         <button
                           type="button"
                           onClick={() => setMode('forgot')}
-                          className="text-xs text-white/30 hover:text-cq-gold/70 transition-colors"
+                          className="text-xs text-white/35 hover:text-cq-gold/70 transition-colors px-1 py-1"
                         >
                           Forgot password?
                         </button>
                       )}
                     </div>
-                    <input
-                      type="password"
-                      value={password}
-                      onChange={(e) => setPassword(e.target.value)}
-                      placeholder="••••••••"
-                      required
-                      minLength={6}
-                      className="w-full px-4 py-3 rounded-xl text-sm text-white/90 placeholder:text-white/25 outline-none transition-all"
-                      style={inputStyle}
-                      onFocus={inputFocus}
-                      onBlur={inputBlur}
-                    />
+                    <div className="relative">
+                      <input
+                        id="login-password"
+                        type={showPassword ? 'text' : 'password'}
+                        autoComplete={mode === 'signup' ? 'new-password' : 'current-password'}
+                        value={password}
+                        onChange={(e) => setPassword(e.target.value)}
+                        placeholder="••••••••"
+                        required
+                        minLength={6}
+                        className="w-full px-4 py-3 pr-12 rounded-xl text-sm text-white/90 placeholder:text-white/25 outline-none transition-all"
+                        style={inputStyle}
+                      />
+                      <button
+                        type="button"
+                        onClick={() => setShowPassword((s) => !s)}
+                        aria-label={showPassword ? 'Hide password' : 'Show password'}
+                        className="absolute right-1.5 top-1/2 -translate-y-1/2 w-9 h-9 flex items-center justify-center rounded-lg text-white/35 hover:text-white/70 transition-colors"
+                      >
+                        {showPassword ? '🙈' : '👁️'}
+                      </button>
+                    </div>
                   </div>
 
                   <motion.button

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,38 @@
+import Link from 'next/link'
+import { StarField } from '@/components/star-field'
+
+export default function NotFound() {
+  return (
+    <div className="min-h-screen bg-quest-void flex items-center justify-center px-4 text-center">
+      <StarField />
+      <div className="relative z-10 max-w-md">
+        <p className="text-6xl mb-6" aria-hidden="true">🗺️</p>
+        <h1 className="font-heading text-4xl sm:text-5xl font-black text-gradient-gold tracking-widest mb-4">
+          Off the Map
+        </h1>
+        <p className="text-white/45 text-base mb-8 leading-relaxed">
+          The realm you&apos;re looking for isn&apos;t here. Maybe the link expired, or maybe the cartographers got it wrong.
+        </p>
+        <div className="flex flex-col sm:flex-row gap-3 justify-center">
+          <Link
+            href="/"
+            className="inline-flex items-center justify-center px-6 py-3 rounded-2xl font-bold text-sm transition-all"
+            style={{
+              background: 'rgba(251,191,36,0.18)',
+              border: '1px solid rgba(251,191,36,0.4)',
+              color: '#fbbf24',
+            }}
+          >
+            ← Back to ChoreQuest
+          </Link>
+          <Link
+            href="/login"
+            className="inline-flex items-center justify-center px-6 py-3 rounded-2xl font-bold text-sm transition-all text-white/60 hover:text-white/90 glass border-glass"
+          >
+            Sign in
+          </Link>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -627,7 +627,7 @@ export default function MarketingPage() {
       <section className="relative z-10 py-24 px-6">
         <Reveal>
           <div
-            className="max-w-2xl mx-auto rounded-3xl p-12 text-center relative overflow-hidden"
+            className="max-w-2xl mx-auto rounded-3xl p-8 sm:p-12 text-center relative overflow-hidden"
             style={{
               background: 'linear-gradient(135deg, rgba(251,191,36,0.1) 0%, rgba(167,139,250,0.08) 100%)',
               border: '1px solid rgba(251,191,36,0.25)',

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { useRef } from 'react'
-import { motion, useInView } from 'framer-motion'
+import { useRef, useState } from 'react'
+import { motion, useInView, AnimatePresence } from 'framer-motion'
 import Link from 'next/link'
 import { StarField } from '@/components/star-field'
 
@@ -223,13 +223,16 @@ const HOW_IT_WORKS = [
 
 // ─── Main page ────────────────────────────────────────────────────────────────
 export default function MarketingPage() {
+  const [mobileNavOpen, setMobileNavOpen] = useState(false)
+  const closeNav = () => setMobileNavOpen(false)
+
   return (
     <div className="min-h-screen bg-quest-void text-white overflow-x-hidden">
       <StarField />
 
       {/* ── Nav ── */}
       <header
-        className="fixed top-0 left-0 right-0 z-50 flex items-center justify-between px-6 py-4"
+        className="fixed top-0 left-0 right-0 z-50 flex items-center justify-between px-4 sm:px-6 py-3 sm:py-4"
         style={{ background: 'rgba(5,3,16,0.8)', backdropFilter: 'blur(16px)', borderBottom: '1px solid rgba(255,255,255,0.06)' }}
       >
         <div className="flex items-center gap-2">
@@ -242,14 +245,81 @@ export default function MarketingPage() {
           <a href="#pricing" className="hover:text-white/80 transition-colors">Pricing</a>
           <Link href="/blog" className="hover:text-white/80 transition-colors">Blog</Link>
         </nav>
-        <Link
-          href="/login"
-          className="px-5 py-2 rounded-xl text-sm font-bold transition-all"
-          style={{ background: 'rgba(251,191,36,0.15)', border: '1px solid rgba(251,191,36,0.35)', color: '#fbbf24' }}
-        >
-          Start Free →
-        </Link>
+        <div className="flex items-center gap-2">
+          <Link
+            href="/login"
+            className="px-4 sm:px-5 py-2 rounded-xl text-sm font-bold transition-all"
+            style={{ background: 'rgba(251,191,36,0.15)', border: '1px solid rgba(251,191,36,0.35)', color: '#fbbf24' }}
+          >
+            Start Free →
+          </Link>
+          <button
+            type="button"
+            onClick={() => setMobileNavOpen((o) => !o)}
+            className="md:hidden w-11 h-11 flex flex-col items-center justify-center gap-1.5 rounded-xl"
+            style={{ background: 'rgba(255,255,255,0.05)', border: '1px solid rgba(255,255,255,0.08)' }}
+            aria-label={mobileNavOpen ? 'Close menu' : 'Open menu'}
+            aria-expanded={mobileNavOpen}
+            aria-controls="mobile-nav-panel"
+          >
+            <span
+              className="block w-4 h-px bg-white/70 transition-transform"
+              style={mobileNavOpen ? { transform: 'translateY(3px) rotate(45deg)' } : undefined}
+            />
+            <span
+              className="block w-4 h-px bg-white/70 transition-transform"
+              style={mobileNavOpen ? { transform: 'translateY(-3px) rotate(-45deg)' } : undefined}
+            />
+          </button>
+        </div>
       </header>
+
+      {/* Mobile nav panel */}
+      <AnimatePresence>
+        {mobileNavOpen && (
+          <motion.div
+            id="mobile-nav-panel"
+            className="fixed inset-x-0 top-[56px] z-40 md:hidden px-4"
+            initial={{ opacity: 0, y: -8 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -8 }}
+            transition={{ duration: 0.18 }}
+          >
+            <nav
+              className="rounded-2xl overflow-hidden flex flex-col"
+              style={{
+                background: 'rgba(10,6,28,0.96)',
+                border: '1px solid rgba(255,255,255,0.08)',
+                backdropFilter: 'blur(16px)',
+                boxShadow: '0 20px 40px rgba(0,0,0,0.4)',
+              }}
+            >
+              {[
+                { href: '#how-it-works', label: 'How It Works' },
+                { href: '#features', label: 'Features' },
+                { href: '#pricing', label: 'Pricing' },
+              ].map((item) => (
+                <a
+                  key={item.href}
+                  href={item.href}
+                  onClick={closeNav}
+                  className="px-5 py-4 text-white/75 hover:bg-white/[0.04] active:bg-white/[0.06] transition-colors text-base font-medium"
+                  style={{ borderBottom: '1px solid rgba(255,255,255,0.05)' }}
+                >
+                  {item.label}
+                </a>
+              ))}
+              <Link
+                href="/blog"
+                onClick={closeNav}
+                className="px-5 py-4 text-white/75 hover:bg-white/[0.04] active:bg-white/[0.06] transition-colors text-base font-medium"
+              >
+                Blog
+              </Link>
+            </nav>
+          </motion.div>
+        )}
+      </AnimatePresence>
 
       {/* ── Hero ── */}
       <section className="relative z-10 pt-32 pb-20 px-6 text-center">

--- a/src/app/parent/_ui.tsx
+++ b/src/app/parent/_ui.tsx
@@ -16,11 +16,20 @@ export function Section({ title, children }: { title: string; children: React.Re
   )
 }
 
-export function Empty({ icon, message }: { icon: string; message: string }) {
+export function Empty({
+  icon,
+  message,
+  hint,
+}: {
+  icon: string
+  message: string
+  hint?: string
+}) {
   return (
     <div className="text-center py-8 text-white/30">
-      <p className="text-3xl mb-2">{icon}</p>
-      <p className="text-sm">{message}</p>
+      <p className="text-3xl mb-2" aria-hidden="true">{icon}</p>
+      <p className="text-sm text-white/45">{message}</p>
+      {hint && <p className="text-xs text-white/30 mt-1.5">{hint}</p>}
     </div>
   )
 }

--- a/src/app/parent/approvals-tab.tsx
+++ b/src/app/parent/approvals-tab.tsx
@@ -97,6 +97,11 @@ export function ApprovalsTab({
         <Empty
           icon="✅"
           message={pendingRedemptions.length === 0 ? 'All clear — nothing pending!' : 'No pending quests'}
+          hint={
+            pendingRedemptions.length === 0
+              ? 'Submissions from kids will show up here for you to approve or reject.'
+              : undefined
+          }
         />
       ) : (
         pendingCompletions.map((c) => {

--- a/src/app/parent/curses-tab.tsx
+++ b/src/app/parent/curses-tab.tsx
@@ -5,6 +5,7 @@ import { motion } from 'framer-motion'
 import type { Kid, Plan, Curse, CurseInstance } from '@/lib/types'
 import { PLAN_LIMITS } from '@/lib/plans'
 import { Empty, FormInput, Section, fadeSlide } from './_ui'
+import { ConfirmDelete } from '@/components/ui/confirm-delete'
 import type { ParentActions } from './use-parent-actions'
 
 const CURSE_ICONS = ['☠️','😈','🌩️','🔥','💀','👿','🦂','🕸️']
@@ -201,12 +202,12 @@ export function CursesTab({ kids, curses, activeCurseInstances, actions, plan }:
                       >
                         Cast ⚡
                       </button>
-                      <button
-                        onClick={() => actions.deleteCurse(curse.id)}
-                        className="text-white/20 hover:text-red-400 transition-all text-xs"
-                      >
-                        ✕
-                      </button>
+                      <ConfirmDelete
+                        onConfirm={() => actions.deleteCurse(curse.id)}
+                        ariaLabel={`Delete curse ${curse.title}`}
+                        confirmLabel="Delete curse"
+                        className="px-1 py-1"
+                      />
                     </div>
                   )}
                 </div>

--- a/src/app/parent/dungeons-tab.tsx
+++ b/src/app/parent/dungeons-tab.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { motion } from 'framer-motion'
 import type { DungeonRun, DungeonClear, RaidBoss, Kid, Completion } from '@/lib/types'
 import { Section, FormInput, Empty, fadeSlide } from './_ui'
+import { ConfirmDelete } from '@/components/ui/confirm-delete'
 import type { ParentActions } from './use-parent-actions'
 
 const DUNGEON_ICONS = ['🏰', '⚔️', '🗡️', '🛡️', '🔮', '🌋', '🕳️', '🐲']
@@ -86,13 +87,13 @@ export function DungeonsTab({ activeDungeon, dungeonClears, weeklyCompletions, k
                 <p className="text-white/90 font-semibold">{activeDungeon.title}</p>
                 <p className="text-white/40 text-xs">Goal: {activeDungeon.hp} coins each · Loot: +{activeDungeon.reward_coins} coins · +{activeDungeon.reward_xp} XP</p>
               </div>
-              <button
-                onClick={() => actions.deleteDungeonRun(activeDungeon.id)}
-                className="text-white/20 hover:text-red-400 transition-all text-xs"
-                title="Cancel dungeon"
-              >
-                ✕
-              </button>
+              <ConfirmDelete
+                onConfirm={() => actions.deleteDungeonRun(activeDungeon.id)}
+                ariaLabel="Cancel this dungeon"
+                prompt="Cancel?"
+                confirmLabel="Yes, cancel"
+                className="px-1 py-1"
+              />
             </div>
             {kids.length === 0 && (
               <p className="text-white/30 text-xs text-center">Add kids to track progress</p>
@@ -193,13 +194,13 @@ export function DungeonsTab({ activeDungeon, dungeonClears, weeklyCompletions, k
                 <p className="text-white/90 font-semibold font-heading">{activeBoss.title}</p>
                 <p className="text-white/40 text-xs">Bounty: {activeBoss.bounty_coins} coins split among all kids</p>
               </div>
-              <button
-                onClick={() => actions.deleteRaidBoss(activeBoss.id)}
-                className="text-white/20 hover:text-red-400 transition-all text-xs"
-                title="Dismiss boss"
-              >
-                ✕
-              </button>
+              <ConfirmDelete
+                onConfirm={() => actions.deleteRaidBoss(activeBoss.id)}
+                ariaLabel="Dismiss raid boss"
+                prompt="Dismiss?"
+                confirmLabel="Yes, dismiss"
+                className="px-1 py-1"
+              />
             </div>
             <HpBar
               current={activeBoss.current_hp}

--- a/src/app/parent/family-tab.tsx
+++ b/src/app/parent/family-tab.tsx
@@ -10,6 +10,8 @@ import { ActionButton, Empty, FormInput, Section, fadeSlide } from './_ui'
 import type { ParentActions } from './use-parent-actions'
 import { CoinLedger } from '@/components/coin-ledger'
 import type { LedgerEntry } from '@/lib/ledger'
+import { useEscapeToClose } from '@/lib/use-escape-to-close'
+import { ConfirmDelete } from '@/components/ui/confirm-delete'
 
 const RESET_HOUR_PRESETS = [0, 3, 5, 6] as const
 
@@ -150,12 +152,16 @@ function ParentLockSettings({ family, actions }: { family: Family | null; action
               className="flex-shrink-0 px-5"
             />
           </div>
-          <button
-            onClick={actions.removeParentPin}
-            className="text-xs text-white/30 hover:text-red-400 transition-all text-center"
-          >
-            Remove parent lock
-          </button>
+          <div className="flex justify-center">
+            <ConfirmDelete
+              onConfirm={actions.removeParentPin}
+              trigger="Remove parent lock"
+              prompt="Remove?"
+              confirmLabel="Yes, remove"
+              ariaLabel="Remove parent lock"
+              className="text-xs text-white/35 px-1"
+            />
+          </div>
         </div>
       ) : (
         <div className="flex flex-col gap-3">
@@ -284,6 +290,8 @@ function KidList({ kids, onShowQr, actions }: { kids: Kid[]; onShowQr: (kidId: s
   const [ledger, setLedger] = useState<LedgerEntry[]>([])
   const [ledgerBalance, setLedgerBalance] = useState(0)
   const [ledgerLoading, setLedgerLoading] = useState(false)
+
+  useEscapeToClose(ledgerKid !== null, () => setLedgerKid(null))
 
   const openLedger = async (kid: Kid) => {
     setLedgerKid(kid)
@@ -484,26 +492,26 @@ function InviteLink({ family, actions }: { family: Family; actions: ParentAction
         >
           {typeof window !== 'undefined' ? `${window.location.origin}/join/${family.invite_token}` : `/join/${family.invite_token}`}
         </div>
-        <div className="flex gap-2">
+        <div className="flex gap-2 items-center">
           <button
             onClick={() => {
               const url = `${window.location.origin}/join/${family.invite_token}`
               navigator.clipboard.writeText(url)
               toast.success('Invite link copied!')
             }}
-            className="flex-1 py-2 rounded-xl text-sm font-semibold transition-all"
+            className="flex-1 min-h-[44px] py-2 rounded-xl text-sm font-semibold transition-all"
             style={{ background: 'rgba(56,189,248,0.1)', border: '1px solid rgba(56,189,248,0.25)', color: '#38bdf8' }}
           >
             Copy Link
           </button>
-          <button
-            onClick={actions.regenerateInviteToken}
-            className="px-4 py-2 rounded-xl text-sm font-semibold transition-all"
-            style={{ background: 'rgba(255,255,255,0.05)', border: '1px solid rgba(255,255,255,0.1)', color: 'rgba(255,255,255,0.4)' }}
-            title="Regenerate to invalidate old link"
-          >
-            ↻
-          </button>
+          <ConfirmDelete
+            onConfirm={actions.regenerateInviteToken}
+            trigger="↻"
+            prompt="Replace?"
+            confirmLabel="Yes, replace"
+            ariaLabel="Regenerate invite link (invalidates the current one)"
+            className="px-3 py-2 rounded-xl text-sm"
+          />
         </div>
       </div>
     </Section>
@@ -531,12 +539,16 @@ function ApiKey({ family, actions }: { family: Family; actions: ParentActions })
             Copy
           </button>
         </div>
-        <button
-          onClick={actions.regenerateApiKey}
-          className="text-xs text-white/25 hover:text-red-400 transition-all text-center"
-        >
-          Regenerate key (invalidates current key)
-        </button>
+        <div className="flex justify-center">
+          <ConfirmDelete
+            onConfirm={actions.regenerateApiKey}
+            trigger="Regenerate key (invalidates current key)"
+            prompt="Regenerate?"
+            confirmLabel="Yes, regenerate"
+            ariaLabel="Regenerate API key (invalidates the current key)"
+            className="text-xs text-white/30 px-1"
+          />
+        </div>
       </div>
     </Section>
   )

--- a/src/app/parent/family-tab.tsx
+++ b/src/app/parent/family-tab.tsx
@@ -308,7 +308,11 @@ function KidList({ kids, onShowQr, actions }: { kids: Kid[]; onShowQr: (kidId: s
   return (
     <Section title="Your Adventurers">
       {kids.length === 0 ? (
-        <Empty icon="🧙" message="No adventurers yet" />
+        <Empty
+          icon="🧙"
+          message="No adventurers yet"
+          hint="Use the form above to add your first kid — they'll need a name, avatar, and a 4-digit PIN."
+        />
       ) : (
         <div className="flex flex-col gap-3">
           {kids.map((kid) => {
@@ -401,6 +405,9 @@ function KidList({ kids, onShowQr, actions }: { kids: Kid[]; onShowQr: (kidId: s
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
           onClick={() => setLedgerKid(null)}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="ledger-modal-title"
         >
           <motion.div
             className="rounded-3xl mx-4 w-full max-w-md overflow-hidden"
@@ -418,18 +425,19 @@ function KidList({ kids, onShowQr, actions }: { kids: Kid[]; onShowQr: (kidId: s
             transition={{ type: 'spring', stiffness: 340, damping: 28 }}
             onClick={(e) => e.stopPropagation()}
           >
-            <div className="px-6 pt-5 pb-4 flex-shrink-0 flex items-center justify-between"
+            <div className="px-6 pt-5 pb-4 flex-shrink-0 flex items-center justify-between gap-3"
               style={{ borderBottom: '1px solid rgba(255,255,255,0.06)' }}
             >
-              <div>
-                <h2 className="font-heading text-lg font-bold text-white/90">
+              <div className="min-w-0">
+                <h2 id="ledger-modal-title" className="font-heading text-lg font-bold text-white/90 truncate">
                   {ledgerKid.avatar} {ledgerKid.name}&apos;s Ledger
                 </h2>
                 <p className="text-white/35 text-xs mt-0.5">Full coin transaction history</p>
               </div>
               <button
                 onClick={() => setLedgerKid(null)}
-                className="w-8 h-8 rounded-full flex items-center justify-center text-white/30 hover:text-white/60 transition-all"
+                aria-label="Close ledger"
+                className="w-11 h-11 rounded-full flex items-center justify-center text-white/35 hover:text-white/70 transition-all flex-shrink-0"
                 style={{ background: 'rgba(255,255,255,0.05)', border: '1px solid rgba(255,255,255,0.08)' }}
               >
                 ✕
@@ -438,7 +446,12 @@ function KidList({ kids, onShowQr, actions }: { kids: Kid[]; onShowQr: (kidId: s
 
             <div className="overflow-y-auto px-6 py-4 flex-1">
               {ledgerLoading ? (
-                <div className="flex items-center justify-center py-16">
+                <div
+                  className="flex items-center justify-center py-16"
+                  role="status"
+                  aria-live="polite"
+                  aria-label="Loading ledger"
+                >
                   <motion.p
                     className="font-heading text-xl text-white/30"
                     animate={{ opacity: [0.3, 0.7, 0.3] }}

--- a/src/app/parent/page.tsx
+++ b/src/app/parent/page.tsx
@@ -6,7 +6,7 @@ import { useState } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import Link from 'next/link'
 import { StarField } from '@/components/star-field'
-import { LoadingScreen } from '@/components/loading-screen'
+import { ParentSkeleton } from '@/components/parent-skeleton'
 
 import { useParentData } from './use-parent-data'
 import { useParentActions } from './use-parent-actions'
@@ -36,7 +36,7 @@ export default function ParentDashboard() {
   const reviewedRedemptions = data.redemptions.filter((r) => r.status === 'approved' || r.status === 'denied')
 
   if (data.loading) {
-    return <LoadingScreen />
+    return <ParentSkeleton />
   }
 
   if (lock.parentLocked) {

--- a/src/app/parent/page.tsx
+++ b/src/app/parent/page.tsx
@@ -102,21 +102,31 @@ export default function ParentDashboard() {
           </div>
         </motion.header>
 
-        <div className="flex gap-1.5 px-6 py-4 flex-shrink-0">
+        <div
+          className="flex gap-1.5 px-4 sm:px-6 py-3 sm:py-4 flex-shrink-0"
+          role="tablist"
+          aria-label="Parent dashboard sections"
+        >
           {tabs.map((t) => (
             <button
               key={t.id}
               onClick={() => setTab(t.id)}
-              className="relative flex-1 min-w-0 flex items-center justify-center gap-1.5 px-1 sm:px-3 py-2 rounded-xl text-sm font-semibold transition-all"
+              role="tab"
+              aria-selected={tab === t.id}
+              aria-label={t.label}
+              className="relative flex-1 min-w-0 min-h-[48px] sm:min-h-0 flex sm:flex-row flex-col items-center justify-center gap-0.5 sm:gap-1.5 px-1 sm:px-3 py-1.5 sm:py-2 rounded-xl text-sm font-semibold transition-all"
               style={{
                 background: tab === t.id ? 'rgba(251,191,36,0.14)' : 'rgba(255,255,255,0.05)',
                 border: `1px solid ${tab === t.id ? 'rgba(251,191,36,0.35)' : 'rgba(255,255,255,0.08)'}`,
                 color: tab === t.id ? '#fbbf24' : 'rgba(255,255,255,0.5)',
               }}
             >
-              {/* Mobile: icon only */}
-              <span className="sm:hidden">{t.icon}</span>
-              {/* Desktop: icon + label */}
+              {/* Mobile: icon + tiny label stacked */}
+              <span className="sm:hidden text-base leading-none">{t.icon}</span>
+              <span className="sm:hidden text-[9px] font-bold tracking-wide uppercase leading-none mt-0.5">
+                {t.label}
+              </span>
+              {/* Desktop: icon + full label inline */}
               <span className="hidden sm:inline">{t.icon} {t.label}</span>
               {/* Desktop badge: inline pill */}
               {t.badge && t.badge > 0 ? (
@@ -131,6 +141,7 @@ export default function ParentDashboard() {
                   <span
                     className="sm:hidden absolute top-0.5 right-0.5 min-w-[14px] h-[14px] flex items-center justify-center rounded-full text-[8px] font-bold leading-none px-0.5"
                     style={{ background: '#fbbf24', color: '#0a0620' }}
+                    aria-label={`${t.badge} pending`}
                   >
                     {t.badge}
                   </span>

--- a/src/app/parent/page.tsx
+++ b/src/app/parent/page.tsx
@@ -6,6 +6,7 @@ import { useState } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import Link from 'next/link'
 import { StarField } from '@/components/star-field'
+import { LoadingScreen } from '@/components/loading-screen'
 
 import { useParentData } from './use-parent-data'
 import { useParentActions } from './use-parent-actions'
@@ -35,18 +36,7 @@ export default function ParentDashboard() {
   const reviewedRedemptions = data.redemptions.filter((r) => r.status === 'approved' || r.status === 'denied')
 
   if (data.loading) {
-    return (
-      <div className="min-h-screen bg-quest-void flex items-center justify-center">
-        <StarField />
-        <motion.p
-          className="relative z-10 font-heading text-2xl text-white/40"
-          animate={{ opacity: [0.3, 0.8, 0.3] }}
-          transition={{ duration: 2, repeat: Infinity }}
-        >
-          ✦ Loading ✦
-        </motion.p>
-      </div>
-    )
+    return <LoadingScreen />
   }
 
   if (lock.parentLocked) {

--- a/src/app/parent/page.tsx
+++ b/src/app/parent/page.tsx
@@ -72,30 +72,34 @@ export default function ParentDashboard() {
 
       <div className="relative z-10 flex flex-col flex-1 w-full max-w-2xl mx-auto">
         <motion.header
-          className="flex items-center gap-4 px-6 py-4 flex-shrink-0"
+          className="flex items-center gap-3 px-4 sm:px-6 py-3 sm:py-4 flex-shrink-0"
           style={{ borderBottom: '1px solid rgba(255,255,255,0.07)' }}
           initial={{ opacity: 0, y: -12 }}
           animate={{ opacity: 1, y: 0 }}
         >
-          <Link href="/display" className="text-white/40 hover:text-white/70 transition-all text-sm flex-shrink-0">
+          <Link
+            href="/display"
+            className="text-white/45 hover:text-white/80 transition-all text-sm flex-shrink-0 min-h-[44px] flex items-center px-1"
+          >
             ← Realm
           </Link>
-          <div className="flex-1 text-center">
+          <div className="flex-1 text-center min-w-0">
             <span className="font-heading text-lg font-bold text-white/80">Parent Command</span>
           </div>
-          <div className="flex items-center gap-3 flex-shrink-0">
+          <div className="flex items-center gap-1 flex-shrink-0">
             {data.family?.has_parent_pin && (
               <button
                 onClick={lock.handleLock}
-                className="text-white/30 hover:text-cq-gold transition-all text-lg"
+                className="w-11 h-11 flex items-center justify-center text-white/40 hover:text-cq-gold transition-all text-lg rounded-lg"
                 title="Lock parent area"
+                aria-label="Lock parent area"
               >
                 🔒
               </button>
             )}
             <button
               onClick={actions.signOut}
-              className="text-white/30 hover:text-white/60 transition-all text-sm"
+              className="text-white/40 hover:text-white/70 transition-all text-sm min-h-[44px] px-2"
             >
               Sign out
             </button>

--- a/src/app/parent/qr-modal.tsx
+++ b/src/app/parent/qr-modal.tsx
@@ -4,6 +4,7 @@ import { motion, AnimatePresence } from 'framer-motion'
 import QRCode from 'react-qr-code'
 import { toast } from 'sonner'
 import type { Kid } from '@/lib/types'
+import { useEscapeToClose } from '@/lib/use-escape-to-close'
 
 interface Props {
   kid: Kid | null
@@ -11,6 +12,7 @@ interface Props {
 }
 
 export function QrModal({ kid, onClose }: Props) {
+  useEscapeToClose(kid !== null, onClose)
   return (
     <AnimatePresence>
       {kid && (() => {

--- a/src/app/parent/qr-modal.tsx
+++ b/src/app/parent/qr-modal.tsx
@@ -25,6 +25,9 @@ export function QrModal({ kid, onClose }: Props) {
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
             onClick={onClose}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="qr-modal-title"
           >
             <motion.div
               className="relative w-full max-w-xs rounded-3xl p-6 text-center"
@@ -36,12 +39,13 @@ export function QrModal({ kid, onClose }: Props) {
             >
               <button
                 onClick={onClose}
-                className="absolute top-4 right-4 text-white/30 hover:text-white/70 transition-all text-lg"
+                aria-label="Close QR code"
+                className="absolute top-3 right-3 w-9 h-9 flex items-center justify-center rounded-lg text-white/35 hover:text-white/70 transition-all text-lg"
               >
                 ✕
               </button>
-              <span className="text-4xl block mb-2">{kid.avatar}</span>
-              <h3 className="font-heading font-bold text-white text-xl mb-4">{kid.name}</h3>
+              <span className="text-4xl block mb-2" aria-hidden="true">{kid.avatar}</span>
+              <h3 id="qr-modal-title" className="font-heading font-bold text-white text-xl mb-4">{kid.name}</h3>
               <div className="bg-white p-4 rounded-2xl inline-block mb-4">
                 <QRCode value={kidUrl} size={160} />
               </div>

--- a/src/app/parent/quest-row.tsx
+++ b/src/app/parent/quest-row.tsx
@@ -6,6 +6,7 @@ import type { Kid, Quest, QuestKind, QuestTier } from '@/lib/types'
 import { QuestFormFields, type QuestFormState } from './quest-form'
 import { TierBadge } from '@/components/ui/tier-badge'
 import { KindBadge } from '@/components/ui/kind-badge'
+import { ConfirmDelete } from '@/components/ui/confirm-delete'
 
 interface Props {
   quest: Quest
@@ -98,12 +99,12 @@ export function QuestRow({ quest, kids, onToggle, onDelete, onSave }: Props) {
           >
             {quest.active ? 'On' : 'Off'}
           </button>
-          <button
-            onClick={() => onDelete(quest.id)}
-            className="text-white/20 hover:text-red-400 transition-all text-xs ml-0.5"
-          >
-            ✕
-          </button>
+          <ConfirmDelete
+            onConfirm={() => onDelete(quest.id)}
+            ariaLabel={`Delete quest ${quest.title}`}
+            confirmLabel="Delete quest"
+            className="ml-0.5 px-1 py-1"
+          />
         </div>
       </div>
 

--- a/src/app/parent/quests-tab.tsx
+++ b/src/app/parent/quests-tab.tsx
@@ -78,7 +78,11 @@ export function QuestsTab({ kids, quests, actions, plan }: Props) {
 
       <Section title="Active Quests">
         {active.length === 0 ? (
-          <Empty icon="⚔️" message="No active quests" />
+          <Empty
+            icon="⚔️"
+            message="No active quests yet"
+            hint="Use the form above to create one, or tap “Or add default starter quests” below."
+          />
         ) : (
           active.map((q) => (
             <QuestRow

--- a/src/app/parent/rewards-tab.tsx
+++ b/src/app/parent/rewards-tab.tsx
@@ -195,7 +195,11 @@ export function RewardsTab({ rewards, actions, plan }: Props) {
 
       <Section title="Reward Store">
         {rewards.length === 0 ? (
-          <Empty icon="🎁" message="No rewards yet" />
+          <Empty
+            icon="🎁"
+            message="No rewards yet"
+            hint="Add a reward above so kids can spend the coins they earn."
+          />
         ) : (
           <div className="flex flex-col gap-2">
             {rewards.map((r) => (

--- a/src/app/parent/rewards-tab.tsx
+++ b/src/app/parent/rewards-tab.tsx
@@ -5,6 +5,7 @@ import { motion, AnimatePresence } from 'framer-motion'
 import type { Plan, Reward } from '@/lib/types'
 import { PLAN_LABELS, PLAN_LIMITS } from '@/lib/plans'
 import { ActionButton, Empty, FormInput, Section, fadeSlide } from './_ui'
+import { ConfirmDelete } from '@/components/ui/confirm-delete'
 import type { ParentActions } from './use-parent-actions'
 
 const REWARD_ICONS = ['🎁', '🎮', '📱', '🍕', '🎬', '🎡', '🎪', '🛒', '💤', '🎯', '🎨', '🎵']
@@ -57,12 +58,12 @@ function RewardRow({ reward, onSave, onDelete }: RewardRowProps) {
         >
           ✏️
         </button>
-        <button
-          onClick={() => onDelete(reward.id)}
-          className="text-white/20 hover:text-red-400 transition-all text-xs ml-1"
-        >
-          ✕
-        </button>
+        <ConfirmDelete
+          onConfirm={() => onDelete(reward.id)}
+          ariaLabel={`Delete reward ${reward.title}`}
+          confirmLabel="Delete reward"
+          className="ml-1 px-1 py-1"
+        />
       </div>
 
       <AnimatePresence>

--- a/src/app/parent/use-parent-actions.ts
+++ b/src/app/parent/use-parent-actions.ts
@@ -367,12 +367,16 @@ export function useParentActions(deps: Deps): ParentActions {
   }, [family, quests, refetch, supabase])
 
   const toggleQuest = useCallback(async (id: string, active: boolean) => {
-    await supabase.from('quests').update({ active: !active }).eq('id', id)
+    const { error } = await supabase.from('quests').update({ active: !active }).eq('id', id)
+    if (error) toast.error('Failed to update quest')
+    else toast.success(active ? 'Quest paused' : 'Quest reactivated')
     await refetch()
   }, [refetch, supabase])
 
   const deleteQuest = useCallback(async (id: string) => {
-    await supabase.from('quests').delete().eq('id', id)
+    const { error } = await supabase.from('quests').delete().eq('id', id)
+    if (error) toast.error('Failed to delete quest')
+    else toast.success('Quest deleted')
     await refetch()
   }, [refetch, supabase])
 
@@ -436,7 +440,9 @@ export function useParentActions(deps: Deps): ParentActions {
   }, [family, rewards, refetch, supabase])
 
   const deleteReward = useCallback(async (id: string) => {
-    await supabase.from('rewards').delete().eq('id', id)
+    const { error } = await supabase.from('rewards').delete().eq('id', id)
+    if (error) toast.error('Failed to delete reward')
+    else toast.success('Reward removed')
     await refetch()
   }, [refetch, supabase])
 
@@ -528,7 +534,9 @@ export function useParentActions(deps: Deps): ParentActions {
   }, [family, refetch, supabase])
 
   const deleteCurse = useCallback(async (id: string) => {
-    await supabase.from('curses').delete().eq('id', id)
+    const { error } = await supabase.from('curses').delete().eq('id', id)
+    if (error) toast.error('Failed to delete curse')
+    else toast.success('Curse removed from arsenal')
     await refetch()
   }, [refetch, supabase])
 
@@ -637,7 +645,9 @@ export function useParentActions(deps: Deps): ParentActions {
   }, [family, refetch, supabase])
 
   const deleteDungeonRun = useCallback(async (id: string) => {
-    await supabase.from('dungeon_runs').delete().eq('id', id)
+    const { error } = await supabase.from('dungeon_runs').delete().eq('id', id)
+    if (error) toast.error('Failed to delete dungeon')
+    else toast.success('Dungeon dismissed')
     await refetch()
   }, [refetch, supabase])
 
@@ -662,7 +672,9 @@ export function useParentActions(deps: Deps): ParentActions {
   }, [family, kids, refetch, supabase])
 
   const deleteRaidBoss = useCallback(async (id: string) => {
-    await supabase.from('raid_bosses').delete().eq('id', id)
+    const { error } = await supabase.from('raid_bosses').delete().eq('id', id)
+    if (error) toast.error('Failed to dismiss raid boss')
+    else toast.success('Raid boss dismissed')
     await refetch()
   }, [refetch, supabase])
 

--- a/src/app/reset-password/page.tsx
+++ b/src/app/reset-password/page.tsx
@@ -12,22 +12,18 @@ import { toast } from 'sonner'
 export default function ResetPasswordPage() {
   const [password, setPassword] = useState('')
   const [confirm, setConfirm] = useState('')
+  const [showPassword, setShowPassword] = useState(false)
   const [loading, setLoading] = useState(false)
   const [done, setDone] = useState(false)
   const router = useRouter()
   const supabase = createClient()
 
+  const mismatch = confirm.length > 0 && password !== confirm
+  const tooShort = password.length > 0 && password.length < 6
+
   const inputStyle = {
     background: 'rgba(255, 255, 255, 0.06)',
     border: '1px solid rgba(255, 255, 255, 0.1)',
-  }
-  const inputFocus = (e: React.FocusEvent<HTMLInputElement>) => {
-    e.target.style.borderColor = 'rgba(251, 191, 36, 0.45)'
-    e.target.style.boxShadow = '0 0 0 3px rgba(251, 191, 36, 0.1)'
-  }
-  const inputBlur = (e: React.FocusEvent<HTMLInputElement>) => {
-    e.target.style.borderColor = 'rgba(255, 255, 255, 0.1)'
-    e.target.style.boxShadow = 'none'
   }
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -101,44 +97,68 @@ export default function ResetPasswordPage() {
               </div>
 
               <div>
-                <label className="block text-xs font-semibold text-white/50 uppercase tracking-widest mb-1.5">
+                <label htmlFor="rp-password" className="block text-xs font-semibold text-white/50 uppercase tracking-widest mb-1.5">
                   New password
                 </label>
-                <input
-                  type="password"
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  placeholder="At least 6 characters"
-                  required
-                  minLength={6}
-                  className="w-full px-4 py-3 rounded-xl text-sm text-white/90 placeholder:text-white/25 outline-none transition-all"
-                  style={inputStyle}
-                  onFocus={inputFocus}
-                  onBlur={inputBlur}
-                />
+                <div className="relative">
+                  <input
+                    id="rp-password"
+                    type={showPassword ? 'text' : 'password'}
+                    autoComplete="new-password"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    placeholder="At least 6 characters"
+                    required
+                    minLength={6}
+                    aria-invalid={tooShort}
+                    aria-describedby={tooShort ? 'rp-password-error' : undefined}
+                    className="w-full px-4 py-3 pr-12 rounded-xl text-sm text-white/90 placeholder:text-white/25 outline-none transition-all"
+                    style={inputStyle}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowPassword((s) => !s)}
+                    aria-label={showPassword ? 'Hide password' : 'Show password'}
+                    className="absolute right-1.5 top-1/2 -translate-y-1/2 w-9 h-9 flex items-center justify-center rounded-lg text-white/35 hover:text-white/70 transition-colors"
+                  >
+                    {showPassword ? '🙈' : '👁️'}
+                  </button>
+                </div>
+                {tooShort && (
+                  <p id="rp-password-error" className="mt-1.5 text-xs text-red-400/80">
+                    Must be at least 6 characters
+                  </p>
+                )}
               </div>
 
               <div>
-                <label className="block text-xs font-semibold text-white/50 uppercase tracking-widest mb-1.5">
+                <label htmlFor="rp-confirm" className="block text-xs font-semibold text-white/50 uppercase tracking-widest mb-1.5">
                   Confirm password
                 </label>
                 <input
-                  type="password"
+                  id="rp-confirm"
+                  type={showPassword ? 'text' : 'password'}
+                  autoComplete="new-password"
                   value={confirm}
                   onChange={(e) => setConfirm(e.target.value)}
                   placeholder="Same as above"
                   required
+                  aria-invalid={mismatch}
+                  aria-describedby={mismatch ? 'rp-confirm-error' : undefined}
                   className="w-full px-4 py-3 rounded-xl text-sm text-white/90 placeholder:text-white/25 outline-none transition-all"
                   style={inputStyle}
-                  onFocus={inputFocus}
-                  onBlur={inputBlur}
                 />
+                {mismatch && (
+                  <p id="rp-confirm-error" className="mt-1.5 text-xs text-red-400/80">
+                    Passwords don&apos;t match yet
+                  </p>
+                )}
               </div>
 
               <motion.button
                 type="submit"
-                disabled={loading}
-                className="mt-2 w-full py-3.5 rounded-xl font-heading font-bold tracking-widest text-sm uppercase transition-all disabled:opacity-50"
+                disabled={loading || mismatch || tooShort || password.length === 0}
+                className="mt-2 w-full py-3.5 rounded-xl font-heading font-bold tracking-widest text-sm uppercase transition-all disabled:opacity-50 disabled:cursor-not-allowed"
                 style={{
                   background: 'linear-gradient(135deg, rgba(251,191,36,0.25), rgba(251,191,36,0.12))',
                   border: '1px solid rgba(251, 191, 36, 0.4)',

--- a/src/components/kid-column.tsx
+++ b/src/components/kid-column.tsx
@@ -76,14 +76,14 @@ export function KidColumn({
       >
         {/* Avatar — links to kid's personal view */}
         {linkToKidView ? (
-          <Link href={`/kid/${kid.id}`}>
+          <Link href={`/kid/${kid.id}`} aria-label={`Open ${kid.name}'s quest board`}>
             <motion.div
               className="relative cursor-pointer"
               whileHover={{ scale: 1.08 }}
               whileTap={{ scale: 0.95 }}
             >
               <motion.span
-                className="block"
+                className="text-5xl block"
                 animate={{ y: [0, -5, 0] }}
                 transition={{ duration: 3.5, repeat: Infinity, ease: 'easeInOut' }}
               >

--- a/src/components/loading-screen.tsx
+++ b/src/components/loading-screen.tsx
@@ -1,0 +1,30 @@
+'use client'
+
+import { motion } from 'framer-motion'
+import { StarField } from './star-field'
+
+interface Props {
+  label?: string
+  size?: 'sm' | 'md' | 'lg'
+}
+
+export function LoadingScreen({ label = 'Loading', size = 'md' }: Props) {
+  const textSize = size === 'lg' ? 'text-3xl' : size === 'sm' ? 'text-xl' : 'text-2xl'
+  return (
+    <div
+      className="min-h-screen bg-quest-void flex items-center justify-center"
+      role="status"
+      aria-live="polite"
+      aria-label={label}
+    >
+      <StarField />
+      <motion.p
+        className={`relative z-10 font-heading ${textSize} text-white/40`}
+        animate={{ opacity: [0.3, 0.8, 0.3] }}
+        transition={{ duration: 2, repeat: Infinity }}
+      >
+        ✦ {label} ✦
+      </motion.p>
+    </div>
+  )
+}

--- a/src/components/parent-skeleton.tsx
+++ b/src/components/parent-skeleton.tsx
@@ -1,0 +1,62 @@
+'use client'
+
+import { motion } from 'framer-motion'
+import { StarField } from './star-field'
+
+/**
+ * Skeleton shown while the parent dashboard data loads. Mirrors the real layout
+ * (header, tab strip, content blocks) so the perceived load is shorter than a
+ * full-screen "Loading" message.
+ */
+export function ParentSkeleton() {
+  return (
+    <div
+      className="min-h-screen bg-quest-void flex flex-col"
+      role="status"
+      aria-live="polite"
+      aria-label="Loading parent dashboard"
+    >
+      <StarField />
+      <div className="relative z-10 flex flex-col flex-1 w-full max-w-2xl mx-auto">
+        <header
+          className="flex items-center gap-3 px-4 sm:px-6 py-3 sm:py-4 flex-shrink-0"
+          style={{ borderBottom: '1px solid rgba(255,255,255,0.07)' }}
+        >
+          <Shimmer className="h-5 w-16 rounded-md" />
+          <div className="flex-1 flex justify-center">
+            <Shimmer className="h-5 w-40 rounded-md" />
+          </div>
+          <Shimmer className="h-5 w-16 rounded-md" />
+        </header>
+
+        <div className="flex gap-1.5 px-4 sm:px-6 py-3 sm:py-4 flex-shrink-0">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <Shimmer key={i} className="flex-1 h-12 rounded-xl" />
+          ))}
+        </div>
+
+        <main className="flex-1 px-4 sm:px-6 pb-8 flex flex-col gap-4">
+          <Shimmer className="h-5 w-24 rounded-md" />
+          <Shimmer className="h-20 w-full rounded-2xl" />
+          <Shimmer className="h-20 w-full rounded-2xl" />
+          <Shimmer className="h-20 w-full rounded-2xl" />
+        </main>
+      </div>
+    </div>
+  )
+}
+
+function Shimmer({ className = '' }: { className?: string }) {
+  return (
+    <motion.div
+      className={className}
+      style={{
+        background:
+          'linear-gradient(90deg, rgba(255,255,255,0.04) 0%, rgba(255,255,255,0.09) 50%, rgba(255,255,255,0.04) 100%)',
+        backgroundSize: '200% 100%',
+      }}
+      animate={{ backgroundPosition: ['200% 0', '-200% 0'] }}
+      transition={{ duration: 1.4, repeat: Infinity, ease: 'linear' }}
+    />
+  )
+}

--- a/src/components/ui/__tests__/confirm-delete.test.tsx
+++ b/src/components/ui/__tests__/confirm-delete.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+import React from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen, fireEvent, act, cleanup } from '@testing-library/react'
+
+vi.mock('framer-motion', () => ({
+  motion: new Proxy({}, {
+    get: (_target, prop: string) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const Tag = prop as any
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return ({ children, ...rest }: any) => React.createElement(Tag, rest, children)
+    },
+  }),
+}))
+
+import { ConfirmDelete } from '../confirm-delete'
+
+describe('ConfirmDelete', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+    cleanup()
+  })
+
+  it('first tap reveals the confirm prompt but does not call onConfirm', () => {
+    const onConfirm = vi.fn()
+    render(<ConfirmDelete onConfirm={onConfirm} ariaLabel="Delete item" />)
+    fireEvent.click(screen.getByRole('button', { name: 'Delete item' }))
+    expect(onConfirm).not.toHaveBeenCalled()
+    expect(screen.getByRole('button', { name: /Sure\? Delete/ })).toBeInTheDocument()
+  })
+
+  it('second tap on the prompt commits onConfirm', () => {
+    const onConfirm = vi.fn()
+    render(<ConfirmDelete onConfirm={onConfirm} ariaLabel="Delete item" />)
+    fireEvent.click(screen.getByRole('button', { name: 'Delete item' }))
+    fireEvent.click(screen.getByRole('button', { name: /Sure\? Delete/ }))
+    expect(onConfirm).toHaveBeenCalledTimes(1)
+  })
+
+  it('Cancel button disarms without calling onConfirm', () => {
+    const onConfirm = vi.fn()
+    render(<ConfirmDelete onConfirm={onConfirm} ariaLabel="Delete item" />)
+    fireEvent.click(screen.getByRole('button', { name: 'Delete item' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(onConfirm).not.toHaveBeenCalled()
+    expect(screen.getByRole('button', { name: 'Delete item' })).toBeInTheDocument()
+  })
+
+  it('auto-disarms after the timeout if neither tapped', () => {
+    const onConfirm = vi.fn()
+    render(<ConfirmDelete onConfirm={onConfirm} ariaLabel="Delete item" timeoutMs={2000} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Delete item' }))
+    expect(screen.getByRole('button', { name: /Sure\? Delete/ })).toBeInTheDocument()
+    act(() => {
+      vi.advanceTimersByTime(2100)
+    })
+    expect(onConfirm).not.toHaveBeenCalled()
+    expect(screen.getByRole('button', { name: 'Delete item' })).toBeInTheDocument()
+  })
+})

--- a/src/components/ui/confirm-delete.tsx
+++ b/src/components/ui/confirm-delete.tsx
@@ -1,0 +1,91 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { motion } from 'framer-motion'
+
+interface Props {
+  onConfirm: () => void
+  /** Label shown when collapsed. Defaults to ✕. */
+  trigger?: React.ReactNode
+  /** Confirm prompt shown in the expanded state. */
+  prompt?: string
+  /** Confirm button label. */
+  confirmLabel?: string
+  className?: string
+  /** aria-label for the trigger button. */
+  ariaLabel?: string
+  /** Auto-collapse after this many ms if the user doesn't confirm. */
+  timeoutMs?: number
+}
+
+/**
+ * Two-tap inline destructive confirmation. First tap reveals "Sure?" — second tap commits.
+ * Reverts after a few seconds of inactivity so a stray tap doesn't sit in a primed state.
+ */
+export function ConfirmDelete({
+  onConfirm,
+  trigger = '✕',
+  prompt = 'Sure?',
+  confirmLabel = 'Delete',
+  className = '',
+  ariaLabel = 'Delete',
+  timeoutMs = 4000,
+}: Props) {
+  const [armed, setArmed] = useState(false)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    if (!armed) return
+    timerRef.current = setTimeout(() => setArmed(false), timeoutMs)
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current)
+    }
+  }, [armed, timeoutMs])
+
+  if (!armed) {
+    return (
+      <button
+        type="button"
+        onClick={() => setArmed(true)}
+        aria-label={ariaLabel}
+        className={`text-white/25 hover:text-red-400 transition-all text-sm ${className}`}
+      >
+        {trigger}
+      </button>
+    )
+  }
+
+  return (
+    <motion.div
+      className="flex items-center gap-1.5"
+      initial={{ opacity: 0, scale: 0.95 }}
+      animate={{ opacity: 1, scale: 1 }}
+      transition={{ duration: 0.12 }}
+    >
+      <button
+        type="button"
+        onClick={() => {
+          if (timerRef.current) clearTimeout(timerRef.current)
+          setArmed(false)
+          onConfirm()
+        }}
+        className="px-2.5 py-1 rounded-lg text-xs font-bold transition-all"
+        style={{
+          background: 'rgba(239,68,68,0.15)',
+          border: '1px solid rgba(239,68,68,0.4)',
+          color: '#f87171',
+        }}
+      >
+        {prompt} {confirmLabel}
+      </button>
+      <button
+        type="button"
+        onClick={() => setArmed(false)}
+        className="text-xs text-white/35 hover:text-white/65 px-1.5 py-1 rounded-lg"
+        aria-label="Cancel"
+      >
+        Cancel
+      </button>
+    </motion.div>
+  )
+}

--- a/src/lib/use-escape-to-close.ts
+++ b/src/lib/use-escape-to-close.ts
@@ -1,0 +1,21 @@
+'use client'
+
+import { useEffect } from 'react'
+
+/**
+ * Closes a modal-like UI when the user presses Escape. The handler only attaches
+ * while `active` is true, so multiple modals on a page don't all fire at once.
+ */
+export function useEscapeToClose(active: boolean, onClose: () => void): void {
+  useEffect(() => {
+    if (!active) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation()
+        onClose()
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [active, onClose])
+}


### PR DESCRIPTION
## Summary

Started as a fix for "pages render zoomed-in on mobile" and grew into a release-readiness pass across every surface. Five commits, scoped to three themes the user asked me to bias toward: **mobile UX**, **visual consistency**, **states & feedback** — with accessibility bumped along the way because it was cheap once the focus styles were centralized.

The original mobile-zoom bug was iOS Safari auto-zooming on focus of any `<input>` with `font-size < 16px`. Every input in the app used `text-sm` (14px), so once any input got focus the tab stayed zoomed across navigation. Fixed by a global CSS rule that bumps inputs to 16px on `<640px` and lets `text-sm` apply on `sm+` so the compact desktop forms keep their design intent.

## What changed

### Mobile UX
- iOS auto-zoom on input focus eliminated (`globals.css`)
- Marketing landing: added hamburger menu for `<md` — 4 nav links were hidden with no replacement
- Parent dashboard tabs: stack icon + tiny label on mobile so unfamiliar emoji (`☠️ Curses`, `🏰 Dungeons`) are decipherable; min 48px target
- All small icon buttons in headers (display, parent, kid) bumped to min 44×44 with proper `aria-label`s
- Kid view tabs given `min-h-44px` and `role=tablist`/`aria-selected`
- Marketing CTA banner padding: `p-12` → `p-8` mobile, `p-12` desktop
- Blog header cleaned up so it doesn't truncate on small screens

### Visual consistency
- Shared `LoadingScreen` component dedupes four near-identical loaders across parent, kid, join, display
- New `ParentSkeleton` mirrors the real dashboard layout while data loads — much shorter perceived load than a centered "Loading"
- Removed inline `onFocus`/`onBlur` JS from login + reset-password; one global CSS rule for `:focus-visible` on all form fields
- Global `:focus-visible` outlines on buttons/links for keyboard a11y baseline
- Honor `prefers-reduced-motion` globally — kills heavy framer animations for sensitive users
- Custom themed 404 page (Next default was unbranded)
- Fix bug: kid-column avatar rendered at 16px instead of 48px when clickable (missing size class on the inner motion.span)

### States & feedback
- New `ConfirmDelete`: two-tap inline pattern that arms on first tap, auto-disarms after 4s. Wired into quest/reward/curse/dungeon/raid-boss deletes that were previously silent + instant
- Also gated behind ConfirmDelete: `removeParentPin`, `regenerateInviteToken`, `regenerateApiKey` — these invalidate live tokens or disable security and shouldn't be one-tap
- Toast feedback added to `toggleQuest`, `deleteQuest`, `deleteReward`, `deleteCurse`, `deleteDungeonRun`, `deleteRaidBoss` (all previously succeeded silently)
- Login + reset-password: password reveal toggle, `autocomplete` attributes, `htmlFor` labels
- Reset-password: real-time mismatch + length validation with `aria-invalid` + `aria-describedby` error messages
- Empty states pick up an optional `hint` slot; first-time guidance added to Quests, Rewards, Family, Approvals
- ESC-to-close on all five modals (QR, ledger, bounty board, reward vault, bounty claim), with `role=dialog`/`aria-modal`/`aria-labelledby`

## Verification

- `npm run lint` — only pre-existing warnings, zero from this PR
- `npm test` — 124 passed (added 4 new ConfirmDelete tests)
- `npx tsc --noEmit` — clean
- `npm run build` — clean, no warnings

## Risk notes

- The new global input focus styles override any inline focus styling that was previously set via JS. Visually identical (golden ring on focus), but a manual eyeball pass on every form is worth one minute of the reviewer's time
- I deliberately did NOT migrate every custom `<input>`/`<button>` to the shadcn primitives in `src/components/ui/` — that would be a much larger invasive refactor with regression risk
- `removeParentPin`, `regenerateInviteToken`, `regenerateApiKey` now require a second tap to commit. Existing E2E tests don't exercise these (I checked); manual smoke welcome if anyone uses them habitually

## Test plan

- [ ] Visit `/login` on iPhone Safari → focus email → page should NOT zoom in
- [ ] Visit `/` on iPhone — hamburger menu opens / closes / navigates / X icon flips to close
- [ ] Parent dashboard: tap tabs on mobile — each shows icon + tiny label, badges visible
- [ ] Parent dashboard: tap ✕ on a quest/reward/curse → "Sure? Delete X" prompt appears; second tap deletes with toast; Cancel disarms; waiting 4s disarms automatically
- [ ] Modal: open QR / ledger / bounty / rewards / claim → ESC closes it
- [ ] `/reset-password`: typing mismatched passwords shows inline error in real-time; submit button stays disabled until both fields are valid
- [ ] Tab through forms with keyboard — visible focus ring on every interactive element
- [ ] Hit an unknown route (e.g. `/foo`) → themed 404 page
- [ ] OS-level reduced-motion enabled → animations effectively disabled

https://claude.ai/code/session_01NADHgmdGzKbrC9mx1spDWK

---
_Generated by [Claude Code](https://claude.ai/code/session_01NADHgmdGzKbrC9mx1spDWK)_